### PR TITLE
Expand sitemap with all site pages

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,25 +1,53 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 
-  <url><loc>https://www.carltravels.com/index.html</loc></url>
-  <url><loc>https://www.carltravels.com/blog.html</loc></url>
+  <url><loc>https://www.carltravels.com/</loc></url>
   <url><loc>https://www.carltravels.com/Berlin.html</loc></url>
-  <url><loc>https://www.carltravels.com/phuketravelguide.html</loc></url>
-  <url><loc>https://www.carltravels.com/getyourwisecard.html</loc></url>
-  <url><loc>https://www.carltravels.com/melbournetravelguide.html</loc></url>
-  <url><loc>https://www.carltravels.com/cairnstravelguide.html</loc></url>
-  <url><loc>https://www.carltravels.com/hanoitravelguide.html</loc></url>
-  <url><loc>https://www.carltravels.com/osakatravelguide.html</loc></url>
-  <url><loc>https://www.carltravels.com/budvatravelguide.html</loc></url>
-  <url><loc>https://www.carltravels.com/mytop10travelhacks.html</loc></url>
-  <url><loc>https://www.carltravels.com/buskingguide.html</loc></url>
-  <url><loc>https://www.carltravels.com/becomingadigitalnomad.html</loc></url>
-  <url><loc>https://www.carltravels.com/howtogetcroatiancitizenship.html</loc></url>
-  <url><loc>https://www.carltravels.com/becomingadigitalnomad.html</loc></url>
+  <url><loc>https://www.carltravels.com/DJI-Flip-review.html</loc></url>
+  <url><loc>https://www.carltravels.com/about.html</loc></url>
   <url><loc>https://www.carltravels.com/balitravelguide.html</loc></url>
-  <url><loc>https://www.carltravels.com/howtofoldapopuptent.html</loc></url>
+  <url><loc>https://www.carltravels.com/becomingadigitalnomad.html</loc></url>
+  <url><loc>https://www.carltravels.com/blog.html</loc></url>
+  <url><loc>https://www.carltravels.com/bose-s1pro-plus-vs-everse8-the-best-portable-speaker.html</loc></url>
+  <url><loc>https://www.carltravels.com/budvatravelguide.html</loc></url>
+  <url><loc>https://www.carltravels.com/buskingguide.html</loc></url>
+  <url><loc>https://www.carltravels.com/cairnstravelguide.html</loc></url>
+  <url><loc>https://www.carltravels.com/contact.html</loc></url>
+  <url><loc>https://www.carltravels.com/danangtravelguide.html</loc></url>
+  <url><loc>https://www.carltravels.com/destinations.html</loc></url>
+  <url><loc>https://www.carltravels.com/dji-mini-3-pro-review.html</loc></url>
+  <url><loc>https://www.carltravels.com/donate.html</loc></url>
+  <url><loc>https://www.carltravels.com/esim-guide.html</loc></url>
+  <url><loc>https://www.carltravels.com/farnorthqueenslandtravelguide.html</loc></url>
+  <url><loc>https://www.carltravels.com/gear.html</loc></url>
+  <url><loc>https://www.carltravels.com/getyourwisecard.html</loc></url>
+  <url><loc>https://www.carltravels.com/hanoitravelguide.html</loc></url>
   <url><loc>https://www.carltravels.com/how-to-get-croatian-citizenship-by-descent.html</loc></url>
   <url><loc>https://www.carltravels.com/how-to-get-croatian-citizenship-through-your-grandparent.html</loc></url>
+  <url><loc>https://www.carltravels.com/how-to-make-your-videos-look-cinematic.html</loc></url>
+  <url><loc>https://www.carltravels.com/howtofoldapopuptent.html</loc></url>
+  <url><loc>https://www.carltravels.com/howtomakemoneyonlinesellingstockfootage.html</loc></url>
+  <url><loc>https://www.carltravels.com/index.html</loc></url>
+  <url><loc>https://www.carltravels.com/japanonabudget.html</loc></url>
+  <url><loc>https://www.carltravels.com/korcula.html</loc></url>
+  <url><loc>https://www.carltravels.com/kyototravelguide.html</loc></url>
+  <url><loc>https://www.carltravels.com/melbournetravelguide.html</loc></url>
+  <url><loc>https://www.carltravels.com/mytop10travelhacks.html</loc></url>
+  <url><loc>https://www.carltravels.com/nusalembongan.html</loc></url>
+  <url><loc>https://www.carltravels.com/osakatravelguide.html</loc></url>
+  <url><loc>https://www.carltravels.com/phuketravelguide.html</loc></url>
+  <url><loc>https://www.carltravels.com/portdouglas.html</loc></url>
+  <url><loc>https://www.carltravels.com/portfolio.html</loc></url>
+  <url><loc>https://www.carltravels.com/privacy-policy.html</loc></url>
+  <url><loc>https://www.carltravels.com/sony-a7cii-review.html</loc></url>
+  <url><loc>https://www.carltravels.com/tech-review-dji-mavic3.html</loc></url>
+  <url><loc>https://www.carltravels.com/tech-review-sony-a7siii.html</loc></url>
+  <url><loc>https://www.carltravels.com/tech-review-zhiyun-weebill2.html</loc></url>
+  <url><loc>https://www.carltravels.com/terms-and-conditions.html</loc></url>
+  <url><loc>https://www.carltravels.com/thankyou.html</loc></url>
+  <url><loc>https://www.carltravels.com/tokyotravelguide.html</loc></url>
+  <url><loc>https://www.carltravels.com/travel-gear-2025.html</loc></url>
+  <url><loc>https://www.carltravels.com/whyileftaustralia.html</loc></url>
+  <url><loc>https://www.carltravels.com/work.html</loc></url>
 
-  
 </urlset>


### PR DESCRIPTION
## Summary
- regenerate sitemap.xml to list every HTML page on carltravels.com, including destinations, blog, gear, and other sections
- add the root URL entry and remove outdated or duplicate sitemap entries

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cabd39678c83238edc7daecd5ab23f