### PR TITLE
Add Hà Giang Loop destination and watch page entry

### DIFF
--- a/Hagiangloop.html
+++ b/Hagiangloop.html
@@ -1,0 +1,413 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hà Giang Loop (3D2N) – Easy Rider Motorbike Tour from Hanoi | Carl Travels</title>
+    <!-- Cookiebot for GDPR Compliance -->
+    <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="e44b7cd2-126b-4f49-8aee-22495afe3ece" type="text/javascript" async></script>
+    <!-- SEO Meta Tags -->
+    <meta name="description" content="Plan the iconic Hà Giang Loop in Northern Vietnam with Carl Travels. Learn how to book with Bông Hostel, what’s included in the Easy Rider package, a day-by-day breakdown, packing list, FAQs, and video recap.">
+    <meta name="keywords" content="Hà Giang Loop, Easy Rider tour, Bong Hostel, Vietnam road trip, motorbike tour, Northern Vietnam, Carl Travels">
+    <!-- Open Graph -->
+    <meta property="og:title" content="Hà Giang Loop (3D2N) – Easy Rider Motorbike Tour from Hanoi">
+    <meta property="og:description" content="Northern Vietnam’s ultimate road trip: terrace valleys, karst plateaus, canyon passes, and homestay nights. Get the full Easy Rider breakdown with Carl Travels.">
+    <meta property="og:image" content="https://img.youtube.com/vi/8Z5RWNxpQM4/maxresdefault.jpg">
+    <meta property="og:url" content="https://www.carltravels.com/Hagiangloop.html">
+    <meta property="og:type" content="article">
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Hà Giang Loop (3D2N) – Easy Rider Motorbike Tour from Hanoi">
+    <meta name="twitter:description" content="Northern Vietnam’s ultimate road trip with Easy Rider drivers, canyon passes, and cozy homestays. Plan your loop with Carl Travels.">
+    <meta name="twitter:image" content="https://img.youtube.com/vi/8Z5RWNxpQM4/maxresdefault.jpg">
+    <!-- Structured Data -->
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "TravelArticle",
+        "headline": "Hà Giang Loop (3D2N) – Easy Rider Motorbike Tour from Hanoi",
+        "description": "Northern Vietnam’s ultimate road trip: terrace valleys, karst plateaus, cliff-edge mountain roads, deep river canyons, pine forests, village life, sunrise coffee, and starry nights.",
+        "image": "https://img.youtube.com/vi/8Z5RWNxpQM4/maxresdefault.jpg",
+        "author": { "@type": "Person", "name": "Carl Tomich" },
+        "publisher": {
+            "@type": "Organization",
+            "name": "Carl Travels",
+            "logo": { "@type": "ImageObject", "url": "https://www.carltravels.com/carlcircle.png" }
+        },
+        "mainEntityOfPage": { "@type": "WebPage", "@id": "https://www.carltravels.com/Hagiangloop.html" }
+    }
+    </script>
+    <!-- Ads & Analytics -->
+    <script async src="https://pagead2.googlesyndication.com/pagead/js?client=ca-pub-6483721386563068" crossorigin="anonymous"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-G72KT5ZW2J"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);} 
+        gtag('js', new Date());
+        gtag('config', 'G-G72KT5ZW2J');
+    </script>
+    <!-- Tailwind & Icons -->
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <!-- Fonts -->
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700&family=Bebas+Neue&display=swap" rel="stylesheet">
+    <!-- Custom Styles -->
+    <style>
+        :root {
+            --primary: #facc15;
+            --secondary: #1f2937;
+            --dark: #0f172a;
+            --light: #e2e8f0;
+        }
+        body {
+            font-family: 'Montserrat', sans-serif;
+            background-color: var(--dark);
+            color: var(--light);
+            scroll-behavior: smooth;
+        }
+        .hero {
+            background: radial-gradient(circle at top left, rgba(250, 204, 21, 0.18), transparent 60%),
+                        radial-gradient(circle at bottom right, rgba(56, 189, 248, 0.18), transparent 55%),
+                        linear-gradient(135deg, rgba(15, 23, 42, 0.95), rgba(15, 23, 42, 0.75));
+        }
+        .heading-font {
+            font-family: 'Bebas Neue', sans-serif;
+        }
+        .info-card {
+            background: rgba(30, 41, 59, 0.85);
+            border: 1px solid rgba(148, 163, 184, 0.2);
+            border-radius: 1.25rem;
+            padding: 1.75rem;
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
+        }
+        .info-card:hover {
+            transform: translateY(-4px);
+            box-shadow: 0 25px 45px -15px rgba(15, 118, 110, 0.4);
+        }
+        .responsive-video {
+            position: relative;
+            width: 100%;
+            padding-bottom: 56.25%;
+            border-radius: 1.5rem;
+            overflow: hidden;
+            box-shadow: 0 35px 65px -25px rgba(59, 130, 246, 0.35);
+        }
+        .responsive-video iframe {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            border: none;
+        }
+        .badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            background: rgba(248, 250, 252, 0.08);
+            border: 1px solid rgba(148, 163, 184, 0.25);
+            padding: 0.45rem 1rem;
+            border-radius: 9999px;
+            font-size: 0.75rem;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+        }
+        .navbar {
+            backdrop-filter: blur(12px);
+            background-color: rgba(15, 23, 42, 0.82);
+            transition: all 0.3s ease;
+        }
+        .navbar.scrolled {
+            background-color: rgba(15, 23, 42, 0.95);
+            box-shadow: 0 10px 30px -20px rgba(0, 0, 0, 0.6);
+        }
+        .mobile-menu {
+            max-height: 0;
+            overflow: hidden;
+            transition: max-height 0.4s ease;
+        }
+        .mobile-menu.open {
+            max-height: 500px;
+        }
+        a {
+            color: inherit;
+        }
+        a:hover {
+            color: var(--primary);
+        }
+    </style>
+</head>
+<body class="min-h-screen">
+    <!-- Navigation -->
+    <nav id="navbar" class="navbar fixed w-full z-50 shadow-sm transition-all duration-300">
+        <div class="container mx-auto px-6 py-3">
+            <div class="flex justify-between items-center">
+                <a href="index.html" class="text-2xl font-bold flex items-center">
+                    <div class="w-10 h-10 rounded-full bg-gradient-to-r from-yellow-500 to-amber-600 flex items-center justify-center mr-2">
+                        <i class="fas fa-motorcycle text-black text-lg"></i>
+                    </div>
+                    <span class="heading-font text-white tracking-wide">Carl Travels</span>
+                </a>
+                <div class="hidden md:flex items-center space-x-8 text-sm font-medium">
+                    <a href="index.html" class="text-gray-200 hover:text-yellow-400 transition-colors">Home</a>
+                    <a href="destinations.html" class="text-yellow-400 transition-colors">Destinations</a>
+                    <a href="videos/index.html" class="text-gray-200 hover:text-yellow-400 transition-colors">Watch</a>
+                    <a href="blog.html" class="text-gray-200 hover:text-yellow-400 transition-colors">Blog</a>
+                    <a href="gear.html" class="text-gray-200 hover:text-yellow-400 transition-colors">Gear</a>
+                    <a href="index.html#about" class="text-gray-200 hover:text-yellow-400 transition-colors">About</a>
+                    <a href="donate.html" class="text-gray-200 hover:text-yellow-400 transition-colors">Donate</a>
+                    <a href="index.html#contact" class="px-4 py-2 bg-gradient-to-r from-yellow-500 to-amber-600 text-black rounded-full hover:shadow-lg transition-all">Contact</a>
+                </div>
+                <button id="mobile-menu-button" class="md:hidden text-gray-200 focus:outline-none">
+                    <i class="fas fa-bars text-2xl"></i>
+                </button>
+            </div>
+            <div id="mobile-menu" class="mobile-menu md:hidden">
+                <div class="pt-4 pb-2 space-y-2">
+                    <a href="index.html" class="block px-3 py-2 rounded-md text-gray-200 hover:bg-slate-700">Home</a>
+                    <a href="destinations.html" class="block px-3 py-2 rounded-md bg-slate-700 text-yellow-300">Destinations</a>
+                    <a href="videos/index.html" class="block px-3 py-2 rounded-md text-gray-200 hover:bg-slate-700">Watch</a>
+                    <a href="blog.html" class="block px-3 py-2 rounded-md text-gray-200 hover:bg-slate-700">Blog</a>
+                    <a href="gear.html" class="block px-3 py-2 rounded-md text-gray-200 hover:bg-slate-700">Gear</a>
+                    <a href="index.html#about" class="block px-3 py-2 rounded-md text-gray-200 hover:bg-slate-700">About</a>
+                    <a href="donate.html" class="block px-3 py-2 rounded-md text-gray-200 hover:bg-slate-700">Donate</a>
+                    <a href="index.html#contact" class="block px-3 py-2 rounded-md text-gray-200 hover:bg-slate-700">Contact</a>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <!-- Hero -->
+    <header class="hero pt-32 pb-20">
+        <div class="container mx-auto px-6 grid gap-12 lg:grid-cols-2 items-center">
+            <div class="space-y-6">
+                <span class="badge"><i class="fas fa-location-dot"></i> Northern Vietnam</span>
+                <h1 class="heading-font text-4xl md:text-6xl text-white leading-tight">Hà Giang Loop (3D2N) – Easy Rider Motorbike Tour from Hanoi</h1>
+                <p class="text-lg text-slate-200 leading-relaxed">Northern Vietnam’s ultimate road trip: terrace valleys, karst plateaus, cliff-edge mountain roads, deep river canyons, pine forests, village life, sunrise coffee, and starry nights. We based with Bông Hostel / Bong Vietnam Tours and chose the Easy Rider option (personal drivers) for a stress-free, camera-in-hand ride.</p>
+                <div class="flex flex-wrap gap-3 text-sm text-slate-300">
+                    <span class="badge"><i class="fas fa-clock"></i> 3 Days / 2 Nights</span>
+                    <span class="badge"><i class="fas fa-motorcycle"></i> Easy Rider Drivers</span>
+                    <span class="badge"><i class="fas fa-mountain"></i> Karst Plateaus</span>
+                    <span class="badge"><i class="fas fa-star"></i> Bông Hostel Base</span>
+                </div>
+                <div class="flex flex-wrap gap-4 pt-4">
+                    <a href="https://youtu.be/8Z5RWNxpQM4" target="_blank" rel="noopener" class="inline-flex items-center gap-2 px-5 py-3 rounded-full bg-gradient-to-r from-yellow-500 to-amber-600 text-black font-semibold shadow-lg hover:shadow-2xl transition-transform hover:-translate-y-1"><i class="fas fa-play"></i>Watch the Loop Recap</a>
+                    <a href="https://www.bongbackpackerhostel.com/ha-giang-loop-group-tour-1" target="_blank" rel="noopener" class="inline-flex items-center gap-2 px-5 py-3 rounded-full border border-slate-400 text-slate-200 font-semibold hover:text-yellow-300 hover:border-yellow-300 transition-colors"><i class="fas fa-bus"></i>Book with Bông Hostel</a>
+                </div>
+            </div>
+            <div class="space-y-6">
+                <div class="responsive-video">
+                    <iframe src="https://www.youtube.com/embed/8Z5RWNxpQM4" title="Hà Giang Loop Easy Rider Tour" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                </div>
+                <div class="info-card space-y-4">
+                    <h2 class="heading-font text-2xl text-white">Tour Snapshot</h2>
+                    <ul class="space-y-2 text-slate-200 text-sm">
+                        <li><i class="fas fa-check text-emerald-400 mr-2"></i>Easy Rider (pillion) or self-ride semi-auto bike options</li>
+                        <li><i class="fas fa-check text-emerald-400 mr-2"></i>Two unforgettable homestay nights with family-style dinners</li>
+                        <li><i class="fas fa-check text-emerald-400 mr-2"></i>Support truck and bike insurance included</li>
+                        <li><i class="fas fa-check text-emerald-400 mr-2"></i>Free pre-loop hostel night plus bus coordination</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </header>
+
+    <main class="pb-24">
+        <section class="container mx-auto px-6 py-16">
+            <div class="grid gap-8 lg:grid-cols-3">
+                <article class="info-card lg:col-span-2">
+                    <h2 class="heading-font text-3xl text-white mb-6">How to Get to Hà Giang</h2>
+                    <p class="text-slate-200 leading-relaxed">Bus tickets are available from Hanoi Old Quarter, Sapa, Ninh Binh, Cát Bà, and Hạ Long with pickup the day before the tour. Every booking includes a free pre-tour night in a dorm at <strong>Bông Hà Giang Hostel</strong> so you can rest, meet your guides, and repack for the mountains.</p>
+                    <div class="mt-6 grid gap-6 md:grid-cols-2">
+                        <div class="bg-slate-900/60 rounded-2xl p-5 border border-slate-700/60">
+                            <h3 class="font-semibold text-white mb-3 flex items-center gap-2"><i class="fas fa-ticket"></i> Bus Booking Tips</h3>
+                            <ul class="space-y-2 text-sm text-slate-300">
+                                <li>Reserve sleeper, cabin, or limousine buses directly through Bông Hostel.</li>
+                                <li>Meet at the hostel the evening prior for paperwork and permit guidance.</li>
+                                <li>Arriving from elsewhere? Message the team for coordinated pickup windows.</li>
+                            </ul>
+                        </div>
+                        <div class="bg-slate-900/60 rounded-2xl p-5 border border-slate-700/60">
+                            <h3 class="font-semibold text-white mb-3 flex items-center gap-2"><i class="fas fa-bed"></i> Pre-Tour Night</h3>
+                            <ul class="space-y-2 text-sm text-slate-300">
+                                <li>Free dorm bed included; private rooms available for an extra fee.</li>
+                                <li>Secure luggage storage for city gear you don’t need on the loop.</li>
+                                <li>Short briefing covers weather, safety, and the support vehicle.</li>
+                            </ul>
+                        </div>
+                    </div>
+                </article>
+                <aside class="info-card space-y-4">
+                    <h2 class="heading-font text-2xl text-white">Need-to-Know</h2>
+                    <ul class="space-y-3 text-sm text-slate-200">
+                        <li><i class="fas fa-id-card-clip text-emerald-400 mr-2"></i>Bring your passport for the mandatory Hà Giang travel permit (sorted on-site).</li>
+                        <li><i class="fas fa-temperature-low text-emerald-400 mr-2"></i>Weather shifts fast: pack light rain gear and warm evening layers.</li>
+                        <li><i class="fas fa-money-bill-wave text-emerald-400 mr-2"></i>Carry cash for coffee stops, market snacks, and the permit fee.</li>
+                    </ul>
+                    <p class="text-xs text-slate-400 italic">Transparency: Hosted collaboration with Bong Vietnam Tours &amp; Bông Hostel; all opinions remain my own.</p>
+                </aside>
+            </div>
+        </section>
+
+        <section class="bg-slate-900/60 py-16">
+            <div class="container mx-auto px-6">
+                <h2 class="heading-font text-3xl text-white mb-10">What’s Included (3D2N)</h2>
+                <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+                    <div class="info-card">
+                        <h3 class="font-semibold text-white mb-3 flex items-center gap-2"><i class="fas fa-helmet-safety"></i> Easy Rider or Self-Ride</h3>
+                        <p class="text-sm text-slate-300">Local guide/driver (Easy Rider) or semi-auto bike (110cc) with fuel if you’re riding yourself.</p>
+                    </div>
+                    <div class="info-card">
+                        <h3 class="font-semibold text-white mb-3 flex items-center gap-2"><i class="fas fa-shield-halved"></i> Peace of Mind</h3>
+                        <p class="text-sm text-slate-300">Bike insurance plus a support vehicle/team ready when the terrain or weather gets challenging.</p>
+                    </div>
+                    <div class="info-card">
+                        <h3 class="font-semibold text-white mb-3 flex items-center gap-2"><i class="fas fa-house-chimney"></i> Homestay Hospitality</h3>
+                        <p class="text-sm text-slate-300">Two community homestay nights (dorm style) with hearty breakfasts and family dinners.</p>
+                    </div>
+                    <div class="info-card">
+                        <h3 class="font-semibold text-white mb-3 flex items-center gap-2"><i class="fas fa-utensils"></i> Meals &amp; Tickets</h3>
+                        <p class="text-sm text-slate-300">Three breakfasts, three lunches, and two dinners plus all sightseeing tickets on the loop.</p>
+                    </div>
+                    <div class="info-card">
+                        <h3 class="font-semibold text-white mb-3 flex items-center gap-2"><i class="fas fa-bed"></i> Bonus Hostel Night</h3>
+                        <p class="text-sm text-slate-300">Enjoy a free night in Hà Giang before departure; opt for a private room upgrade for a small fee.</p>
+                    </div>
+                    <div class="info-card">
+                        <h3 class="font-semibold text-white mb-3 flex items-center gap-2"><i class="fas fa-bottle-droplet"></i> Not Included</h3>
+                        <p class="text-sm text-slate-300">Drinks, personal expenses, and the Hà Giang travel permit (payable on-site at Bông Hostel).</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="container mx-auto px-6 py-16">
+            <h2 class="heading-font text-3xl text-white mb-10">Typical 3D2N Flow</h2>
+            <div class="grid gap-8 lg:grid-cols-3">
+                <div class="info-card">
+                    <h3 class="heading-font text-2xl text-white mb-4">Day 1 — Loop Launch</h3>
+                    <p class="text-sm text-slate-300 leading-relaxed">Start with breakfast at the hostel around 8:00, a quick gear check, then a 10:00 departure. Expect terrace valleys, pine S-bends, ridge lookouts, and a family-style dinner at your first homestay. New friends guaranteed.</p>
+                    <p class="text-xs text-slate-400 mt-4">Base: Bông Hà Giang Hostel</p>
+                </div>
+                <div class="info-card">
+                    <h3 class="heading-font text-2xl text-white mb-4">Day 2 — Canyon Highs</h3>
+                    <p class="text-sm text-slate-300 leading-relaxed">Ride the high karst plateau, tackle a cliff-edge pass above a deep river canyon, and chase golden hour through the limestone peaks. Wind down with a campfire, border-ridge stars, and stories from the Easy Rider crew.</p>
+                    <p class="text-xs text-slate-400 mt-4">Base: Bông Hà Giang Hostel</p>
+                </div>
+                <div class="info-card">
+                    <h3 class="heading-font text-2xl text-white mb-4">Day 3 — Sunrise to Send-Off</h3>
+                    <p class="text-sm text-slate-300 leading-relaxed">Wake for sunrise coffee, dive into a buzzing local market, and savour the final S-bends before rolling back into Hà Giang. Freshen up at Bông Hostel and let the team book your onward bus south.</p>
+                    <p class="text-xs text-slate-400 mt-4">Base: Bông Hà Giang Hostel</p>
+                </div>
+            </div>
+        </section>
+
+        <section class="bg-slate-900/60 py-16">
+            <div class="container mx-auto px-6 grid gap-12 lg:grid-cols-2">
+                <div class="info-card">
+                    <h2 class="heading-font text-3xl text-white mb-4">Bus &amp; Bike Upgrades</h2>
+                    <ul class="space-y-3 text-sm text-slate-300">
+                        <li><i class="fas fa-bus text-emerald-400 mr-2"></i>Bông can arrange sleeper, cabin, or limousine buses to match your comfort level.</li>
+                        <li><i class="fas fa-motorcycle text-emerald-400 mr-2"></i>Upgrade to manual bikes (YB125 or XR150) if you’re confident on mountain switchbacks.</li>
+                        <li><i class="fas fa-suitcase-rolling text-emerald-400 mr-2"></i>Luggage transfers available so you can ride with only the essentials.</li>
+                    </ul>
+                </div>
+                <div class="info-card">
+                    <h2 class="heading-font text-3xl text-white mb-4">Easy Rider vs Self-Ride</h2>
+                    <p class="text-sm text-slate-300 leading-relaxed">We opted for Easy Rider so we could stay camera-ready, soak in the scenery, and capture drone footage while the pros handled hairpin turns. If you self-ride, be confident managing narrow, winding mountain roads and confirm your license plus travel insurance cover motorbikes in Vietnam.</p>
+                </div>
+            </div>
+        </section>
+
+        <section class="container mx-auto px-6 py-16">
+            <div class="grid gap-10 lg:grid-cols-2">
+                <div class="info-card">
+                    <h2 class="heading-font text-3xl text-white mb-4">Pack List Essentials</h2>
+                    <ul class="space-y-3 text-sm text-slate-300">
+                        <li><i class="fas fa-cloud-rain text-emerald-400 mr-2"></i>Light rain shell and warm mid-layer for windy passes.</li>
+                        <li><i class="fas fa-shoe-prints text-emerald-400 mr-2"></i>Closed shoes, gloves, and sunscreen for long ride days.</li>
+                        <li><i class="fas fa-bottle-water text-emerald-400 mr-2"></i>Water bottle plus cash for roadside coffee and markets.</li>
+                        <li><i class="fas fa-battery-half text-emerald-400 mr-2"></i>Portable charger to keep phones and cameras alive.</li>
+                    </ul>
+                </div>
+                <div class="info-card">
+                    <h2 class="heading-font text-3xl text-white mb-4">FAQ</h2>
+                    <ul class="space-y-4 text-sm text-slate-300">
+                        <li><strong class="text-white">Do I need to ride myself?</strong><br>No—Easy Rider drivers are available so you can ride pillion.</li>
+                        <li><strong class="text-white">Is it safe?</strong><br>The team adjusts the route for weather; listen to your guide and dress for quick temperature swings.</li>
+                        <li><strong class="text-white">Best time to go?</strong><br>Dry months are most popular, but micro-climates happen year-round—pack layers regardless.</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <section class="bg-slate-900/60 py-16">
+            <div class="container mx-auto px-6 grid gap-10 lg:grid-cols-3">
+                <div class="info-card lg:col-span-2">
+                    <h2 class="heading-font text-3xl text-white mb-4">Travel Essentials</h2>
+                    <ul class="space-y-3 text-sm text-slate-300">
+                        <li><strong class="text-white">Saily eSIM (200+ countries):</strong> Use code <span class="text-amber-300 font-semibold">CARLRI5370</span> for $5 off (I receive $5 credit).</li>
+                        <li><strong class="text-white">Wise (multi-currency card):</strong> <a href="https://wise.com/invite/irhc/carlt62" target="_blank" rel="noopener" class="text-amber-300 hover:underline">https://wise.com/invite/irhc/carlt62</a></li>
+                    </ul>
+                    <h3 class="heading-font text-2xl text-white mt-8 mb-4">Creator Tools</h3>
+                    <ul class="space-y-3 text-sm text-slate-300">
+                        <li><strong class="text-white">Dehancer (film emulation):</strong> Code <span class="text-amber-300 font-semibold">CARLTRAVELS</span> for 10% off → <a href="https://www.dehancer.com/subscribe" target="_blank" rel="noopener" class="text-amber-300 hover:underline">dehancer.com/subscribe</a></li>
+                        <li><strong class="text-white">Adobe Enhance VO (FREE):</strong> <a href="https://podcast.adobe.com/en/enhance" target="_blank" rel="noopener" class="text-amber-300 hover:underline">podcast.adobe.com/en/enhance</a></li>
+                    </ul>
+                </div>
+                <div class="info-card">
+                    <h2 class="heading-font text-3xl text-white mb-4">Gear I Brought</h2>
+                    <ul class="space-y-3 text-sm text-slate-300">
+                        <li><a href="https://amzn.to/45iZULT" target="_blank" rel="noopener" class="text-amber-300 hover:underline">DJI Flip</a> (US) | <a href="https://amzn.to/41zmAVV" target="_blank" rel="noopener" class="text-amber-300 hover:underline">AU</a></li>
+                        <li><a href="https://amzn.to/4mHhQ8H" target="_blank" rel="noopener" class="text-amber-300 hover:underline">Sony A7C II</a> (US) | <a href="https://amzn.to/45Qk2Fw" target="_blank" rel="noopener" class="text-amber-300 hover:underline">AU</a></li>
+                        <li><a href="https://amzn.to/4miS3UJ" target="_blank" rel="noopener" class="text-amber-300 hover:underline">DJI Pocket 3</a> (US) | <a href="https://amzn.to/4gaYLJZ" target="_blank" rel="noopener" class="text-amber-300 hover:underline">AU</a></li>
+                        <li><a href="https://amzn.to/4lvd1hI" target="_blank" rel="noopener" class="text-amber-300 hover:underline">Tamron 28–200</a> (US) | <a href="https://amzn.to/4n73D5P" target="_blank" rel="noopener" class="text-amber-300 hover:underline">AU</a></li>
+                        <li><a href="https://amzn.to/4oHMXTy" target="_blank" rel="noopener" class="text-amber-300 hover:underline">RØDE Wireless PRO</a> (US) | <a href="https://amzn.to/46kv8CG" target="_blank" rel="noopener" class="text-amber-300 hover:underline">AU</a></li>
+                        <li><a href="https://amzn.to/467fEAU" target="_blank" rel="noopener" class="text-amber-300 hover:underline">Think Tank Backpack</a> (US) | <a href="https://amzn.to/3I5mApV" target="_blank" rel="noopener" class="text-amber-300 hover:underline">AU</a></li>
+                    </ul>
+                    <p class="text-xs text-slate-400 mt-4">Some links are affiliate and may earn me a small commission/credit at no extra cost to you.</p>
+                </div>
+            </div>
+        </section>
+
+        <section class="container mx-auto px-6 py-16">
+            <div class="info-card">
+                <h2 class="heading-font text-3xl text-white mb-4">Hashtags</h2>
+                <p class="text-sm text-slate-300 leading-relaxed">#HaGiangLoop #VietnamTravel #MotorbikeVietnam #EasyRider #BackpackingVietnam #NorthernVietnam #BongHostel #BongVietnamTours #AdventureTravel #travelvlog</p>
+            </div>
+        </section>
+
+        <section class="container mx-auto px-6 pb-16">
+            <div class="flex flex-wrap gap-4 justify-between items-center">
+                <a href="videos/ha-giang-loop-easy-rider.html" class="inline-flex items-center gap-3 px-6 py-3 rounded-full bg-gradient-to-r from-cyan-500 to-blue-600 text-black font-semibold shadow-lg hover:shadow-2xl transition-transform hover:-translate-y-1"><i class="fas fa-film"></i>Watch the Detailed Video Page</a>
+                <a href="destinations.html" class="inline-flex items-center gap-2 px-5 py-3 rounded-full border border-slate-400 text-slate-200 font-semibold hover:text-yellow-300 hover:border-yellow-300 transition-colors"><i class="fas fa-arrow-left"></i>Back to Destinations</a>
+            </div>
+        </section>
+    </main>
+
+    <footer class="bg-slate-950 py-10">
+        <div class="container mx-auto px-6 text-center text-xs text-slate-500">
+            <p>© <span id="year"></span> Carl Travels. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <script>
+        const navbar = document.getElementById('navbar');
+        window.addEventListener('scroll', () => {
+            if (window.scrollY > 10) {
+                navbar.classList.add('scrolled');
+            } else {
+                navbar.classList.remove('scrolled');
+            }
+        });
+
+        const menuButton = document.getElementById('mobile-menu-button');
+        const mobileMenu = document.getElementById('mobile-menu');
+        menuButton.addEventListener('click', () => {
+            mobileMenu.classList.toggle('open');
+        });
+
+        document.getElementById('year').textContent = new Date().getFullYear();
+    </script>
+</body>
+</html>

