### PR TITLE
Create stock footage income blog page and link from blog index

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -187,6 +187,34 @@
             </div>
             
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+                <!-- Blog Post: How to Earn Money Selling Stock Footage -->
+                <div class="blog-card rounded-xl overflow-hidden shadow-lg">
+                    <div class="relative overflow-hidden h-64">
+                        <img src="/carlcamera2.jpg" alt="Selling stock footage while traveling" class="w-full h-full object-cover transform hover:scale-110 transition-transform duration-500">
+                        <div class="absolute inset-0 bg-gradient-to-t from-black via-transparent to-transparent opacity-70"></div>
+                        <div class="absolute bottom-0 left-0 p-6 text-white">
+                            <h3 class="text-xl font-bold">How to Earn Money on Adobe Stock &amp; Shutterstock</h3>
+                            <p class="text-sm">Stock Footage Income</p>
+                        </div>
+                        <span class="absolute top-4 right-4 bg-yellow-9000 text-white text-xs px-3 py-1 rounded-full">Guide</span>
+                    </div>
+                    <div class="p-6 bg-white">
+                        <div class="flex justify-between items-center mb-3">
+                            <span class="text-gray-500 text-sm"><i class="fas fa-film mr-1 text-yellow-500"></i> Filmmaking</span>
+                            <div class="flex items-center">
+                                <i class="fas fa-star text-yellow-400 mr-1"></i>
+                                <span class="font-medium">4.9</span>
+                            </div>
+                        </div>
+                        <p class="text-gray-600 mb-4">
+                            My real earnings, workflow, and keyword strategy for turning travel footage into passive stock income.
+                        </p>
+                        <a href="howtomakemoneyonlinesellingstockfootage.html" class="text-yellow-500 font-medium hover:text-yellow-500 inline-flex items-center">
+                            Click here to find out more <i class="fas fa-arrow-right ml-2"></i>
+                        </a>
+                    </div>
+                </div>
+
                 <!-- Blog Post: Why I Use Dehancer to Make My Videos Look Cinematic -->
                 <div class="blog-card rounded-xl overflow-hidden shadow-lg">
                     <div class="relative overflow-hidden h-64">

