### PR TITLE
Add video sitemap and reference in robots.txt

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,4 @@
 User-agent: *
 Allow: /
 Sitemap: https://www.carltravels.com/sitemap.xml
+Sitemap: https://www.carltravels.com/sitemap-video.xml

--- a/sitemap-video.xml
+++ b/sitemap-video.xml
@@ -1,0 +1,195 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
+  <url>
+    <loc>https://www.carltravels.com/videos/commercial-1.html</loc>
+    <video:video>
+      <video:thumbnail_loc>https://img.youtube.com/vi/V2iZFD5yW_k/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title>Commercial 1</video:title>
+      <video:description>A boutique hotel brand film blending architectural details, guest experiences, and sunrise drone sweeps.</video:description>
+      <video:player_loc allow_embed="yes">https://www.youtube.com/embed/V2iZFD5yW_k</video:player_loc>
+      <video:content_loc>https://www.youtube.com/watch?v=V2iZFD5yW_k</video:content_loc>
+      <video:publication_date>2025-09-17T23:04:40+07:00</video:publication_date>
+      <video:family_friendly>yes</video:family_friendly>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://www.carltravels.com/videos/commercial-2.html</loc>
+    <video:video>
+      <video:thumbnail_loc>https://img.youtube.com/vi/oHjvJAfbW-w/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title>Commercial 2</video:title>
+      <video:description>High-energy launch video for a wearable fitness device mixing macro product shots with athlete testimonials.</video:description>
+      <video:player_loc allow_embed="yes">https://www.youtube.com/embed/oHjvJAfbW-w</video:player_loc>
+      <video:content_loc>https://www.youtube.com/watch?v=oHjvJAfbW-w</video:content_loc>
+      <video:publication_date>2025-09-17T23:04:40+07:00</video:publication_date>
+      <video:family_friendly>yes</video:family_friendly>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://www.carltravels.com/videos/commercial-3.html</loc>
+    <video:video>
+      <video:thumbnail_loc>https://img.youtube.com/vi/EssKbtalMwc/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title>Commercial 3</video:title>
+      <video:description>Lifestyle campaign celebrating everyday ritual for an artisan coffee brand, filmed entirely in natural light.</video:description>
+      <video:player_loc allow_embed="yes">https://www.youtube.com/embed/EssKbtalMwc</video:player_loc>
+      <video:content_loc>https://www.youtube.com/watch?v=EssKbtalMwc</video:content_loc>
+      <video:publication_date>2025-09-17T23:04:40+07:00</video:publication_date>
+      <video:family_friendly>yes</video:family_friendly>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://www.carltravels.com/videos/hanoi-ha-long-bay-adventure.html</loc>
+    <video:video>
+      <video:thumbnail_loc>https://img.youtube.com/vi/gWw7ygXH_Eo/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title>Ha Long Bay Adventure (Days 6–7)</video:title>
+      <video:description>Board an overnight junk boat, kayak hidden lagoons, and greet the sun with tai chi while limestone karsts glow gold across Ha Long Bay.</video:description>
+      <video:player_loc allow_embed="yes">https://www.youtube.com/embed/gWw7ygXH_Eo</video:player_loc>
+      <video:content_loc>https://www.youtube.com/watch?v=gWw7ygXH_Eo</video:content_loc>
+      <video:publication_date>2025-09-17T23:04:40+07:00</video:publication_date>
+      <video:family_friendly>yes</video:family_friendly>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://www.carltravels.com/videos/hanoi-learn-vietnamese-testimonial.html</loc>
+    <video:video>
+      <video:thumbnail_loc>https://img.youtube.com/vi/ay5fwK0OVaM/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title>Learn Vietnamese with Quynh</video:title>
+      <video:description>Carl shares his experience taking a one-on-one language lesson with Quynh from iSpeak Viet Lingo, highlighting teaching style, pricing, and what to expect.</video:description>
+      <video:player_loc allow_embed="yes">https://www.youtube.com/embed/ay5fwK0OVaM</video:player_loc>
+      <video:content_loc>https://www.youtube.com/watch?v=ay5fwK0OVaM</video:content_loc>
+      <video:publication_date>2025-09-17T23:04:40+07:00</video:publication_date>
+      <video:family_friendly>yes</video:family_friendly>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://www.carltravels.com/videos/hanoi-old-quarter-vibes.html</loc>
+    <video:video>
+      <video:thumbnail_loc>https://img.youtube.com/vi/6I8DYrGi37g/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title>Old Quarter Vibes (Day 4)</video:title>
+      <video:description>Follow Carl into Hanoi's Old Quarter where scooter dodging, bun cha feasts, and bia hoi storytelling collide in one frenetic evening.</video:description>
+      <video:player_loc allow_embed="yes">https://www.youtube.com/embed/6I8DYrGi37g</video:player_loc>
+      <video:content_loc>https://www.youtube.com/watch?v=6I8DYrGi37g</video:content_loc>
+      <video:publication_date>2025-09-17T23:04:40+07:00</video:publication_date>
+      <video:family_friendly>yes</video:family_friendly>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://www.carltravels.com/videos/hanoi-train-street-thrills.html</loc>
+    <video:video>
+      <video:thumbnail_loc>https://img.youtube.com/vi/31idWwYdPIc/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title>Train Street Thrills (Day 2)</video:title>
+      <video:description>Carl grabs a tiny café stool inches from Hanoi's Train Street tracks to capture the heart-stopping moment when a full-sized locomotive brushes past residents sipping egg coffee.</video:description>
+      <video:player_loc allow_embed="yes">https://www.youtube.com/embed/31idWwYdPIc</video:player_loc>
+      <video:content_loc>https://www.youtube.com/watch?v=31idWwYdPIc</video:content_loc>
+      <video:publication_date>2025-09-17T23:04:40+07:00</video:publication_date>
+      <video:family_friendly>yes</video:family_friendly>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://www.carltravels.com/videos/music-video-1.html</loc>
+    <video:video>
+      <video:thumbnail_loc>https://img.youtube.com/vi/g7bFA8Rrwik/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title>Music Video 1</video:title>
+      <video:description>A moody warehouse performance drenched in blue gels and practical smoke, cut to a synth-pop anthem about second chances.</video:description>
+      <video:player_loc allow_embed="yes">https://www.youtube.com/embed/g7bFA8Rrwik</video:player_loc>
+      <video:content_loc>https://www.youtube.com/watch?v=g7bFA8Rrwik</video:content_loc>
+      <video:publication_date>2025-09-17T23:04:40+07:00</video:publication_date>
+      <video:family_friendly>yes</video:family_friendly>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://www.carltravels.com/videos/music-video-2.html</loc>
+    <video:video>
+      <video:thumbnail_loc>https://img.youtube.com/vi/Iubiv9CKUvk/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title>Music Video 2</video:title>
+      <video:description>Sunset rooftops and frenetic dance breaks drive this indie-pop video that celebrates found family in the city.</video:description>
+      <video:player_loc allow_embed="yes">https://www.youtube.com/embed/Iubiv9CKUvk</video:player_loc>
+      <video:content_loc>https://www.youtube.com/watch?v=Iubiv9CKUvk</video:content_loc>
+      <video:publication_date>2025-09-17T23:04:40+07:00</video:publication_date>
+      <video:family_friendly>yes</video:family_friendly>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://www.carltravels.com/videos/music-video-3.html</loc>
+    <video:video>
+      <video:thumbnail_loc>https://img.youtube.com/vi/vnDDcKRQZI8/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title>Music Video 3</video:title>
+      <video:description>Golden hour ballad visuals pair countryside vistas with intimate close-ups for a heartfelt acoustic release.</video:description>
+      <video:player_loc allow_embed="yes">https://www.youtube.com/embed/vnDDcKRQZI8</video:player_loc>
+      <video:content_loc>https://www.youtube.com/watch?v=vnDDcKRQZI8</video:content_loc>
+      <video:publication_date>2025-09-17T23:04:40+07:00</video:publication_date>
+      <video:family_friendly>yes</video:family_friendly>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://www.carltravels.com/videos/osaka-dotonbori-at-night.html</loc>
+    <video:video>
+      <video:thumbnail_loc>https://img.youtube.com/vi/5qCfcpFk38I/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title>Dotonbori at Night</video:title>
+      <video:description>A neon-powered walk through Dotonbori with sizzling takoyaki, river reflections, and the legendary Glico sign lighting the sky.</video:description>
+      <video:player_loc allow_embed="yes">https://www.youtube.com/embed/5qCfcpFk38I</video:player_loc>
+      <video:content_loc>https://www.youtube.com/watch?v=5qCfcpFk38I</video:content_loc>
+      <video:publication_date>2025-09-17T23:04:40+07:00</video:publication_date>
+      <video:family_friendly>yes</video:family_friendly>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://www.carltravels.com/videos/osaka-expo-70-park-journey.html</loc>
+    <video:video>
+      <video:thumbnail_loc>https://img.youtube.com/vi/mZF3X5DSxIM/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title>Expo '70 Park Daytrip</video:title>
+      <video:description>Ride the Osaka Monorail to Expo '70 Commemorative Park for retro-futuristic architecture, the Tower of the Sun, and tranquil Japanese gardens.</video:description>
+      <video:player_loc allow_embed="yes">https://www.youtube.com/embed/mZF3X5DSxIM</video:player_loc>
+      <video:content_loc>https://www.youtube.com/watch?v=mZF3X5DSxIM</video:content_loc>
+      <video:publication_date>2025-09-17T23:04:40+07:00</video:publication_date>
+      <video:family_friendly>yes</video:family_friendly>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://www.carltravels.com/videos/osaka-kobe-beef-experience.html</loc>
+    <video:video>
+      <video:thumbnail_loc>https://img.youtube.com/vi/GuSrgoggQCI/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title>Kobe Beef Pilgrimage</video:title>
+      <video:description>Join Carl on the quick hop to Kobe for a sizzling teppan lunch that demystifies grades of wagyu and the ritual of Kobe beef service.</video:description>
+      <video:player_loc allow_embed="yes">https://www.youtube.com/embed/GuSrgoggQCI</video:player_loc>
+      <video:content_loc>https://www.youtube.com/watch?v=GuSrgoggQCI</video:content_loc>
+      <video:publication_date>2025-09-17T23:04:40+07:00</video:publication_date>
+      <video:family_friendly>yes</video:family_friendly>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://www.carltravels.com/videos/wedding-film-1.html</loc>
+    <video:video>
+      <video:thumbnail_loc>https://img.youtube.com/vi/BkqojyevuTA/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title>Wedding Film 1</video:title>
+      <video:description>From sun-drenched vows on the coast to sparkler exits, this wedding highlight film leans into timeless romance.</video:description>
+      <video:player_loc allow_embed="yes">https://www.youtube.com/embed/BkqojyevuTA</video:player_loc>
+      <video:content_loc>https://www.youtube.com/watch?v=BkqojyevuTA</video:content_loc>
+      <video:publication_date>2025-09-17T23:04:40+07:00</video:publication_date>
+      <video:family_friendly>yes</video:family_friendly>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://www.carltravels.com/videos/wedding-film-2.html</loc>
+    <video:video>
+      <video:thumbnail_loc>https://img.youtube.com/vi/XYXxJ7t0YwE/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title>Wedding Film 2</video:title>
+      <video:description>Rustic barn textures, tearful speeches, and a choreographed first dance anchor this heartfelt countryside celebration.</video:description>
+      <video:player_loc allow_embed="yes">https://www.youtube.com/embed/XYXxJ7t0YwE</video:player_loc>
+      <video:content_loc>https://www.youtube.com/watch?v=XYXxJ7t0YwE</video:content_loc>
+      <video:publication_date>2025-09-17T23:04:40+07:00</video:publication_date>
+      <video:family_friendly>yes</video:family_friendly>
+    </video:video>
+  </url>
+  <url>
+    <loc>https://www.carltravels.com/videos/wedding-film-3.html</loc>
+    <video:video>
+      <video:thumbnail_loc>https://img.youtube.com/vi/NwT73rCVnMY/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title>Wedding Film 3</video:title>
+      <video:description>An intimate forest elopement with rain-kissed greenery, handwritten vows, and cozy cabin celebrations.</video:description>
+      <video:player_loc allow_embed="yes">https://www.youtube.com/embed/NwT73rCVnMY</video:player_loc>
+      <video:content_loc>https://www.youtube.com/watch?v=NwT73rCVnMY</video:content_loc>
+      <video:publication_date>2025-09-17T23:04:40+07:00</video:publication_date>
+      <video:family_friendly>yes</video:family_friendly>
+    </video:video>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- add a dedicated `sitemap-video.xml` that lists each watch page with Google video sitemap metadata
- reference the new video sitemap from `robots.txt` alongside the existing sitemap declaration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cadf2b11dc8323abd707dd67ebfca4