### PR TITLE
Add affiliate gear section to destination pages

### DIFF
--- a/Berlin.html
+++ b/Berlin.html
@@ -307,6 +307,54 @@
         </div>
     </main>
 
+    <!-- Travel Essentials & Creator Gear -->
+    <section class="py-16 bg-gray-100">
+        <div class="container mx-auto px-6">
+            <div class="text-center mb-12">
+                <h2 class="heading-font text-3xl md:text-4xl font-bold text-gray-800 mb-4">Travel Essentials &amp; Creator Gear</h2>
+                <div class="w-20 h-1 bg-yellow-500 mx-auto"></div>
+            </div>
+            <div class="max-w-3xl mx-auto space-y-10">
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🌍 TRAVEL ESSENTIALS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li>Saily eSIM (200+ countries): Use code <span class="font-semibold">CARLRI5370</span> for $5 off (I receive $5 credit)</li>
+                        <li>Wise (multi-currency card): <a href="https://wise.com/invite/irhc/carlt62" class="text-yellow-500 hover:text-yellow-600">Sign up here</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🎬 CREATOR TOOLS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li>Dehancer (film emulation): Code <span class="font-semibold">CARLTRAVELS</span> for 10% off → <a href="https://www.dehancer.com/subscribe" class="text-yellow-500 hover:text-yellow-600">dehancer.com/subscribe</a></li>
+                        <li>Adobe Enhance VO (FREE): <a href="https://podcast.adobe.com/en/enhance" class="text-yellow-500 hover:text-yellow-600">podcast.adobe.com/en/enhance</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🧰 MY GEAR — US LINKS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li><a href="https://amzn.to/45iZULT" class="text-yellow-500 hover:text-yellow-600">DJI Flip</a></li>
+                        <li><a href="https://amzn.to/4mHhQ8H" class="text-yellow-500 hover:text-yellow-600">Sony A7C II</a></li>
+                        <li><a href="https://amzn.to/4miS3UJ" class="text-yellow-500 hover:text-yellow-600">DJI Pocket 3</a></li>
+                        <li><a href="https://amzn.to/4lvd1hI" class="text-yellow-500 hover:text-yellow-600">Tamron 28–200</a></li>
+                        <li><a href="https://amzn.to/4oHMXTy" class="text-yellow-500 hover:text-yellow-600">RØDE Wireless PRO</a></li>
+                        <li><a href="https://amzn.to/467fEAU" class="text-yellow-500 hover:text-yellow-600">Think Tank Backpack</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🧰 MY GEAR — AU LINKS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li><a href="https://amzn.to/41zmAVV" class="text-yellow-500 hover:text-yellow-600">DJI Flip</a></li>
+                        <li><a href="https://amzn.to/45Qk2Fw" class="text-yellow-500 hover:text-yellow-600">Sony A7C II</a></li>
+                        <li><a href="https://amzn.to/4gaYLJZ" class="text-yellow-500 hover:text-yellow-600">DJI Osmo Pocket 3</a></li>
+                        <li><a href="https://amzn.to/4n73D5P" class="text-yellow-500 hover:text-yellow-600">Tamron 24–200</a></li>
+                        <li><a href="https://amzn.to/46kv8CG" class="text-yellow-500 hover:text-yellow-600">RØDE Wireless PRO</a></li>
+                        <li><a href="https://amzn.to/3I5mApV" class="text-yellow-500 hover:text-yellow-600">Think Tank Backpack</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
     <!-- Footer -->
     <footer class="bg-gray-900 text-white py-12">
         <div class="container mx-auto px-6">

--- a/balitravelguide.html
+++ b/balitravelguide.html
@@ -381,6 +381,53 @@
             </div>
         </div>
     </section>