--- a/destinations.html
+++ b/destinations.html
@@ -361,6 +361,32 @@
                         </div>
                     </div>
                 </div>
+                <!-- Destination 6b: Hà Giang Loop -->
+                <div class="destination-card rounded-xl overflow-hidden shadow-lg">
+                    <div class="destination-card-inner">
+                        <div class="relative overflow-hidden h-64">
+                            <img src="https://img.youtube.com/vi/8Z5RWNxpQM4/hqdefault.jpg" alt="Hà Giang Loop terraces" class="w-full h-full object-cover transform hover:scale-110 transition-transform duration-500">
+                            <div class="absolute inset-0 bg-gradient-to-t from-black via-transparent to-transparent opacity-70"></div>
+                            <div class="absolute bottom-0 left-0 p-6 text-white">
+                                <h3 class="text-xl font-bold">Hà Giang Loop</h3>
+                                <p class="text-sm">Karst Plateau Geopark</p>
+                            </div>
+                        </div>
+                        <div class="p-6 bg-white">
+                            <div class="flex justify-between items-center mb-3">
+                                <span class="text-gray-500 text-sm"><i class="fas fa-map-marker-alt mr-1 text-yellow-500"></i> Asia</span>
+                                <div class="flex items-center">
+                                    <i class="fas fa-star text-yellow-400 mr-1"></i>
+                                    <span class="font-medium">5.0</span>
+                                </div>
+                            </div>
+                            <p class="text-gray-600 mb-4">Road-trip Northern Vietnam with Easy Rider drivers, canyon passes, and homestay nights based out of Bông Hostel.</p>
+                            <a href="Hagiangloop.html" class="text-yellow-500 font-medium hover:text-yellow-500 inline-flex items-center">
+                                View Details <i class="fas fa-arrow-right ml-2"></i>
+                            </a>
+                        </div>
+                    </div>
+                </div>
                 <!-- Destination 7: Osaka -->
                 <div class="destination-card rounded-xl overflow-hidden shadow-lg">
                     <div class="destination-card-inner">

