### PR TITLE
Highlight feature documentaries in About section

### DIFF
--- a/index.html
+++ b/index.html
@@ -490,6 +490,33 @@
                     <p class="text-gray-300 mb-8">
                         Carl Travels is where all of that comes together — a home for real-world travel tips, filmmaking and editing hacks, gear guides, and the kind of life knowledge you only pick up on the road. I shoot mainly on the Sony A7CII, fly a variety of drones depending on the job, and edit between Adobe Premiere Pro and DaVinci Resolve (depending on how much punishment I’m willing to take). If you’re looking for polished storytelling with a raw edge — or just curious how someone survives making a living out of pixels and passport stamps — welcome to the ride.
                     </p>
+                    <div class="mt-10">
+                        <h3 class="text-white text-2xl font-semibold mb-4 flex items-center gap-2">
+                            <i class="fas fa-award text-yellow-500"></i> Feature Documentaries
+                        </h3>
+                        <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
+                            <a href="https://www.imdb.com/title/tt4148728/" target="_blank" rel="noopener noreferrer" class="group bg-black/40 rounded-2xl border border-yellow-500/30 p-5 flex flex-col sm:flex-row gap-4 hover:border-yellow-500 transition-colors">
+                                <img src="/busking.jpg" alt="Busking for Berlin documentary poster" class="w-full sm:w-28 h-40 object-cover rounded-xl shadow-lg group-hover:shadow-yellow-500/40 transition-shadow">
+                                <div>
+                                    <span class="uppercase tracking-wide text-yellow-500 text-sm font-medium">Busking for Berlin</span>
+                                    <h4 class="text-white text-xl font-semibold mt-1">Feature Documentary · 2014</h4>
+                                    <p class="text-gray-300 text-sm mt-3 leading-relaxed">
+                                        Filmmaker Carl Tomich steps into the shoes of a street performer, relying solely on the coins he earns busking across Berlin for an entire year.
+                                    </p>
+                                </div>
+                            </a>
+                            <a href="https://www.imdb.com/title/tt35471599/" target="_blank" rel="noopener noreferrer" class="group bg-black/40 rounded-2xl border border-yellow-500/30 p-5 flex flex-col sm:flex-row gap-4 hover:border-yellow-500 transition-colors">
+                                <img src="/busklifeposter.jpg" alt="Busk Life documentary poster" class="w-full sm:w-28 h-40 object-cover rounded-xl shadow-lg group-hover:shadow-yellow-500/40 transition-shadow">
+                                <div>
+                                    <span class="uppercase tracking-wide text-yellow-500 text-sm font-medium">Busk Life</span>
+                                    <h4 class="text-white text-xl font-semibold mt-1">Feature Documentary · 2024</h4>
+                                    <p class="text-gray-300 text-sm mt-3 leading-relaxed">
+                                        A decade later, Carl returns to Berlin’s streets to reconnect with "Neigh Kid Horse" and spotlight the city’s evolving busking scene alongside a new wave of performers.
+                                    </p>
+                                </div>
+                            </a>
+                        </div>
+                    </div>
                     <a href="#contact" class="px-6 py-3 bg-yellow-500 text-black rounded-full font-medium hover:bg-yellow-600 transition-all">
                         Get In Touch <i class="fas fa-paper-plane ml-2"></i>
                     </a>


### PR DESCRIPTION
## Summary
- add a feature documentaries subsection to the About area on the home page
- showcase Busking for Berlin (2014) and Busk Life (2024) with imagery, blurbs, and IMDb links

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d20ddf80108323ac7ba9b0692689ea