### PR TITLE
Update AIARTY and DaVinci Resolve thumbnails

### DIFF
--- a/gear.html
+++ b/gear.html
@@ -96,7 +96,7 @@
                 </div>
                 <div class="blog-card rounded-xl overflow-hidden shadow-lg">
                     <div class="relative overflow-hidden h-64">
-                        <img src="/carlcamera2.jpg" alt="DaVinci Resolve tutorial workspace" class="w-full h-full object-cover transform hover:scale-110 transition-transform duration-500">
+                        <img src="https://img.youtube.com/vi/wUYUV_F4WQo/maxresdefault.jpg" alt="DaVinci Resolve tutorial workspace" class="w-full h-full object-cover transform hover:scale-110 transition-transform duration-500">
                         <div class="absolute inset-0 bg-gradient-to-t from-black via-transparent to-transparent opacity-70"></div>
                         <div class="absolute bottom-0 left-0 p-6 text-white">
                             <h3 class="text-xl font-bold">Beginner’s Guide to DaVinci Resolve 2025</h3>

--- a/index.html
+++ b/index.html
@@ -397,7 +397,7 @@
                 <!-- Tech Review: AIARTY Video Enhancer -->
                 <div class="portfolio-card rounded-xl overflow-hidden shadow-lg">
                     <div class="relative overflow-hidden h-48">
-                        <img src="carlcamera2.jpg" alt="AIARTY Video Enhancer" class="w-full h-full object-cover">
+                        <img src="https://img.youtube.com/vi/fsYA84tjrTE/maxresdefault.jpg" alt="AIARTY Video Enhancer Review thumbnail" class="w-full h-full object-cover">
                         <div class="hover-overlay">
                             <a href="aiarty-video-enhancer-review.html" class="text-white font-bold text-lg">Read Review</a>
                         </div>


### PR DESCRIPTION
## Summary
- update the AIARTY card on the home page to reuse the correct YouTube thumbnail
- swap the DaVinci Resolve gear card image to the guide's embedded YouTube thumbnail for consistency

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e76512862883238c99836347497b74