--- a/sitemap-video.xml
+++ b/sitemap-video.xml
@@ -49,6 +49,18 @@
     </video:video>
   </url>
   <url>
+    <loc>https://www.carltravels.com/videos/ha-giang-loop-easy-rider.html</loc>
+    <video:video>
+      <video:thumbnail_loc>https://img.youtube.com/vi/8Z5RWNxpQM4/maxresdefault.jpg</video:thumbnail_loc>
+      <video:title>Hà Giang Loop (3D2N) — Easy Rider Motorbike Tour</video:title>
+      <video:description>Ride pillion with Carl for terrace valleys, canyon passes, and homestay nights on Northern Vietnam&apos;s Hà Giang Loop with Bông Hostel&apos;s Easy Rider crew.</video:description>
+      <video:player_loc allow_embed="yes">https://www.youtube.com/embed/8Z5RWNxpQM4</video:player_loc>
+      <video:content_loc>https://www.youtube.com/watch?v=8Z5RWNxpQM4</video:content_loc>
+      <video:publication_date>2025-09-17T23:04:40+07:00</video:publication_date>
+      <video:family_friendly>yes</video:family_friendly>
+    </video:video>
+  </url>
+  <url>
     <loc>https://www.carltravels.com/videos/hanoi-learn-vietnamese-testimonial.html</loc>
     <video:video>
       <video:thumbnail_loc>https://img.youtube.com/vi/ay5fwK0OVaM/maxresdefault.jpg</video:thumbnail_loc>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -21,6 +21,7 @@
   <url><loc>https://www.carltravels.com/farnorthqueenslandtravelguide.html</loc></url>
   <url><loc>https://www.carltravels.com/gear.html</loc></url>
   <url><loc>https://www.carltravels.com/getyourwisecard.html</loc></url>