+    <!-- Travel Essentials & Creator Gear -->
+    <section class="py-16 bg-gray-100">
+        <div class="container mx-auto px-6">
+            <div class="text-center mb-12">
+                <h2 class="heading-font text-3xl md:text-4xl font-bold text-gray-800 mb-4">Travel Essentials &amp; Creator Gear</h2>
+                <div class="w-20 h-1 bg-yellow-500 mx-auto"></div>
+            </div>
+            <div class="max-w-3xl mx-auto space-y-10">
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🌍 TRAVEL ESSENTIALS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li>Saily eSIM (200+ countries): Use code <span class="font-semibold">CARLRI5370</span> for $5 off (I receive $5 credit)</li>
+                        <li>Wise (multi-currency card): <a href="https://wise.com/invite/irhc/carlt62" class="text-yellow-500 hover:text-yellow-600">Sign up here</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🎬 CREATOR TOOLS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li>Dehancer (film emulation): Code <span class="font-semibold">CARLTRAVELS</span> for 10% off → <a href="https://www.dehancer.com/subscribe" class="text-yellow-500 hover:text-yellow-600">dehancer.com/subscribe</a></li>
+                        <li>Adobe Enhance VO (FREE): <a href="https://podcast.adobe.com/en/enhance" class="text-yellow-500 hover:text-yellow-600">podcast.adobe.com/en/enhance</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🧰 MY GEAR — US LINKS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li><a href="https://amzn.to/45iZULT" class="text-yellow-500 hover:text-yellow-600">DJI Flip</a></li>
+                        <li><a href="https://amzn.to/4mHhQ8H" class="text-yellow-500 hover:text-yellow-600">Sony A7C II</a></li>
+                        <li><a href="https://amzn.to/4miS3UJ" class="text-yellow-500 hover:text-yellow-600">DJI Pocket 3</a></li>
+                        <li><a href="https://amzn.to/4lvd1hI" class="text-yellow-500 hover:text-yellow-600">Tamron 28–200</a></li>
+                        <li><a href="https://amzn.to/4oHMXTy" class="text-yellow-500 hover:text-yellow-600">RØDE Wireless PRO</a></li>
+                        <li><a href="https://amzn.to/467fEAU" class="text-yellow-500 hover:text-yellow-600">Think Tank Backpack</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🧰 MY GEAR — AU LINKS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li><a href="https://amzn.to/41zmAVV" class="text-yellow-500 hover:text-yellow-600">DJI Flip</a></li>
+                        <li><a href="https://amzn.to/45Qk2Fw" class="text-yellow-500 hover:text-yellow-600">Sony A7C II</a></li>
+                        <li><a href="https://amzn.to/4gaYLJZ" class="text-yellow-500 hover:text-yellow-600">DJI Osmo Pocket 3</a></li>
+                        <li><a href="https://amzn.to/4n73D5P" class="text-yellow-500 hover:text-yellow-600">Tamron 24–200</a></li>
+                        <li><a href="https://amzn.to/46kv8CG" class="text-yellow-500 hover:text-yellow-600">RØDE Wireless PRO</a></li>
+                        <li><a href="https://amzn.to/3I5mApV" class="text-yellow-500 hover:text-yellow-600">Think Tank Backpack</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
 
     <!-- Newsletter Call-to-Action -->
     <section class="bg-gradient-to-r from-yellow-500 to-amber-600 py-16">

--- a/budvatravelguide.html
+++ b/budvatravelguide.html
@@ -409,6 +409,55 @@
         </div>
     </section>
 
+    <!-- Travel Essentials & Creator Gear -->
+    <section class="py-16 bg-gray-100">
+        <div class="container mx-auto px-6">
+            <div class="text-center mb-12">
+                <h2 class="heading-font text-3xl md:text-4xl font-bold text-gray-800 mb-4">Travel Essentials &amp; Creator Gear</h2>
+                <div class="w-20 h-1 bg-yellow-500 mx-auto"></div>
+            </div>
+            <div class="max-w-3xl mx-auto space-y-10">
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🌍 TRAVEL ESSENTIALS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li>Saily eSIM (200+ countries): Use code <span class="font-semibold">CARLRI5370</span> for $5 off (I receive $5 credit)</li>
+                        <li>Wise (multi-currency card): <a href="https://wise.com/invite/irhc/carlt62" class="text-yellow-500 hover:text-yellow-600">Sign up here</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🎬 CREATOR TOOLS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li>Dehancer (film emulation): Code <span class="font-semibold">CARLTRAVELS</span> for 10% off → <a href="https://www.dehancer.com/subscribe" class="text-yellow-500 hover:text-yellow-600">dehancer.com/subscribe</a></li>
+                        <li>Adobe Enhance VO (FREE): <a href="https://podcast.adobe.com/en/enhance" class="text-yellow-500 hover:text-yellow-600">podcast.adobe.com/en/enhance</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🧰 MY GEAR — US LINKS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li><a href="https://amzn.to/45iZULT" class="text-yellow-500 hover:text-yellow-600">DJI Flip</a></li>
+                        <li><a href="https://amzn.to/4mHhQ8H" class="text-yellow-500 hover:text-yellow-600">Sony A7C II</a></li>
+                        <li><a href="https://amzn.to/4miS3UJ" class="text-yellow-500 hover:text-yellow-600">DJI Pocket 3</a></li>
+                        <li><a href="https://amzn.to/4lvd1hI" class="text-yellow-500 hover:text-yellow-600">Tamron 28–200</a></li>
+                        <li><a href="https://amzn.to/4oHMXTy" class="text-yellow-500 hover:text-yellow-600">RØDE Wireless PRO</a></li>
+                        <li><a href="https://amzn.to/467fEAU" class="text-yellow-500 hover:text-yellow-600">Think Tank Backpack</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🧰 MY GEAR — AU LINKS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li><a href="https://amzn.to/41zmAVV" class="text-yellow-500 hover:text-yellow-600">DJI Flip</a></li>
+                        <li><a href="https://amzn.to/45Qk2Fw" class="text-yellow-500 hover:text-yellow-600">Sony A7C II</a></li>
+                        <li><a href="https://amzn.to/4gaYLJZ" class="text-yellow-500 hover:text-yellow-600">DJI Osmo Pocket 3</a></li>
+                        <li><a href="https://amzn.to/4n73D5P" class="text-yellow-500 hover:text-yellow-600">Tamron 24–200</a></li>
+                        <li><a href="https://amzn.to/46kv8CG" class="text-yellow-500 hover:text-yellow-600">RØDE Wireless PRO</a></li>
+                        <li><a href="https://amzn.to/3I5mApV" class="text-yellow-500 hover:text-yellow-600">Think Tank Backpack</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
+
     <!-- Footer -->
     <footer class="bg-gray-900 text-white py-12">
         <div class="container mx-auto px-6">

