### PR TITLE
Adjust hero section padding on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,7 +206,7 @@
     </nav>
 
     <!-- Hero Section -->
-    <section class="relative overflow-hidden min-h-screen flex items-center justify-center pt-20">
+    <section class="relative overflow-hidden min-h-screen flex items-center justify-center pt-16 md:pt-20">
         <video class="hero-video" autoplay muted loop>
             <source src="/cinematic-reel.mp4" type="video/mp4">
         </video>


### PR DESCRIPTION
## Summary
- reduce the hero section's top padding on small screens so the showreel sits closer to the header

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d4d0eded3c8323bf9fbc78d08ed432