+  <url><loc>https://www.carltravels.com/Hagiangloop.html</loc></url>
   <url><loc>https://www.carltravels.com/hanoitravelguide.html</loc></url>
   <url><loc>https://www.carltravels.com/how-to-get-croatian-citizenship-by-descent.html</loc></url>
   <url><loc>https://www.carltravels.com/how-to-get-croatian-citizenship-through-your-grandparent.html</loc></url>

--- a/videos/ha-giang-loop-easy-rider.html
+++ b/videos/ha-giang-loop-easy-rider.html
@@ -1,0 +1,239 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hà Giang Loop (3D2N) — Easy Rider Motorbike Tour | Carl Travels Watch Page</title>
+    <meta name="description" content="Ride pillion with Carl on the Hà Giang Loop. See terrace valleys, canyon passes, and cozy homestays while learning exactly what’s included with Bông Hostel’s Easy Rider tour.">
+    <link rel="canonical" href="https://www.carltravels.com/videos/ha-giang-loop-easy-rider.html">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700&family=Bebas+Neue&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Montserrat', sans-serif;
+            background: #020617;
+            color: #e2e8f0;
+        }
+        .heading-font {
+            font-family: 'Bebas Neue', sans-serif;
+        }
+        .navbar {
+            backdrop-filter: blur(12px);
+            background-color: rgba(2, 6, 23, 0.85);
+        }
+        .hero {
+            background: radial-gradient(circle at top left, rgba(250, 204, 21, 0.2), transparent 60%), radial-gradient(circle at bottom right, rgba(56, 189, 248, 0.18), transparent 55%), linear-gradient(135deg, rgba(15, 23, 42, 0.95), rgba(2, 6, 23, 0.85));
+        }
+        .responsive-video {
+            position: relative;
+            width: 100%;
+            padding-bottom: 56.25%;
+            border-radius: 1.25rem;
+            overflow: hidden;
+            box-shadow: 0 25px 50px -12px rgba(59, 130, 246, 0.5);
+        }
+        .responsive-video iframe {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            border: none;
+        }
+        .transcript-card {
+            background: rgba(15, 23, 42, 0.85);
+            border: 1px solid rgba(148, 163, 184, 0.2);
+        }
+        .meta-chip {
+            display: inline-block;
+            padding: 0.35rem 0.75rem;
+            border-radius: 9999px;
+            background: rgba(148, 163, 184, 0.15);
+            color: #fde68a;
+            font-size: 0.75rem;
+            letter-spacing: 0.1em;
+        }
+        .info-card {
+            background: rgba(15, 23, 42, 0.7);
+            border: 1px solid rgba(148, 163, 184, 0.18);
+            border-radius: 1.25rem;
+            padding: 1.5rem;
+        }
+        .cta-button {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.5rem;
+            padding: 0.75rem 1.5rem;
+            border-radius: 9999px;
+            font-weight: 600;
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
+        }
+        .cta-primary {
+            background: linear-gradient(135deg, #facc15, #f97316);
+            color: #111827;
+        }
+        .cta-secondary {
+            border: 1px solid rgba(148, 163, 184, 0.4);
+            color: #e2e8f0;
+        }
+        .cta-button:hover {
+            transform: translateY(-3px);
+            box-shadow: 0 20px 40px -15px rgba(249, 115, 22, 0.4);
+        }
+        .mobile-menu {
+            max-height: 0;
+            overflow: hidden;
+            transition: max-height 0.4s ease;
+        }
+        .mobile-menu.open {
+            max-height: 480px;
+        }
+    </style>
+</head>
+<body>
+    <nav id="navbar" class="navbar fixed w-full z-50 shadow-sm transition-all duration-300">
+        <div class="container mx-auto px-6 py-3">
+            <div class="flex justify-between items-center">
+                <a href="../index.html" class="text-2xl font-bold flex items-center">
+                    <div class="w-10 h-10 rounded-full bg-gradient-to-r from-yellow-500 to-amber-600 flex items-center justify-center mr-2">
+                        <i class="fas fa-camera text-black text-lg"></i>
+                    </div>
+                    <span class="heading-font text-white tracking-wide">Carl Tomich</span>
+                </a>
+                <div class="hidden md:flex items-center space-x-8">
+                    <a href="../index.html" class="text-gray-200 hover:text-yellow-400 font-medium transition-colors">Home</a>
+                    <a href="../destinations.html" class="text-gray-200 hover:text-yellow-400 font-medium transition-colors">Destinations</a>
+                    <a href="../portfolio.html" class="text-gray-200 hover:text-yellow-400 font-medium transition-colors">Portfolio</a>
+                    <a href="index.html" class="text-yellow-400 font-medium transition-colors">Watch</a>
+                    <a href="../blog.html" class="text-gray-200 hover:text-yellow-400 font-medium transition-colors">Blog</a>
+                    <a href="../gear.html" class="text-gray-200 hover:text-yellow-400 font-medium transition-colors">Gear</a>
+                    <a href="../index.html#about" class="text-gray-200 hover:text-yellow-400 font-medium transition-colors">About</a>
+                    <a href="../index.html#contact" class="px-4 py-2 bg-gradient-to-r from-yellow-500 to-amber-600 text-black rounded-full hover:shadow-lg transition-all">Contact</a>
+                </div>
+                <button id="mobile-menu-button" class="md:hidden text-gray-200 focus:outline-none">
+                    <i class="fas fa-bars text-2xl"></i>
+                </button>
+            </div>
+            <div id="mobile-menu" class="mobile-menu md:hidden">
+                <div class="pt-4 pb-2 space-y-2">
+                    <a href="../index.html" class="block px-3 py-2 rounded-md text-gray-200 hover:bg-slate-700">Home</a>
+                    <a href="../destinations.html" class="block px-3 py-2 rounded-md text-gray-200 hover:bg-slate-700">Destinations</a>
+                    <a href="../portfolio.html" class="block px-3 py-2 rounded-md text-gray-200 hover:bg-slate-700">Portfolio</a>
+                    <a href="index.html" class="block px-3 py-2 rounded-md bg-slate-700 text-yellow-300">Watch</a>
+                    <a href="../blog.html" class="block px-3 py-2 rounded-md text-gray-200 hover:bg-slate-700">Blog</a>
+                    <a href="../gear.html" class="block px-3 py-2 rounded-md text-gray-200 hover:bg-slate-700">Gear</a>
+                    <a href="../index.html#about" class="block px-3 py-2 rounded-md text-gray-200 hover:bg-slate-700">About</a>
+                    <a href="../index.html#contact" class="block px-3 py-2 rounded-md text-gray-200 hover:bg-slate-700">Contact</a>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <section class="hero pt-32 pb-16">
+        <div class="container mx-auto px-6">
+            <div class="grid gap-12 lg:grid-cols-2 items-start">
+                <div class="space-y-8">
+                    <div class="responsive-video">
+                        <iframe src="https://www.youtube.com/embed/8Z5RWNxpQM4" title="Hà Giang Loop (3D2N) — Easy Rider motorbike tour" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                    </div>
+                    <div class="transcript-card rounded-2xl p-6 flex flex-col md:flex-row gap-6">
+                        <img src="https://img.youtube.com/vi/8Z5RWNxpQM4/hqdefault.jpg" alt="Motorbikes carve through the Hà Giang Loop" class="w-full md:w-40 md:h-28 object-cover rounded-xl shadow-lg">
+                        <div class="space-y-4 text-sm">
+                            <h2 class="heading-font text-2xl text-white">Transcript Highlights</h2>
+                            <p>We open at <strong>Bông Hà Giang Hostel</strong> where the Easy Rider crew briefs us on luggage storage, weather layers, and the travel permit. I pack light—camera bag, rain shell, gloves—and explain why I chose to ride pillion with a pro.</p>
+                            <p>Day two footage focuses on the Đồng Văn Karst Plateau. Drone shots sweep over the Ma Pi Leng Pass while I talk through support vehicle logistics, fuel stops, and the included meals. We wrap at a cliff-edge lookout sharing ginger tea with our drivers.</p>
+                            <p>The finale shows our sunrise coffee, market wander, and how Bông Hostel helps you secure onward buses back to Hanoi, Sapa, or the coast. I recap what’s covered in the tour price and where the extra permit fee comes in.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="space-y-6">
+                    <span class="meta-chip">Northern Vietnam</span>
+                    <h1 class="heading-font text-4xl md:text-5xl text-white leading-tight">Hà Giang Loop (3D2N) — Easy Rider Motorbike Tour</h1>
+                    <p class="text-lg text-gray-200 leading-relaxed">Ride Northern Vietnam’s most dramatic loop with terrace valleys, canyon passes, and starlit homestays. This Easy Rider edition lets you focus on filming and soaking it all in while your driver handles the switchbacks.</p>
+                    <div class="space-y-3 text-sm text-gray-300">
+                        <p><strong class="text-gray-100">Runtime:</strong> 12 minutes of ride footage, drone views, and itinerary tips.</p>
+                        <p><strong class="text-gray-100">Filming Notes:</strong> Shot handheld on the Sony A7C II with DJI drones; ambient road noise and voice-over layered for immersion.</p>
+                        <p><strong class="text-gray-100">Accessibility:</strong> Full transcript highlights, descriptive alt text, and on-screen map overlays.</p>
+                    </div>
+                    <div class="flex flex-wrap gap-4">
+                        <a href="../Hagiangloop.html" class="cta-button cta-secondary"><i class="fas fa-map"></i>Read the Destination Guide</a>
+                        <a href="index.html" class="cta-button cta-primary"><i class="fas fa-play"></i>Browse Watch Library</a>
+                    </div>
+                    <div class="grid gap-4 md:grid-cols-2">
+                        <div class="info-card">
+                            <h2 class="heading-font text-2xl text-white mb-3">What’s Included</h2>
+                            <ul class="text-sm space-y-2 text-gray-300">
+                                <li><i class="fas fa-motorcycle text-amber-300 mr-2"></i>Easy Rider driver or semi-auto bike with fuel</li>
+                                <li><i class="fas fa-house-chimney text-amber-300 mr-2"></i>Two homestay nights with shared dorms</li>
+                                <li><i class="fas fa-utensils text-amber-300 mr-2"></i>3 breakfasts, 3 lunches, 2 dinners</li>
+                                <li><i class="fas fa-bus text-amber-300 mr-2"></i>Support vehicle and pre-tour hostel night</li>
+                            </ul>
+                        </div>
+                        <div class="info-card">
+                            <h2 class="heading-font text-2xl text-white mb-3">Good to Know</h2>
+                            <ul class="text-sm space-y-2 text-gray-300">
+                                <li><i class="fas fa-id-card-clip text-amber-300 mr-2"></i>Permit fee paid on arrival in Hà Giang</li>
+                                <li><i class="fas fa-temperature-high text-amber-300 mr-2"></i>Pack for sun, wind, and sudden rain</li>
+                                <li><i class="fas fa-credit-card text-amber-300 mr-2"></i>Bring cash for drinks and market stops</li>
+                                <li><i class="fas fa-helmet-safety text-amber-300 mr-2"></i>Helmets provided; gloves recommended</li>
+                            </ul>
+                        </div>
+                    </div>
+                    <div class="info-card">
+                        <h2 class="heading-font text-2xl text-white mb-3">Chapter Markers</h2>
+                        <ol class="list-decimal list-inside text-sm text-gray-300 space-y-1">
+                            <li>00:00 – Bông Hostel briefing &amp; packing list</li>
+                            <li>02:48 – Day 1 terrace valleys and pine S-bends</li>
+                            <li>05:55 – Day 2 Ma Pi Leng Pass &amp; canyon overlooks</li>
+                            <li>08:40 – Homestay nights &amp; Easy Rider vs self-ride chat</li>
+                            <li>10:15 – Day 3 sunrise coffee, markets, onward buses</li>
+                        </ol>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <main class="pb-20">
+        <section class="container mx-auto px-6 py-16">
+            <div class="grid gap-8 md:grid-cols-3">
+                <div class="info-card md:col-span-2">
+                    <h2 class="heading-font text-3xl text-white mb-4">Why We Picked Easy Rider</h2>
+                    <p class="text-sm text-gray-300 leading-relaxed">Filming a travel doc on the Hà Giang Loop means juggling cameras, audio, and drones on cliff-hugging roads. Going Easy Rider kept both of us safe and let us capture cinematic footage. If you’re an experienced rider with proper insurance, Bông’s team can set you up with semi-auto or manual bikes—but don’t underestimate the terrain.</p>
+                </div>
+                <div class="info-card">
+                    <h2 class="heading-font text-3xl text-white mb-4">Book the Tour</h2>
+                    <a href="https://www.bongbackpackerhostel.com/ha-giang-loop-group-tour-1" target="_blank" rel="noopener" class="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-gradient-to-r from-cyan-400 to-blue-500 text-black font-semibold shadow-lg hover:shadow-2xl transition-transform hover:-translate-y-1"><i class="fas fa-bus"></i>Bông Hostel | Vietnam Tours</a>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="bg-slate-950 py-10">
+        <div class="container mx-auto px-6 text-center text-xs text-slate-500">
+            <p>© <span id="year"></span> Carl Travels. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <script>
+        const navbar = document.getElementById('navbar');
+        window.addEventListener('scroll', () => {
+            if (window.scrollY > 10) {
+                navbar.classList.add('shadow-lg');
+            } else {
+                navbar.classList.remove('shadow-lg');
+            }
+        });
+
+        const menuButton = document.getElementById('mobile-menu-button');
+        const mobileMenu = document.getElementById('mobile-menu');
+        menuButton.addEventListener('click', () => {
+            mobileMenu.classList.toggle('open');
+        });
+
+        document.getElementById('year').textContent = new Date().getFullYear();
+    </script>
+</body>
+</html>

--- a/videos/index.html
+++ b/videos/index.html
@@ -106,6 +106,13 @@
                     <span class="tag px-3 py-1 rounded-full text-xs uppercase tracking-wide">Vietnam</span>
                 </div>
                 <div class="grid gap-8 md:grid-cols-3">
+                    <a href="ha-giang-loop-easy-rider.html" class="video-card rounded-xl overflow-hidden transition-transform duration-300">
+                        <img src="https://img.youtube.com/vi/8Z5RWNxpQM4/hqdefault.jpg" alt="Hà Giang Loop Easy Rider thumbnail" class="w-full h-48">
+                        <div class="p-5 space-y-2">
+                            <h3 class="text-xl font-semibold text-white">Hà Giang Loop Easy Rider</h3>
+                            <p class="text-gray-300 text-sm">Three-day motorbike road trip with Bông Hostel drivers, canyon passes, and starry homestays.</p>
+                        </div>
+                    </a>
                     <a href="hanoi-train-street-thrills.html" class="video-card rounded-xl overflow-hidden transition-transform duration-300">
                         <img src="https://img.youtube.com/vi/31idWwYdPIc/hqdefault.jpg" alt="Train Street Thrills thumbnail" class="w-full h-48">
                         <div class="p-5 space-y-2">


### PR DESCRIPTION
## Summary
- add a dedicated Hà Giang Loop destination guide with itinerary, packing tips, travel essentials, and embedded recap video
- publish a matching watch detail page and surface the film inside the Hanoi Stories section of the watch library
- register the new destination and video across the destinations hub and XML sitemaps for discovery

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68cc1751260c8323aa9daca6cfd3c9aa