--- a/cairnstravelguide.html
+++ b/cairnstravelguide.html
@@ -333,6 +333,55 @@
         </div>
     </main>
 
+    <!-- Travel Essentials & Creator Gear -->
+    <section class="py-16 bg-gray-100">
+        <div class="container mx-auto px-6">
+            <div class="text-center mb-12">
+                <h2 class="heading-font text-3xl md:text-4xl font-bold text-gray-800 mb-4">Travel Essentials &amp; Creator Gear</h2>
+                <div class="w-20 h-1 bg-yellow-500 mx-auto"></div>
+            </div>
+            <div class="max-w-3xl mx-auto space-y-10">
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🌍 TRAVEL ESSENTIALS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li>Saily eSIM (200+ countries): Use code <span class="font-semibold">CARLRI5370</span> for $5 off (I receive $5 credit)</li>
+                        <li>Wise (multi-currency card): <a href="https://wise.com/invite/irhc/carlt62" class="text-yellow-500 hover:text-yellow-600">Sign up here</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🎬 CREATOR TOOLS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li>Dehancer (film emulation): Code <span class="font-semibold">CARLTRAVELS</span> for 10% off → <a href="https://www.dehancer.com/subscribe" class="text-yellow-500 hover:text-yellow-600">dehancer.com/subscribe</a></li>
+                        <li>Adobe Enhance VO (FREE): <a href="https://podcast.adobe.com/en/enhance" class="text-yellow-500 hover:text-yellow-600">podcast.adobe.com/en/enhance</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🧰 MY GEAR — US LINKS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li><a href="https://amzn.to/45iZULT" class="text-yellow-500 hover:text-yellow-600">DJI Flip</a></li>
+                        <li><a href="https://amzn.to/4mHhQ8H" class="text-yellow-500 hover:text-yellow-600">Sony A7C II</a></li>
+                        <li><a href="https://amzn.to/4miS3UJ" class="text-yellow-500 hover:text-yellow-600">DJI Pocket 3</a></li>
+                        <li><a href="https://amzn.to/4lvd1hI" class="text-yellow-500 hover:text-yellow-600">Tamron 28–200</a></li>
+                        <li><a href="https://amzn.to/4oHMXTy" class="text-yellow-500 hover:text-yellow-600">RØDE Wireless PRO</a></li>
+                        <li><a href="https://amzn.to/467fEAU" class="text-yellow-500 hover:text-yellow-600">Think Tank Backpack</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🧰 MY GEAR — AU LINKS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li><a href="https://amzn.to/41zmAVV" class="text-yellow-500 hover:text-yellow-600">DJI Flip</a></li>
+                        <li><a href="https://amzn.to/45Qk2Fw" class="text-yellow-500 hover:text-yellow-600">Sony A7C II</a></li>
+                        <li><a href="https://amzn.to/4gaYLJZ" class="text-yellow-500 hover:text-yellow-600">DJI Osmo Pocket 3</a></li>
+                        <li><a href="https://amzn.to/4n73D5P" class="text-yellow-500 hover:text-yellow-600">Tamron 24–200</a></li>
+                        <li><a href="https://amzn.to/46kv8CG" class="text-yellow-500 hover:text-yellow-600">RØDE Wireless PRO</a></li>
+                        <li><a href="https://amzn.to/3I5mApV" class="text-yellow-500 hover:text-yellow-600">Think Tank Backpack</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
+
     <!-- Footer -->
     <footer class="bg-gray-900 text-white py-12">
         <div class="container mx-auto px-6">

--- a/danangtravelguide.html
+++ b/danangtravelguide.html
@@ -440,6 +440,55 @@
         </div>
     </section>
 