--- a/howtomakemoneyonlinesellingstockfootage.html
+++ b/howtomakemoneyonlinesellingstockfootage.html
@@ -1,0 +1,589 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>How to Earn Money on Adobe Stock and Shutterstock - Carl Travels</title>
+    <!-- Cookiebot for GDPR Compliance -->
+    <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="e44b7cd2-126b-4f49-8aee-22495afe3ece" type="text/javascript" async></script>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-G72KT5ZW2J"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-G72KT5ZW2J');
+    </script>
+    <!-- Meta Tags -->
+    <meta name="description" content="Learn how traveling filmmaker Carl Tomich earns passive income selling stock footage on Adobe Stock and Shutterstock, including workflow tips, keyword strategy, and real earnings numbers.">
+    <meta name="keywords" content="stock footage income, Adobe Stock earnings, Shutterstock contributor tips, sell stock videos, passive income travel, drone footage, video licensing, stock video workflow, digital nomad side hustle, stock footage keywords">
+    <meta name="author" content="Carl Ostomich">
+    <meta name="tags" content="Adobe Stock, Shutterstock, stock footage, passive income, traveling filmmaker, video licensing, drone footage, stock keywords, digital nomad finances, side hustle">
+    <!-- Open Graph Meta Tags -->
+    <meta property="og:title" content="How to Earn Money on Adobe Stock and Shutterstock - Carl Travels">
+    <meta property="og:description" content="My real-world experience earning passive income selling travel footage on Adobe Stock and Shutterstock, with tips on workflow, pricing, and keywords that convert.">
+    <meta property="og:image" content="https://www.carltravels.com/images/carlcamera2.jpg">
+    <meta property="og:url" content="https://www.carltravels.com/howtomakemoneyonlinesellingstockfootage.html">
+    <meta property="og:type" content="article">
+    <!-- Twitter Card Meta Tags -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="How to Earn Money on Adobe Stock and Shutterstock - Carl Travels">
+    <meta name="twitter:description" content="Step-by-step advice for selling stock footage on Adobe Stock and Shutterstock from a full-time travel filmmaker.">
+    <meta name="twitter:image" content="https://www.carltravels.com/images/carlcamera2.jpg">
+    <!-- External Resources -->
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700&family=Bebas+Neue&display=swap');
+
+        :root {
+            --primary: #f5c518;
+            --secondary: #2a2a2a;
+            --dark: #1a1a1a;
+            --light: #d4d4d4;
+        }
+
+        body {
+            font-family: 'Montserrat', sans-serif;
+            background-color: var(--dark);
+            color: var(--light);
+            scroll-behavior: smooth;
+        }
+
+        .hero-gradient {
+            background: linear-gradient(135deg, rgba(42, 42, 42, 0.9), rgba(26, 26, 26, 0.9));
+        }
+
+        .heading-font {
+            font-family: 'Bebas Neue', sans-serif;
+        }
+
+        .navbar {
+            backdrop-filter: blur(10px);
+            background-color: rgba(255, 255, 255, 0.9);
+            transition: all 0.3s ease;
+        }
+
+        .navbar.scrolled {
+            background-color: rgba(255, 255, 255, 0.98);
+            box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+        }
+
+        .wave-shape {
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            width: 100%;
+            overflow: hidden;
+            line-height: 0;
+        }
+
+        .wave-shape svg {
+            position: relative;
+            display: block;
+            width: calc(100% + 1.3px);
+            height: 150px;
+        }
+
+        .wave-shape .shape-fill {
+            fill: #FFFFFF;
+        }
+
+        .mobile-menu {
+            max-height: 0;
+            overflow: hidden;
+            transition: max-height 0.5s ease-out;
+        }
+
+        .mobile-menu.open {
+            max-height: 500px;
+        }
+    </style>
+</head>
+<body class="text-gray-800">
+    <!-- Navigation -->
+    <nav id="navbar" class="navbar fixed w-full z-50 shadow-sm transition-all duration-300">
+        <div class="container mx-auto px-6 py-3">
+            <div class="flex justify-between items-center">
+                <a href="index.html" class="text-2xl font-bold flex items-center">
+                    <div class="w-10 h-10 rounded-full bg-gradient-to-r from-yellow-500 to-amber-600 flex items-center justify-center mr-2">
+                        <i class="fas fa-plane text-white text-lg transform -rotate-45"></i>
+                    </div>
+                    <span class="heading-font bg-gradient-to-r from-yellow-500 to-amber-600 bg-clip-text text-transparent">Carl Travels</span>
+                </a>
+
+                <div class="hidden md:flex items-center space-x-8">
+                    <a href="index.html" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">Home</a>
+                    <a href="destinations.html" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">Destinations</a>
+                    <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">Videos</a>
+                    <a href="blog.html" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">Blog</a>
+                    <a href="gear.html" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">Gear</a>
+                    <a href="index.html#about" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">About</a>
+                    <a href="donate.html" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">Donate</a>
+                    <a href="index.html#contact" class="px-4 py-2 bg-gradient-to-r from-yellow-500 to-amber-600 text-white rounded-full hover:shadow-lg transition-all">Contact</a>
+                </div>
+
+                <button id="mobile-menu-button" class="md:hidden text-gray-700 focus:outline-none">
+                    <i class="fas fa-bars text-2xl"></i>
+                </button>
+            </div>
+
+            <!-- Mobile Menu -->
+            <div id="mobile-menu" class="mobile-menu md:hidden">
+                <div class="pt-4 pb-2 space-y-2">
+                    <a href="index.html" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">Home</a>
+                    <a href="destinations.html" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">Destinations</a>
+                    <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">Videos</a>
+                    <a href="blog.html" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">Blog</a>
+                    <a href="gear.html" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">Gear</a>
+                    <a href="index.html#about" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">About</a>
+                    <a href="donate.html" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">Donate</a>
+                    <a href="index.html#contact" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">Contact</a>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <!-- Hero Section -->
+    <section class="hero-gradient relative overflow-hidden min-h-[60vh] flex items-center pt-20">
+        <div class="wave-shape">
+            <svg data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 120" preserveAspectRatio="none">
+                <path d="M321.39,56.44c58-10.79,114.16-30.13,172-41.86,82.39-16.72,168.19-17.73,250.45-.39C823.78,31,906.67,72,985.66,92.83c70.05,18.48,146.53,26.09,214.34,3V0H0V27.35A600.21,600.21,0,0,0,321.39,56.44Z" class="shape-fill"></path>
+            </svg>
+        </div>
+
+        <div class="container mx-auto px-6 py-20 relative z-10">
+            <div class="flex flex-col lg:flex-row items-center">
+                <div class="lg:w-1/2 mb-12 lg:mb-0">
+                    <h1 class="heading-font text-4xl md:text-5xl lg:text-6xl font-bold text-white leading-tight mb-6">
+                        How to Earn Money Selling Stock Footage While Traveling
+                    </h1>
+                    <p class="text-lg text-yellow-300 mb-8 max-w-lg">
+                        My honest breakdown of earning passive income on Adobe Stock and Shutterstock as a full-time traveling filmmaker.
+                    </p>
+                    <a href="#article" class="px-8 py-3 bg-white text-yellow-500 rounded-full font-medium hover:bg-gray-100 transition-all shadow-lg">
+                        Read the Guide
+                    </a>
+                </div>
+
+                <div class="lg:w-1/2 relative">
+                    <div class="relative max-w-md mx-auto">
+                        <div class="absolute -top-6 -left-6 w-32 h-32 bg-yellow-300 rounded-full opacity-20 animate-pulse"></div>
+                        <div class="absolute -bottom-6 -right-6 w-32 h-32 bg-yellow-300 rounded-full opacity-20 animate-pulse delay-300"></div>
+                        <div class="relative rounded-2xl overflow-hidden shadow-2xl border-8 border-white transform rotate-2">
+                            <img src="/carlcamera2.jpg" alt="Carl filming stock footage on the road" class="w-full h-auto">
+                            <div class="absolute inset-0 bg-gradient-to-t from-yellow-500 to-transparent opacity-70"></div>
+                            <div class="absolute bottom-0 left-0 p-6 text-white">
+                                <h3 class="text-xl font-bold">Turn Travel Shots Into Income</h3>
+                                <p class="text-sm opacity-90">Carl Travels • Stock Footage Workflow</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Article Section -->
+    <section id="article" class="py-20 bg-white">
+        <div class="container mx-auto px-6">
+            <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
+                <!-- Main Article Content -->
+                <div class="lg:col-span-2">
+                    <div class="text-center mb-16">
+                        <span class="text-yellow-500 font-medium mb-2 inline-block">STOCK FOOTAGE GUIDE</span>
+                        <h2 class="heading-font text-3xl md:text-4xl font-bold text-gray-800 mb-4">🎬 How to Earn Money on Adobe Stock & Shutterstock</h2>
+                        <div class="w-20 h-1 bg-gradient-to-r from-yellow-500 to-amber-600 mx-auto"></div>
+                    </div>
+
+                    <div class="prose max-w-none">
+                        <p class="text-gray-600 mb-8">
+                            When I left Australia in 2024 to travel full-time, I knew I needed multiple income streams. YouTube ad revenue is great, but it fluctuates wildly depending on views and CPMs. That’s why I turned to stock footage as an additional, evergreen way to monetize the cinematic content I was already creating on the road.
+                        </p>
+
+                        <div class="bg-gray-100 border-l-4 border-yellow-500 rounded-xl p-6 shadow-md mb-10">
+                            <h3 class="text-xl font-semibold text-gray-800 mb-2"><i class="fas fa-info-circle text-yellow-500 mr-2"></i>This Video Shows My Real Earnings</h3>
+                            <p class="text-gray-600 mb-4">I break down exactly how much each platform pays and which clips sell best in the video below.</p>
+                            <div class="relative w-full overflow-hidden rounded-xl shadow-lg" style="padding-top: 56.25%;">
+                                <iframe class="absolute inset-0 w-full h-full" src="https://www.youtube.com/embed/L_wTrfTvztk" title="How Much I Make Selling Stock Footage" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                            </div>
+                            <p class="text-sm text-gray-500 mt-3">This video is a video I made showing my earnings and which ones earn best.</p>
+                        </div>
+
+                        <h2 class="text-2xl font-bold text-gray-800 mb-4">Why I Started Selling Stock Footage</h2>
+                        <p class="text-gray-600 mb-6">
+                            Platforms like Adobe Stock and Shutterstock allow creators to upload photos and videos that businesses, agencies, and editors can license. Every time someone downloads your clip, you get paid a royalty. It’s not instant riches, but over time it builds a library that keeps earning—even while you’re asleep or island hopping between shoots.
+                        </p>
+                        <p class="text-gray-600 mb-8">
+                            Stock footage became my favorite “set and forget” side hustle because it monetizes footage that would otherwise sit on a hard drive. The more you upload, the more digital shelves you fill, and the more chances you have for clips to sell month after month.
+                        </p>
+
+                        <h2 class="text-2xl font-bold text-gray-800 mb-4">The Basics: How These Platforms Work</h2>
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
+                            <div class="bg-gray-50 rounded-xl p-6 shadow-lg">
+                                <h3 class="text-xl font-bold text-gray-800 mb-3"><i class="fab fa-adobe mr-2 text-yellow-500"></i>Adobe Stock</h3>
+                                <ul class="list-disc pl-5 text-gray-600 space-y-2">
+                                    <li>Integrated directly with Adobe Premiere Pro, After Effects, and Photoshop—editors can license clips inside their timeline.</li>
+                                    <li>Royalty rates improve as you sell more; quality 4K video can earn $20–80 per download.</li>
+                                    <li>Curated library favors well-exposed, color-corrected footage with clear commercial uses.</li>
+                                </ul>
+                            </div>
+                            <div class="bg-gray-50 rounded-xl p-6 shadow-lg">
+                                <h3 class="text-xl font-bold text-gray-800 mb-3"><i class="fas fa-camera-retro mr-2 text-yellow-500"></i>Shutterstock</h3>
+                                <ul class="list-disc pl-5 text-gray-600 space-y-2">
+                                    <li>One of the largest stock platforms in the world—massive buyer reach but higher competition.</li>
+                                    <li>Contributor levels unlock higher royalties (15%–40%) as you hit download milestones.</li>
+                                    <li>Partner distribution pushes your clips onto affiliated marketplaces for extra passive sales.</li>
+                                </ul>
+                            </div>
+                        </div>
+                        <p class="text-gray-600 mb-8">
+                            Both platforms pay royalties ranging from 15% to 40%, depending on exclusivity and your lifetime sales volume. Video payouts are typically higher than photos, making moving images the best use of your travel filmmaking skills.
+                        </p>
+
+                        <div class="bg-yellow-50 border border-yellow-200 rounded-xl p-6 shadow-inner mb-10">
+                            <h3 class="text-xl font-semibold text-yellow-700 mb-2"><i class="fas fa-coins mr-2"></i>Royalty Snapshot</h3>
+                            <div class="grid grid-cols-1 md:grid-cols-3 gap-4 text-gray-700">
+                                <div class="bg-white rounded-lg p-4 shadow">
+                                    <p class="text-sm font-medium text-gray-500 uppercase">Entry-Level Rate</p>
+                                    <p class="text-2xl font-bold text-gray-800">15%</p>
+                                    <p class="text-sm text-gray-600">Starter royalty on both platforms for new contributors.</p>
+                                </div>
+                                <div class="bg-white rounded-lg p-4 shadow">
+                                    <p class="text-sm font-medium text-gray-500 uppercase">Experienced Creators</p>
+                                    <p class="text-2xl font-bold text-gray-800">35%+</p>
+                                    <p class="text-sm text-gray-600">Reach higher tiers faster with consistent uploads.</p>
+                                </div>
+                                <div class="bg-white rounded-lg p-4 shadow">
+                                    <p class="text-sm font-medium text-gray-500 uppercase">4K Video Sale</p>
+                                    <p class="text-2xl font-bold text-gray-800">$20–$80</p>
+                                    <p class="text-sm text-gray-600">Typical payout range per download depending on buyer plan.</p>
+                                </div>
+                            </div>
+                        </div>
+
+                        <h2 class="text-2xl font-bold text-gray-800 mb-4">What I Upload (And Why)</h2>
+                        <p class="text-gray-600 mb-6">
+                            My content focus is travel: drone shots of skylines, cultural footage from markets and temples, and cinematic landscapes. I only upload clips that have a clear commercial use case so buyers can instantly imagine where they belong.
+                        </p>
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+                            <div class="bg-gray-50 rounded-xl p-6 shadow-lg">
+                                <h4 class="text-lg font-semibold text-gray-800 mb-3">My High-Converting Categories</h4>
+                                <ul class="list-disc pl-5 text-gray-600 space-y-2">
+                                    <li>Drone aerials of skylines, coastlines, and scenic flyovers.</li>
+                                    <li>Cultural footage: bustling markets, temples, and city street life.</li>
+                                    <li>Nature and landscapes: beaches, waterfalls, misty mountains.</li>
+                                </ul>
+                            </div>
+                            <div class="bg-gray-50 rounded-xl p-6 shadow-lg">
+                                <h4 class="text-lg font-semibold text-gray-800 mb-3">Clips with Built-In Buyers</h4>
+                                <ul class="list-disc pl-5 text-gray-600 space-y-2">
+                                    <li>Empty highways for automotive ads and narrative B-roll.</li>
+                                    <li>People walking in markets for lifestyle edits and travel vlogs.</li>
+                                    <li>Neutral corporate skylines with space for titles and motion graphics.</li>
+                                </ul>
+                            </div>
+                        </div>
+                        <div class="bg-gray-900 text-yellow-300 rounded-xl p-6 shadow-lg mb-10">
+                            <p class="text-lg font-semibold mb-2"><i class="fas fa-lightbulb mr-2"></i>Pro Tip:</p>
+                            <p class="text-yellow-100 mb-1">Upload footage with clear use-cases and searchable titles. Think like a buyer and describe what your clip actually solves.</p>
+                            <p class="text-yellow-100">Example: “Drone aerial of Hanoi Old Quarter at sunrise, Vietnam, 4K stock footage.”</p>
+                        </div>
+
+                        <h2 class="text-2xl font-bold text-gray-800 mb-4">How Much You Can Expect to Earn</h2>
+                        <p class="text-gray-600 mb-6">
+                            Earnings vary depending on whether you focus on photos or videos, how many files you contribute, and the production value of your footage. Here’s how I break it down for new contributors:
+                        </p>
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+                            <div class="bg-white border border-gray-200 rounded-xl p-6 shadow-sm">
+                                <h4 class="text-lg font-semibold text-gray-800 mb-3">Photos</h4>
+                                <ul class="list-disc pl-5 text-gray-600 space-y-2">
+                                    <li>Sell more frequently but at lower payouts (cents to a few dollars).</li>
+                                    <li>Requires a very large library to build meaningful passive income.</li>
+                                    <li>Great for filling gaps between video shoots.</li>
+                                </ul>
+                            </div>
+                            <div class="bg-white border border-gray-200 rounded-xl p-6 shadow-sm">
+                                <h4 class="text-lg font-semibold text-gray-800 mb-3">Videos</h4>
+                                <ul class="list-disc pl-5 text-gray-600 space-y-2">
+                                    <li>Lower sales volume, but payouts can range from $10–$50+ per clip.</li>
+                                    <li>A small catalog of strong, well-shot clips can outperform thousands of average photos.</li>
+                                    <li>4K and log-graded footage commands premium royalties.</li>
+                                </ul>
+                            </div>
+                        </div>
+                        <div class="bg-gradient-to-r from-yellow-500 to-amber-600 rounded-xl p-6 shadow-lg text-gray-900 mb-10">
+                            <h3 class="text-2xl font-bold mb-2">My Real Numbers</h3>
+                            <p class="text-lg mb-2">I currently earn about <span class="font-semibold">$1,200 a year</span> in extra passive income from my stock videos.</p>
+                            <p class="text-sm">It may not sound massive, but that’s footage I uploaded once—and it keeps selling while I focus on filming the next adventure.</p>
+                        </div>
+
+                        <h2 class="text-2xl font-bold text-gray-800 mb-4">Workflow: How I Manage It</h2>
+                        <p class="text-gray-600 mb-4">Because I’m already shooting for YouTube, I built a streamlined workflow that repurposes every clip:</p>
+                        <ul class="list-disc pl-6 text-gray-600 space-y-2 mb-8">
+                            <li><strong>Film once, use everywhere:</strong> my footage lives in YouTube edits, stock uploads, and Instagram reels.</li>
+                            <li><strong>Organize by location:</strong> folders named Bali, Hanoi, Cairns, etc., make batch uploads painless.</li>
+                            <li><strong>Multi-platform uploads:</strong> Adobe Stock, Shutterstock, and Pond5 each add incremental revenue.</li>
+                            <li><strong>SEO for stock:</strong> I mirror YouTube SEO—locations, subjects, shot types, and keyword-rich descriptions.</li>
+                        </ul>
+
+                        <h2 class="text-2xl font-bold text-gray-800 mb-4">Tips to Succeed as a Beginner</h2>
+                        <ul class="list-disc pl-6 text-gray-600 space-y-2 mb-8">
+                            <li>Stay consistent—don’t stop after uploading ten clips. The algorithm loves active contributors.</li>
+                            <li>Think like a buyer: “What problem does my clip solve?” rather than “Is it pretty?”</li>
+                            <li>Shoot clean and neutral so editors can add graphics or text without distractions.</li>
+                            <li>Stabilize your footage (or use tripods/drones) to avoid shaky clips getting rejected.</li>
+                            <li>Lean into niches: a unique Hanoi botanical garden shot sells faster than a generic sunset.</li>
+                        </ul>
+
+                        <h2 class="text-2xl font-bold text-gray-800 mb-4">Final Thoughts</h2>
+                        <p class="text-gray-600 mb-4">
+                            Selling on Adobe Stock and Shutterstock won’t replace a full-time income overnight. But for a travel filmmaker, it’s one of the smartest side hustles you can start. Your camera is already rolling—why not let those clips keep earning while you chase the next story?
+                        </p>
+                        <p class="text-gray-600 mb-6">
+                            Once your clips are uploaded, they can sell for years. That’s the definition of passive income: a growing archive working quietly in the background while you’re out filming somewhere new.
+                        </p>
+
+                        <div class="bg-gray-100 rounded-xl p-6 shadow-inner mb-12">
+                            <h3 class="text-xl font-semibold text-gray-800 mb-4"><i class="fas fa-tags text-yellow-500 mr-2"></i>Keywords & Tag Words I Use</h3>
+                            <div class="flex flex-wrap gap-3">
+                                <span class="px-4 py-2 bg-white rounded-full text-sm text-gray-700 shadow">stock footage travel</span>
+                                <span class="px-4 py-2 bg-white rounded-full text-sm text-gray-700 shadow">Adobe Stock earnings</span>
+                                <span class="px-4 py-2 bg-white rounded-full text-sm text-gray-700 shadow">Shutterstock passive income</span>
+                                <span class="px-4 py-2 bg-white rounded-full text-sm text-gray-700 shadow">drone aerial 4K</span>
+                                <span class="px-4 py-2 bg-white rounded-full text-sm text-gray-700 shadow">travel b-roll</span>
+                                <span class="px-4 py-2 bg-white rounded-full text-sm text-gray-700 shadow">video licensing</span>
+                                <span class="px-4 py-2 bg-white rounded-full text-sm text-gray-700 shadow">digital nomad income stream</span>
+                                <span class="px-4 py-2 bg-white rounded-full text-sm text-gray-700 shadow">Southeast Asia footage</span>
+                                <span class="px-4 py-2 bg-white rounded-full text-sm text-gray-700 shadow">stock keywords strategy</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Sidebar -->
+                <div class="lg:col-span-1">
+                    <div class="bg-gray-50 rounded-xl p-6 shadow-lg mb-8 sticky top-24">
+                        <h3 class="text-xl font-bold text-gray-800 mb-4">Why Stock Footage Works</h3>
+                        <ul class="space-y-3 text-gray-600 text-sm">
+                            <li><i class="fas fa-dollar-sign mr-2 text-yellow-500"></i>Royalty payments continue while you travel.</li>
+                            <li><i class="fas fa-video mr-2 text-yellow-500"></i>Repurpose YouTube footage for licensing income.</li>
+                            <li><i class="fas fa-tags mr-2 text-yellow-500"></i>Strong keywords drive organic discovery.</li>
+                            <li><i class="fas fa-cloud-upload-alt mr-2 text-yellow-500"></i>Batch uploads build a catalog fast.</li>
+                            <li><i class="fas fa-chart-line mr-2 text-yellow-500"></i>Compounding income as your library grows.</li>
+                        </ul>
+                    </div>
+
+                    <div class="bg-gradient-to-r from-yellow-500 to-amber-600 rounded-xl p-6 shadow-lg mb-8 text-gray-900">
+                        <h3 class="text-xl font-bold mb-3">Ready to Start Uploading?</h3>
+                        <p class="text-gray-800 mb-4">Grab my free checklist of titles, tags, and metadata prompts that help my clips rank on both platforms.</p>
+                        <a href="mailto:hello@carltravels.com?subject=Stock%20Footage%20Checklist" class="inline-flex items-center px-6 py-3 bg-white text-yellow-600 rounded-full font-medium hover:shadow-lg transition-all">
+                            Request the Checklist <i class="fas fa-arrow-right ml-2"></i>
+                        </a>
+                    </div>
+
+                    <div class="bg-gray-50 rounded-xl p-6 shadow-lg mb-8">
+                        <h3 class="text-xl font-bold text-gray-800 mb-4">More Filmmaking Resources</h3>
+                        <ul class="space-y-3 text-gray-600 text-sm">
+                            <li><a href="how-to-make-your-videos-look-cinematic.html" class="text-yellow-500 hover:text-yellow-600 font-medium">Color grading with Dehancer</a></li>
+                            <li><a href="travel-gear-2025.html" class="text-yellow-500 hover:text-yellow-600 font-medium">My 2025 travel filmmaking kit</a></li>
+                            <li><a href="whyileftaustralia.html" class="text-yellow-500 hover:text-yellow-600 font-medium">Why I chose a nomad lifestyle</a></li>
+                        </ul>
+                    </div>
+
+                    <div class="text-center">
+                        <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="inline-flex items-center px-6 py-3 border border-yellow-500 text-yellow-500 rounded-full font-medium hover:bg-yellow-900 transition-all">
+                            Watch More Travel Films <i class="fas fa-play ml-2"></i>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Newsletter Call-to-Action -->
+    <section class="bg-gradient-to-r from-yellow-500 to-amber-600 py-16">
+        <div class="container mx-auto px-6 text-center">
+            <h2 class="heading-font text-3xl md:text-4xl font-bold text-gray-800 mb-4">Join Our Travel Filmmaker Community</h2>
+            <p class="text-gray-700 mb-8 max-w-2xl mx-auto">
+                Subscribe for monthly stock footage tips, travel hacks, and behind-the-scenes stories straight from the road.
+            </p>
+            <form action="https://formspree.io/f/mnnnoogg" method="POST" class="flex flex-col sm:flex-row gap-4 max-w-xl mx-auto">
+                <input type="email" name="_replyto" placeholder="Your email address" class="px-4 py-3 rounded-full border border-gray-300 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-transparent flex-1" required>
+                <input type="hidden" name="_subject" value="Newsletter Subscription from Carl Travels">
+                <input type="hidden" name="_next" value="https://www.carltravels.com/thankyou.html">
+                <input type="hidden" name="_captcha" value="false">
+                <input type="text" name="_gotcha" style="display:none">
+                <button type="submit" class="px-6 py-3 bg-gradient-to-r from-yellow-500 to-amber-600 text-white rounded-full font-medium hover:shadow-lg transition-all">
+                    Subscribe <i class="fas fa-paper-plane ml-1"></i>
+                </button>
+            </form>
+            <p class="text-gray-800 text-sm mt-4">No spam, ever. Unsubscribe anytime.</p>
+        </div>
+    </section>
+
+    <!-- Footer -->
+    <footer class="bg-gray-900 text-white py-12">
+        <div class="container mx-auto px-6">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
+                <div>
+                    <a href="index.html" class="text-2xl font-bold flex items-center mb-6">
+                        <div class="w-10 h-10 rounded-full bg-gradient-to-r from-yellow-500 to-amber-600 flex items-center justify-center mr-2">
+                            <i class="fas fa-plane text-white text-lg transform -rotate-45"></i>
+                        </div>
+                        <span class="heading-font">Carl Travels</span>
+                    </a>
+                    <p class="text-gray-400 mb-4">
+                        Inspiring meaningful travel through authentic storytelling and cinematic filmmaking.
+                    </p>
+                    <div class="flex space-x-4">
+                        <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="text-gray-400 hover:text-white transition-colors" aria-label="YouTube">
+                            <i class="fab fa-youtube"></i>
+                        </a>
+                        <a href="https://www.youtube.com/@carltomichtech" target="_blank" class="text-gray-400 hover:text-white transition-colors" aria-label="YouTube Tech Channel">
+                            <i class="fab fa-youtube"></i>
+                        </a>
+                        <a href="https://www.youtube.com/@globetraveladventures" target="_blank" class="text-gray-400 hover:text-white transition-colors" aria-label="YouTube Adventures Channel">
+                            <i class="fab fa-youtube"></i>
+                        </a>
+                        <a href="https://www.instagram.com/carlostomich" target="_blank" class="text-gray-400 hover:text-white transition-colors" aria-label="Instagram">
+                            <i class="fab fa-instagram"></i>
+                        </a>
+                        <a href="https://www.facebook.com/thecarlostomich/" target="_blank" class="text-gray-400 hover:text-white transition-colors" aria-label="Facebook">
+                            <i class="fab fa-facebook-f"></i>
+                        </a>
+                    </div>
+                </div>
+
+                <div>
+                    <h3 class="text-lg font-semibold mb-6">Quick Links</h3>
+                    <ul class="space-y-3">
+                        <li><a href="index.html" class="text-gray-400 hover:text-white transition-colors">Home</a></li>
+                        <li><a href="destinations.html" class="text-gray-400 hover:text-white transition-colors">Destinations</a></li>
+                        <li><a href="https://www.youtube.com/@thecarltomich" target="_blank" class="text-gray-400 hover:text-white transition-colors">Videos</a></li>
+                        <li><a href="blog.html" class="text-gray-400 hover:text-white transition-colors">Blog</a></li>
+                        <li><a href="index.html#about" class="text-gray-400 hover:text-white transition-colors">About</a></li>
+                        <li><a href="donate.html" class="text-gray-400 hover:text-white transition-colors">Donate</a></li>
+                        <li><a href="index.html#contact" class="text-gray-400 hover:text-white transition-colors">Contact</a></li>
+                    </ul>
+                </div>
+
+                <div>
+                    <h3 class="text-lg font-semibold mb-6">Popular Guides</h3>
+                    <ul class="space-y-3">
+                        <li><a href="becomingadigitalnomad.html" class="text-gray-400 hover:text-white transition-colors">Digital Nomad Tips</a></li>
+                        <li><a href="balitravelguide.html" class="text-gray-400 hover:text-white transition-colors">Bali Travel Guide</a></li>
+                        <li><a href="travel-gear-2025.html" class="text-gray-400 hover:text-white transition-colors">Filmmaking Gear 2025</a></li>
+                        <li><a href="howtofoldapopuptent.html" class="text-gray-400 hover:text-white transition-colors">Camping Hacks</a></li>
+                    </ul>
+                </div>
+
+                <div>
+                    <h3 class="text-lg font-semibold mb-6">Newsletter</h3>
+                    <p class="text-gray-400 mb-4">
+                        Subscribe to get travel filmmaking tips and exclusive content directly in your inbox.
+                    </p>
+                    <form action="https://formspree.io/f/mnnnoogg" method="POST" class="flex">
+                        <input type="email" name="_replyto" placeholder="Your email" class="px-4 py-2 rounded-l-lg bg-gray-800 text-white focus:outline-none focus:ring-1 focus:ring-yellow-500 w-full" required>
+                        <input type="hidden" name="_subject" value="Newsletter Subscription from Carl Travels">
+                        <input type="hidden" name="_next" value="https://www.carltravels.com/thankyou.html">
+                        <input type="hidden" name="_captcha" value="false">
+                        <input type="text" name="_gotcha" style="display:none">
+                        <button type="submit" class="px-4 py-2 bg-gradient-to-r from-yellow-500 to-amber-600 text-white rounded-r-lg hover:shadow-lg transition-all">
+                            <i class="fas fa-paper-plane"></i>
+                        </button>
+                    </form>
+                </div>
+            </div>
+
+            <div class="border-t border-gray-800 mt-12 pt-8 flex flex-col md:flex-row justify-between items-center">
+                <p class="text-gray-400 text-sm mb-4 md:mb-0">
+                    © 2025 Carl Travels. All rights reserved.
+                </p>
+                <div class="flex space-x-6">
+                    <a href="privacy-policy.html" class="text-gray-400 hover:text-white text-sm transition-colors">Privacy Policy</a>
+                    <a href="terms-and-conditions.html" class="text-gray-400 hover:text-white text-sm transition-colors">Terms of Service</a>
+                    <a href="#" class="text-gray-400 hover:text-white text-sm transition-colors">Cookies</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <!-- Back to Top Button -->
+    <button id="back-to-top" class="fixed bottom-8 right-8 w-12 h-12 bg-gradient-to-r from-yellow-500 to-amber-600 text-white rounded-full shadow-lg flex items-center justify-center transition-all opacity-0 invisible">
+        <i class="fas fa-arrow-up"></i>
+    </button>
+
+    <!-- JavaScript with Error Handling -->
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            try {
+                const mobileMenuButton = document.getElementById('mobile-menu-button');
+                const mobileMenu = document.getElementById('mobile-menu');
+                if (mobileMenuButton && mobileMenu) {
+                    mobileMenuButton.addEventListener('click', function() {
+                        mobileMenu.classList.toggle('open');
+                        this.querySelector('i').classList.toggle('fa-bars');
+                        this.querySelector('i').classList.toggle('fa-times');
+                    });
+                }
+
+                document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+                    anchor.addEventListener('click', function(e) {
+                        const id = this.getAttribute('href');
+                        if (id !== '#') {
+                            const el = document.querySelector(id);
+                            if (el) {
+                                e.preventDefault();
+                                if (mobileMenu && mobileMenu.classList.contains('open')) {
+                                    mobileMenu.classList.remove('open');
+                                    if (mobileMenuButton) {
+                                        mobileMenuButton.querySelector('i').classList.toggle('fa-bars');
+                                        mobileMenuButton.querySelector('i').classList.toggle('fa-times');
+                                    }
+                                }
+                                window.scrollTo({
+                                    top: el.offsetTop - 80,
+                                    behavior: 'smooth'
+                                });
+                            }
+                        }
+                    });
+                });
+
+                const navbar = document.getElementById('navbar');
+                if (navbar) {
+                    window.addEventListener('scroll', function() {
+                        if (window.scrollY > 50) {
+                            navbar.classList.add('scrolled');
+                        } else {
+                            navbar.classList.remove('scrolled');
+                        }
+                    });
+                }
+
+                const backToTopButton = document.getElementById('back-to-top');
+                if (backToTopButton) {
+                    window.addEventListener('scroll', function() {
+                        if (window.scrollY > 300) {
+                            backToTopButton.classList.remove('opacity-0', 'invisible');
+                            backToTopButton.classList.add('opacity-100', 'visible');
+                        } else {
+                            backToTopButton.classList.remove('opacity-100', 'visible');
+                            backToTopButton.classList.add('opacity-0', 'invisible');
+                        }
+                    });
+                    backToTopButton.addEventListener('click', function() {
+                        window.scrollTo({
+                            top: 0,
+                            behavior: 'smooth'
+                        });
+                    });
+                }
+            } catch (error) {
+                console.error('JavaScript Error in howtomakemoneyonlinesellingstockfootage.html:', error);
+            }
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a new stock footage earnings article with YouTube embed, workflow guidance, and keyword/tag suggestions
- configure SEO metadata and sidebar resources tailored to Adobe Stock and Shutterstock contributors
- feature the new post on the blog landing page with an updated card linking to the article

## Testing
- not run (static content changes)


------
https://chatgpt.com/codex/tasks/task_e_68c8fedcb59483238b59525df3dfaac2