+    <!-- Travel Essentials & Creator Gear -->
+    <section class="py-16 bg-gray-100">
+        <div class="container mx-auto px-6">
+            <div class="text-center mb-12">
+                <h2 class="heading-font text-3xl md:text-4xl font-bold text-gray-800 mb-4">Travel Essentials &amp; Creator Gear</h2>
+                <div class="w-20 h-1 bg-yellow-500 mx-auto"></div>
+            </div>
+            <div class="max-w-3xl mx-auto space-y-10">
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🌍 TRAVEL ESSENTIALS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li>Saily eSIM (200+ countries): Use code <span class="font-semibold">CARLRI5370</span> for $5 off (I receive $5 credit)</li>
+                        <li>Wise (multi-currency card): <a href="https://wise.com/invite/irhc/carlt62" class="text-yellow-500 hover:text-yellow-600">Sign up here</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🎬 CREATOR TOOLS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li>Dehancer (film emulation): Code <span class="font-semibold">CARLTRAVELS</span> for 10% off → <a href="https://www.dehancer.com/subscribe" class="text-yellow-500 hover:text-yellow-600">dehancer.com/subscribe</a></li>
+                        <li>Adobe Enhance VO (FREE): <a href="https://podcast.adobe.com/en/enhance" class="text-yellow-500 hover:text-yellow-600">podcast.adobe.com/en/enhance</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🧰 MY GEAR — US LINKS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li><a href="https://amzn.to/45iZULT" class="text-yellow-500 hover:text-yellow-600">DJI Flip</a></li>
+                        <li><a href="https://amzn.to/4mHhQ8H" class="text-yellow-500 hover:text-yellow-600">Sony A7C II</a></li>
+                        <li><a href="https://amzn.to/4miS3UJ" class="text-yellow-500 hover:text-yellow-600">DJI Pocket 3</a></li>
+                        <li><a href="https://amzn.to/4lvd1hI" class="text-yellow-500 hover:text-yellow-600">Tamron 28–200</a></li>
+                        <li><a href="https://amzn.to/4oHMXTy" class="text-yellow-500 hover:text-yellow-600">RØDE Wireless PRO</a></li>
+                        <li><a href="https://amzn.to/467fEAU" class="text-yellow-500 hover:text-yellow-600">Think Tank Backpack</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🧰 MY GEAR — AU LINKS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li><a href="https://amzn.to/41zmAVV" class="text-yellow-500 hover:text-yellow-600">DJI Flip</a></li>
+                        <li><a href="https://amzn.to/45Qk2Fw" class="text-yellow-500 hover:text-yellow-600">Sony A7C II</a></li>
+                        <li><a href="https://amzn.to/4gaYLJZ" class="text-yellow-500 hover:text-yellow-600">DJI Osmo Pocket 3</a></li>
+                        <li><a href="https://amzn.to/4n73D5P" class="text-yellow-500 hover:text-yellow-600">Tamron 24–200</a></li>
+                        <li><a href="https://amzn.to/46kv8CG" class="text-yellow-500 hover:text-yellow-600">RØDE Wireless PRO</a></li>
+                        <li><a href="https://amzn.to/3I5mApV" class="text-yellow-500 hover:text-yellow-600">Think Tank Backpack</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
+
     <!-- Footer -->
     <footer class="bg-gray-900 text-white py-12">
         <div class="container mx-auto px-6">

--- a/hanoitravelguide.html
+++ b/hanoitravelguide.html
@@ -385,6 +385,55 @@
         </div>
     </section>
 
+    <!-- Travel Essentials & Creator Gear -->
+    <section class="py-16 bg-gray-100">
+        <div class="container mx-auto px-6">
+            <div class="text-center mb-12">
+                <h2 class="heading-font text-3xl md:text-4xl font-bold text-gray-800 mb-4">Travel Essentials &amp; Creator Gear</h2>
+                <div class="w-20 h-1 bg-yellow-500 mx-auto"></div>
+            </div>
+            <div class="max-w-3xl mx-auto space-y-10">
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🌍 TRAVEL ESSENTIALS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li>Saily eSIM (200+ countries): Use code <span class="font-semibold">CARLRI5370</span> for $5 off (I receive $5 credit)</li>
+                        <li>Wise (multi-currency card): <a href="https://wise.com/invite/irhc/carlt62" class="text-yellow-500 hover:text-yellow-600">Sign up here</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🎬 CREATOR TOOLS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li>Dehancer (film emulation): Code <span class="font-semibold">CARLTRAVELS</span> for 10% off → <a href="https://www.dehancer.com/subscribe" class="text-yellow-500 hover:text-yellow-600">dehancer.com/subscribe</a></li>
+                        <li>Adobe Enhance VO (FREE): <a href="https://podcast.adobe.com/en/enhance" class="text-yellow-500 hover:text-yellow-600">podcast.adobe.com/en/enhance</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🧰 MY GEAR — US LINKS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li><a href="https://amzn.to/45iZULT" class="text-yellow-500 hover:text-yellow-600">DJI Flip</a></li>
+                        <li><a href="https://amzn.to/4mHhQ8H" class="text-yellow-500 hover:text-yellow-600">Sony A7C II</a></li>
+                        <li><a href="https://amzn.to/4miS3UJ" class="text-yellow-500 hover:text-yellow-600">DJI Pocket 3</a></li>
+                        <li><a href="https://amzn.to/4lvd1hI" class="text-yellow-500 hover:text-yellow-600">Tamron 28–200</a></li>
+                        <li><a href="https://amzn.to/4oHMXTy" class="text-yellow-500 hover:text-yellow-600">RØDE Wireless PRO</a></li>
+                        <li><a href="https://amzn.to/467fEAU" class="text-yellow-500 hover:text-yellow-600">Think Tank Backpack</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🧰 MY GEAR — AU LINKS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li><a href="https://amzn.to/41zmAVV" class="text-yellow-500 hover:text-yellow-600">DJI Flip</a></li>
+                        <li><a href="https://amzn.to/45Qk2Fw" class="text-yellow-500 hover:text-yellow-600">Sony A7C II</a></li>
+                        <li><a href="https://amzn.to/4gaYLJZ" class="text-yellow-500 hover:text-yellow-600">DJI Osmo Pocket 3</a></li>
+                        <li><a href="https://amzn.to/4n73D5P" class="text-yellow-500 hover:text-yellow-600">Tamron 24–200</a></li>
+                        <li><a href="https://amzn.to/46kv8CG" class="text-yellow-500 hover:text-yellow-600">RØDE Wireless PRO</a></li>
+                        <li><a href="https://amzn.to/3I5mApV" class="text-yellow-500 hover:text-yellow-600">Think Tank Backpack</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
+
     <!-- Footer -->
     <footer class="bg-gray-900 text-white py-12">
         <div class="container mx-auto px-6">

--- a/korcula.html
+++ b/korcula.html
@@ -359,6 +359,55 @@
         </div>
     </section>
 
+    <!-- Travel Essentials & Creator Gear -->
+    <section class="py-16 bg-gray-100">
+        <div class="container mx-auto px-6">
+            <div class="text-center mb-12">
+                <h2 class="heading-font text-3xl md:text-4xl font-bold text-gray-800 mb-4">Travel Essentials &amp; Creator Gear</h2>
+                <div class="w-20 h-1 bg-yellow-500 mx-auto"></div>
+            </div>
+            <div class="max-w-3xl mx-auto space-y-10">
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🌍 TRAVEL ESSENTIALS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li>Saily eSIM (200+ countries): Use code <span class="font-semibold">CARLRI5370</span> for $5 off (I receive $5 credit)</li>
+                        <li>Wise (multi-currency card): <a href="https://wise.com/invite/irhc/carlt62" class="text-yellow-500 hover:text-yellow-600">Sign up here</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🎬 CREATOR TOOLS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li>Dehancer (film emulation): Code <span class="font-semibold">CARLTRAVELS</span> for 10% off → <a href="https://www.dehancer.com/subscribe" class="text-yellow-500 hover:text-yellow-600">dehancer.com/subscribe</a></li>
+                        <li>Adobe Enhance VO (FREE): <a href="https://podcast.adobe.com/en/enhance" class="text-yellow-500 hover:text-yellow-600">podcast.adobe.com/en/enhance</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🧰 MY GEAR — US LINKS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li><a href="https://amzn.to/45iZULT" class="text-yellow-500 hover:text-yellow-600">DJI Flip</a></li>
+                        <li><a href="https://amzn.to/4mHhQ8H" class="text-yellow-500 hover:text-yellow-600">Sony A7C II</a></li>
+                        <li><a href="https://amzn.to/4miS3UJ" class="text-yellow-500 hover:text-yellow-600">DJI Pocket 3</a></li>
+                        <li><a href="https://amzn.to/4lvd1hI" class="text-yellow-500 hover:text-yellow-600">Tamron 28–200</a></li>
+                        <li><a href="https://amzn.to/4oHMXTy" class="text-yellow-500 hover:text-yellow-600">RØDE Wireless PRO</a></li>
+                        <li><a href="https://amzn.to/467fEAU" class="text-yellow-500 hover:text-yellow-600">Think Tank Backpack</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🧰 MY GEAR — AU LINKS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li><a href="https://amzn.to/41zmAVV" class="text-yellow-500 hover:text-yellow-600">DJI Flip</a></li>
+                        <li><a href="https://amzn.to/45Qk2Fw" class="text-yellow-500 hover:text-yellow-600">Sony A7C II</a></li>
+                        <li><a href="https://amzn.to/4gaYLJZ" class="text-yellow-500 hover:text-yellow-600">DJI Osmo Pocket 3</a></li>
+                        <li><a href="https://amzn.to/4n73D5P" class="text-yellow-500 hover:text-yellow-600">Tamron 24–200</a></li>
+                        <li><a href="https://amzn.to/46kv8CG" class="text-yellow-500 hover:text-yellow-600">RØDE Wireless PRO</a></li>
+                        <li><a href="https://amzn.to/3I5mApV" class="text-yellow-500 hover:text-yellow-600">Think Tank Backpack</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
+
     <!-- Footer -->
     <footer class="bg-gray-900 text-white py-12">
         <div class="container mx-auto px-6">

--- a/kyototravelguide.html
+++ b/kyototravelguide.html
@@ -401,6 +401,55 @@
         </div>
     </section>
 
+    <!-- Travel Essentials & Creator Gear -->
+    <section class="py-16 bg-gray-100">
+        <div class="container mx-auto px-6">
+            <div class="text-center mb-12">
+                <h2 class="heading-font text-3xl md:text-4xl font-bold text-gray-800 mb-4">Travel Essentials &amp; Creator Gear</h2>
+                <div class="w-20 h-1 bg-yellow-500 mx-auto"></div>
+            </div>
+            <div class="max-w-3xl mx-auto space-y-10">
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🌍 TRAVEL ESSENTIALS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li>Saily eSIM (200+ countries): Use code <span class="font-semibold">CARLRI5370</span> for $5 off (I receive $5 credit)</li>
+                        <li>Wise (multi-currency card): <a href="https://wise.com/invite/irhc/carlt62" class="text-yellow-500 hover:text-yellow-600">Sign up here</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🎬 CREATOR TOOLS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li>Dehancer (film emulation): Code <span class="font-semibold">CARLTRAVELS</span> for 10% off → <a href="https://www.dehancer.com/subscribe" class="text-yellow-500 hover:text-yellow-600">dehancer.com/subscribe</a></li>
+                        <li>Adobe Enhance VO (FREE): <a href="https://podcast.adobe.com/en/enhance" class="text-yellow-500 hover:text-yellow-600">podcast.adobe.com/en/enhance</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🧰 MY GEAR — US LINKS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li><a href="https://amzn.to/45iZULT" class="text-yellow-500 hover:text-yellow-600">DJI Flip</a></li>
+                        <li><a href="https://amzn.to/4mHhQ8H" class="text-yellow-500 hover:text-yellow-600">Sony A7C II</a></li>
+                        <li><a href="https://amzn.to/4miS3UJ" class="text-yellow-500 hover:text-yellow-600">DJI Pocket 3</a></li>
+                        <li><a href="https://amzn.to/4lvd1hI" class="text-yellow-500 hover:text-yellow-600">Tamron 28–200</a></li>
+                        <li><a href="https://amzn.to/4oHMXTy" class="text-yellow-500 hover:text-yellow-600">RØDE Wireless PRO</a></li>
+                        <li><a href="https://amzn.to/467fEAU" class="text-yellow-500 hover:text-yellow-600">Think Tank Backpack</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🧰 MY GEAR — AU LINKS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li><a href="https://amzn.to/41zmAVV" class="text-yellow-500 hover:text-yellow-600">DJI Flip</a></li>
+                        <li><a href="https://amzn.to/45Qk2Fw" class="text-yellow-500 hover:text-yellow-600">Sony A7C II</a></li>
+                        <li><a href="https://amzn.to/4gaYLJZ" class="text-yellow-500 hover:text-yellow-600">DJI Osmo Pocket 3</a></li>
+                        <li><a href="https://amzn.to/4n73D5P" class="text-yellow-500 hover:text-yellow-600">Tamron 24–200</a></li>
+                        <li><a href="https://amzn.to/46kv8CG" class="text-yellow-500 hover:text-yellow-600">RØDE Wireless PRO</a></li>
+                        <li><a href="https://amzn.to/3I5mApV" class="text-yellow-500 hover:text-yellow-600">Think Tank Backpack</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
+
     <!-- Footer -->
     <footer class="bg-gray-900 text-white py-12">
         <div class="container mx-auto px-6">

--- a/melbournetravelguide.html
+++ b/melbournetravelguide.html
@@ -311,6 +311,55 @@
         </div>
     </main>
 
+    <!-- Travel Essentials & Creator Gear -->
+    <section class="py-16 bg-gray-100">
+        <div class="container mx-auto px-6">
+            <div class="text-center mb-12">
+                <h2 class="heading-font text-3xl md:text-4xl font-bold text-gray-800 mb-4">Travel Essentials &amp; Creator Gear</h2>
+                <div class="w-20 h-1 bg-yellow-500 mx-auto"></div>
+            </div>
+            <div class="max-w-3xl mx-auto space-y-10">
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🌍 TRAVEL ESSENTIALS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li>Saily eSIM (200+ countries): Use code <span class="font-semibold">CARLRI5370</span> for $5 off (I receive $5 credit)</li>
+                        <li>Wise (multi-currency card): <a href="https://wise.com/invite/irhc/carlt62" class="text-yellow-500 hover:text-yellow-600">Sign up here</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🎬 CREATOR TOOLS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li>Dehancer (film emulation): Code <span class="font-semibold">CARLTRAVELS</span> for 10% off → <a href="https://www.dehancer.com/subscribe" class="text-yellow-500 hover:text-yellow-600">dehancer.com/subscribe</a></li>
+                        <li>Adobe Enhance VO (FREE): <a href="https://podcast.adobe.com/en/enhance" class="text-yellow-500 hover:text-yellow-600">podcast.adobe.com/en/enhance</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🧰 MY GEAR — US LINKS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li><a href="https://amzn.to/45iZULT" class="text-yellow-500 hover:text-yellow-600">DJI Flip</a></li>
+                        <li><a href="https://amzn.to/4mHhQ8H" class="text-yellow-500 hover:text-yellow-600">Sony A7C II</a></li>
+                        <li><a href="https://amzn.to/4miS3UJ" class="text-yellow-500 hover:text-yellow-600">DJI Pocket 3</a></li>
+                        <li><a href="https://amzn.to/4lvd1hI" class="text-yellow-500 hover:text-yellow-600">Tamron 28–200</a></li>
+                        <li><a href="https://amzn.to/4oHMXTy" class="text-yellow-500 hover:text-yellow-600">RØDE Wireless PRO</a></li>
+                        <li><a href="https://amzn.to/467fEAU" class="text-yellow-500 hover:text-yellow-600">Think Tank Backpack</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🧰 MY GEAR — AU LINKS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li><a href="https://amzn.to/41zmAVV" class="text-yellow-500 hover:text-yellow-600">DJI Flip</a></li>
+                        <li><a href="https://amzn.to/45Qk2Fw" class="text-yellow-500 hover:text-yellow-600">Sony A7C II</a></li>
+                        <li><a href="https://amzn.to/4gaYLJZ" class="text-yellow-500 hover:text-yellow-600">DJI Osmo Pocket 3</a></li>
+                        <li><a href="https://amzn.to/4n73D5P" class="text-yellow-500 hover:text-yellow-600">Tamron 24–200</a></li>
+                        <li><a href="https://amzn.to/46kv8CG" class="text-yellow-500 hover:text-yellow-600">RØDE Wireless PRO</a></li>
+                        <li><a href="https://amzn.to/3I5mApV" class="text-yellow-500 hover:text-yellow-600">Think Tank Backpack</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
+
     <!-- Footer -->
     <footer class="bg-gray-900 text-white py-12">
         <div class="container mx-auto px-6">

--- a/osakatravelguide.html
+++ b/osakatravelguide.html
@@ -309,6 +309,55 @@
         </div>
     </main>
 
+    <!-- Travel Essentials & Creator Gear -->
+    <section class="py-16 bg-gray-100">
+        <div class="container mx-auto px-6">
+            <div class="text-center mb-12">
+                <h2 class="heading-font text-3xl md:text-4xl font-bold text-gray-800 mb-4">Travel Essentials &amp; Creator Gear</h2>
+                <div class="w-20 h-1 bg-yellow-500 mx-auto"></div>
+            </div>
+            <div class="max-w-3xl mx-auto space-y-10">
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🌍 TRAVEL ESSENTIALS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li>Saily eSIM (200+ countries): Use code <span class="font-semibold">CARLRI5370</span> for $5 off (I receive $5 credit)</li>
+                        <li>Wise (multi-currency card): <a href="https://wise.com/invite/irhc/carlt62" class="text-yellow-500 hover:text-yellow-600">Sign up here</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🎬 CREATOR TOOLS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li>Dehancer (film emulation): Code <span class="font-semibold">CARLTRAVELS</span> for 10% off → <a href="https://www.dehancer.com/subscribe" class="text-yellow-500 hover:text-yellow-600">dehancer.com/subscribe</a></li>
+                        <li>Adobe Enhance VO (FREE): <a href="https://podcast.adobe.com/en/enhance" class="text-yellow-500 hover:text-yellow-600">podcast.adobe.com/en/enhance</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🧰 MY GEAR — US LINKS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li><a href="https://amzn.to/45iZULT" class="text-yellow-500 hover:text-yellow-600">DJI Flip</a></li>
+                        <li><a href="https://amzn.to/4mHhQ8H" class="text-yellow-500 hover:text-yellow-600">Sony A7C II</a></li>
+                        <li><a href="https://amzn.to/4miS3UJ" class="text-yellow-500 hover:text-yellow-600">DJI Pocket 3</a></li>
+                        <li><a href="https://amzn.to/4lvd1hI" class="text-yellow-500 hover:text-yellow-600">Tamron 28–200</a></li>
+                        <li><a href="https://amzn.to/4oHMXTy" class="text-yellow-500 hover:text-yellow-600">RØDE Wireless PRO</a></li>
+                        <li><a href="https://amzn.to/467fEAU" class="text-yellow-500 hover:text-yellow-600">Think Tank Backpack</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🧰 MY GEAR — AU LINKS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li><a href="https://amzn.to/41zmAVV" class="text-yellow-500 hover:text-yellow-600">DJI Flip</a></li>
+                        <li><a href="https://amzn.to/45Qk2Fw" class="text-yellow-500 hover:text-yellow-600">Sony A7C II</a></li>
+                        <li><a href="https://amzn.to/4gaYLJZ" class="text-yellow-500 hover:text-yellow-600">DJI Osmo Pocket 3</a></li>
+                        <li><a href="https://amzn.to/4n73D5P" class="text-yellow-500 hover:text-yellow-600">Tamron 24–200</a></li>
+                        <li><a href="https://amzn.to/46kv8CG" class="text-yellow-500 hover:text-yellow-600">RØDE Wireless PRO</a></li>
+                        <li><a href="https://amzn.to/3I5mApV" class="text-yellow-500 hover:text-yellow-600">Think Tank Backpack</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
+
     <!-- Footer -->
     <footer class="bg-gray-900 text-white py-12">
         <div class="container mx-auto px-6">

--- a/phuketravelguide.html
+++ b/phuketravelguide.html
@@ -310,6 +310,55 @@
         </div>
     </section>
 
+    <!-- Travel Essentials & Creator Gear -->
+    <section class="py-16 bg-gray-100">
+        <div class="container mx-auto px-6">
+            <div class="text-center mb-12">
+                <h2 class="heading-font text-3xl md:text-4xl font-bold text-gray-800 mb-4">Travel Essentials &amp; Creator Gear</h2>
+                <div class="w-20 h-1 bg-yellow-500 mx-auto"></div>
+            </div>
+            <div class="max-w-3xl mx-auto space-y-10">
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🌍 TRAVEL ESSENTIALS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li>Saily eSIM (200+ countries): Use code <span class="font-semibold">CARLRI5370</span> for $5 off (I receive $5 credit)</li>
+                        <li>Wise (multi-currency card): <a href="https://wise.com/invite/irhc/carlt62" class="text-yellow-500 hover:text-yellow-600">Sign up here</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🎬 CREATOR TOOLS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li>Dehancer (film emulation): Code <span class="font-semibold">CARLTRAVELS</span> for 10% off → <a href="https://www.dehancer.com/subscribe" class="text-yellow-500 hover:text-yellow-600">dehancer.com/subscribe</a></li>
+                        <li>Adobe Enhance VO (FREE): <a href="https://podcast.adobe.com/en/enhance" class="text-yellow-500 hover:text-yellow-600">podcast.adobe.com/en/enhance</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🧰 MY GEAR — US LINKS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li><a href="https://amzn.to/45iZULT" class="text-yellow-500 hover:text-yellow-600">DJI Flip</a></li>
+                        <li><a href="https://amzn.to/4mHhQ8H" class="text-yellow-500 hover:text-yellow-600">Sony A7C II</a></li>
+                        <li><a href="https://amzn.to/4miS3UJ" class="text-yellow-500 hover:text-yellow-600">DJI Pocket 3</a></li>
+                        <li><a href="https://amzn.to/4lvd1hI" class="text-yellow-500 hover:text-yellow-600">Tamron 28–200</a></li>
+                        <li><a href="https://amzn.to/4oHMXTy" class="text-yellow-500 hover:text-yellow-600">RØDE Wireless PRO</a></li>
+                        <li><a href="https://amzn.to/467fEAU" class="text-yellow-500 hover:text-yellow-600">Think Tank Backpack</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🧰 MY GEAR — AU LINKS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li><a href="https://amzn.to/41zmAVV" class="text-yellow-500 hover:text-yellow-600">DJI Flip</a></li>
+                        <li><a href="https://amzn.to/45Qk2Fw" class="text-yellow-500 hover:text-yellow-600">Sony A7C II</a></li>
+                        <li><a href="https://amzn.to/4gaYLJZ" class="text-yellow-500 hover:text-yellow-600">DJI Osmo Pocket 3</a></li>
+                        <li><a href="https://amzn.to/4n73D5P" class="text-yellow-500 hover:text-yellow-600">Tamron 24–200</a></li>
+                        <li><a href="https://amzn.to/46kv8CG" class="text-yellow-500 hover:text-yellow-600">RØDE Wireless PRO</a></li>
+                        <li><a href="https://amzn.to/3I5mApV" class="text-yellow-500 hover:text-yellow-600">Think Tank Backpack</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
+
     <!-- Footer -->
     <footer class="bg-gray-900 text-white py-12">
         <div class="container mx-auto px-6">

--- a/tokyotravelguide.html
+++ b/tokyotravelguide.html
@@ -402,6 +402,55 @@
         </div>
     </section>
 
+    <!-- Travel Essentials & Creator Gear -->
+    <section class="py-16 bg-gray-100">
+        <div class="container mx-auto px-6">
+            <div class="text-center mb-12">
+                <h2 class="heading-font text-3xl md:text-4xl font-bold text-gray-800 mb-4">Travel Essentials &amp; Creator Gear</h2>
+                <div class="w-20 h-1 bg-yellow-500 mx-auto"></div>
+            </div>
+            <div class="max-w-3xl mx-auto space-y-10">
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🌍 TRAVEL ESSENTIALS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li>Saily eSIM (200+ countries): Use code <span class="font-semibold">CARLRI5370</span> for $5 off (I receive $5 credit)</li>
+                        <li>Wise (multi-currency card): <a href="https://wise.com/invite/irhc/carlt62" class="text-yellow-500 hover:text-yellow-600">Sign up here</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🎬 CREATOR TOOLS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li>Dehancer (film emulation): Code <span class="font-semibold">CARLTRAVELS</span> for 10% off → <a href="https://www.dehancer.com/subscribe" class="text-yellow-500 hover:text-yellow-600">dehancer.com/subscribe</a></li>
+                        <li>Adobe Enhance VO (FREE): <a href="https://podcast.adobe.com/en/enhance" class="text-yellow-500 hover:text-yellow-600">podcast.adobe.com/en/enhance</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🧰 MY GEAR — US LINKS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li><a href="https://amzn.to/45iZULT" class="text-yellow-500 hover:text-yellow-600">DJI Flip</a></li>
+                        <li><a href="https://amzn.to/4mHhQ8H" class="text-yellow-500 hover:text-yellow-600">Sony A7C II</a></li>
+                        <li><a href="https://amzn.to/4miS3UJ" class="text-yellow-500 hover:text-yellow-600">DJI Pocket 3</a></li>
+                        <li><a href="https://amzn.to/4lvd1hI" class="text-yellow-500 hover:text-yellow-600">Tamron 28–200</a></li>
+                        <li><a href="https://amzn.to/4oHMXTy" class="text-yellow-500 hover:text-yellow-600">RØDE Wireless PRO</a></li>
+                        <li><a href="https://amzn.to/467fEAU" class="text-yellow-500 hover:text-yellow-600">Think Tank Backpack</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold text-gray-800 mb-4">🧰 MY GEAR — AU LINKS</h3>
+                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+                        <li><a href="https://amzn.to/41zmAVV" class="text-yellow-500 hover:text-yellow-600">DJI Flip</a></li>
+                        <li><a href="https://amzn.to/45Qk2Fw" class="text-yellow-500 hover:text-yellow-600">Sony A7C II</a></li>
+                        <li><a href="https://amzn.to/4gaYLJZ" class="text-yellow-500 hover:text-yellow-600">DJI Osmo Pocket 3</a></li>
+                        <li><a href="https://amzn.to/4n73D5P" class="text-yellow-500 hover:text-yellow-600">Tamron 24–200</a></li>
+                        <li><a href="https://amzn.to/46kv8CG" class="text-yellow-500 hover:text-yellow-600">RØDE Wireless PRO</a></li>
+                        <li><a href="https://amzn.to/3I5mApV" class="text-yellow-500 hover:text-yellow-600">Think Tank Backpack</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
+
     <!-- Footer -->
     <footer class="bg-gray-900 text-white py-12">
         <div class="container mx-auto px-6">


### PR DESCRIPTION
## Summary
- add Travel Essentials & Creator Gear affiliate section to all destination guides

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba86624ddc8323b911d7e2ddae32a0