### PR TITLE
Refresh Berlin and Osaka destination pages to match modern styling

### DIFF
--- a/Berlin.html
+++ b/Berlin.html
@@ -70,12 +70,12 @@
         }
         .navbar {
             backdrop-filter: blur(10px);
-            background-color: rgba(255, 255, 255, 0.9);
+            background-color: rgba(26, 26, 26, 0.9);
             transition: all 0.3s ease;
         }
         .navbar.scrolled {
-            background-color: rgba(255, 255, 255, 0.98);
-            box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+            background-color: rgba(26, 26, 26, 0.98);
+            box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.3);
         }
         .mobile-menu {
             max-height: 0;
@@ -85,26 +85,29 @@
         .mobile-menu.open {
             max-height: 500px;
         }
-        .wave-shape {
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            width: 100%;
-            overflow: hidden;
-            line-height: 0;
+        .hero-overlay {
+            background: linear-gradient(180deg, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.7) 65%, rgba(0, 0, 0, 0.92) 100%);
         }
-        .wave-shape svg {
-            position: relative;
-            display: block;
-            width: calc(100% + 1.3px);
-            height: 150px;
+        .glass-card {
+            background: rgba(26, 26, 26, 0.68);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            backdrop-filter: blur(14px);
         }
-        .wave-shape .shape-fill {
-            fill: #FFFFFF;
+        .highlight-card {
+            background: rgba(15, 15, 15, 0.75);
+            border: 1px solid rgba(255, 255, 255, 0.06);
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
+        }
+        .highlight-card:hover {
+            transform: translateY(-6px);
+            box-shadow: 0 20px 45px -20px rgba(0, 0, 0, 0.5);
+        }
+        .section-title {
+            letter-spacing: 0.35em;
         }
     </style>
 </head>
-<body class="bg-gray-50 text-gray-800">
+<body class="text-gray-300">
     <!-- Navigation -->
     <nav id="navbar" class="navbar fixed w-full z-50 shadow-sm transition-all duration-300">
         <div class="container mx-auto px-6 py-3">
@@ -116,239 +119,262 @@
                     <span class="heading-font bg-gradient-to-r from-yellow-500 to-amber-600 bg-clip-text text-transparent">Carl Travels</span>
                 </a>
                 <div class="hidden md:flex items-center space-x-8">
-                    <a href="index.html" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">Home</a>
+                    <a href="index.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Home</a>
                     <a href="destinations.html" class="text-yellow-500 font-medium transition-colors">Destinations</a>
-                    <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">Videos</a>
-                    <a href="blog.html" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">Blog</a>
-                    <a href="gear.html" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">Gear</a>
-                    <a href="#about" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">About</a>
-                    <a href="donate.html" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">Donate</a>
-                    <a href="#contact" class="px-4 py-2 bg-gradient-to-r from-yellow-500 to-amber-600 text-white rounded-full hover:shadow-lg transition-all">Contact</a>
+                    <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Videos</a>
+                    <a href="blog.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Blog</a>
+                    <a href="gear.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Gear</a>
+                    <a href="#about" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">About</a>
+                    <a href="donate.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Donate</a>
+                    <a href="#contact" class="px-4 py-2 bg-gradient-to-r from-yellow-500 to-amber-600 text-black rounded-full hover:shadow-lg transition-all">Contact</a>
                 </div>
-                <button id="mobile-menu-button" class="md:hidden text-gray-700 focus:outline-none">
+                <button id="mobile-menu-button" class="md:hidden text-gray-300 focus:outline-none">
                     <i class="fas fa-bars text-2xl"></i>
                 </button>
             </div>
             <!-- Mobile Menu -->
             <div id="mobile-menu" class="mobile-menu md:hidden">
                 <div class="pt-4 pb-2 space-y-2">
-                    <a href="index.html" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">Home</a>
+                    <a href="index.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Home</a>
                     <a href="destinations.html" class="block px-3 py-2 rounded-md bg-yellow-900 text-yellow-500 font-medium">Destinations</a>
-                    <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">Videos</a>
-                    <a href="blog.html" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">Blog</a>
-                    <a href="gear.html" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">Gear</a>
-                    <a href="#about" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">About</a>
-                    <a href="donate.html" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">Donate</a>
-                    <a href="#contact" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">Contact</a>
+                    <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Videos</a>
+                    <a href="blog.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Blog</a>
+                    <a href="gear.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Gear</a>
+                    <a href="#about" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">About</a>
+                    <a href="donate.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Donate</a>
+                    <a href="#contact" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Contact</a>
                 </div>
             </div>
         </div>
     </nav>
 
     <!-- Hero Section -->
-    <section class="hero-gradient relative overflow-hidden min-h-[60vh] flex items-center pt-20">
-        <div class="wave-shape">
-            <svg data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 120" preserveAspectRatio="none">
-                <path d="M321.39,56.44c58-10.79,114.16-30.13,172-41.86,82.39-16.72,168.19-17.73,250.45-.39C823.78,31,906.67,72,985.66,92.83c70.05,18.48,146.53,26.09,214.34,3V0H0V27.35A600.21,600.21,0,0,0,321.39,56.44Z" class="shape-fill"></path>
-            </svg>
-        </div>
-        <div class="container mx-auto px-6 py-12 text-center text-white relative z-10">
-            <div class="bg-black bg-opacity-50 px-6 py-12 max-w-3xl mx-auto rounded-2xl">
-                <h1 class="heading-font text-4xl md:text-5xl font-bold mb-4">Your Ultimate Guide to a Week in Berlin</h1>
-                <p class="text-lg">Where history, hedonism, and raw creativity collide—discover Berlin’s soul with insider tips from a decade of living here.</p>
+    <section class="relative min-h-[70vh] flex items-end pt-24" style="background-image: url('berlinworld.jpg'); background-size: cover; background-position: center;">
+        <div class="absolute inset-0 hero-overlay"></div>
+        <div class="container mx-auto px-6 py-20 relative z-10">
+            <div class="max-w-3xl">
+                <span class="section-title text-yellow-400 uppercase text-xs">Germany City Break</span>
+                <h1 class="heading-font text-4xl md:text-6xl text-white mt-4 mb-6 leading-tight">Berlin: History, Art &amp; Hedonism</h1>
+                <p class="text-lg md:text-xl text-gray-200 leading-relaxed">From the East Side Gallery to sunrise techno sessions, this week-long Berlin itinerary blends iconic landmarks with insider-only experiences from my decade living in the city.</p>
+                <div class="mt-8 flex flex-wrap gap-4">
+                    <a href="#plan" class="px-6 py-3 bg-yellow-500 text-black rounded-full font-semibold hover:bg-yellow-400 transition">Build Your Week</a>
+                    <a href="#video" class="px-6 py-3 border border-yellow-500 text-yellow-500 rounded-full font-semibold hover:bg-yellow-500 hover:text-black transition">Watch the Highlights</a>
+                </div>
             </div>
         </div>
     </section>
 
-    <!-- Main Content with Two-Column Layout -->
-    <main id="main-content" class="max-w-7xl mx-auto px-4 py-16">
-        <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
-            <!-- Left Column: Main Sections -->
-            <div class="md:col-span-2 space-y-12">
-                <!-- Introduction -->
-                <section>
-                    <h2 class="heading-font text-2xl font-semibold mb-4 text-yellow-500">Welcome to Berlin: A City Like No Other</h2>
-                    <p class="mb-4">Berlin isn’t just a city—it’s a vibe. A sprawling metropolis that somehow feels like a village, where history whispers from every corner, and raw creativity spills onto the streets. It’s wild and chaotic one minute, serene and thoughtful the next. When I first moved here in 2011, I was broke, curious, and drawn to Berlin’s magnetic pull—the art, the freedom, the underground scene. Berlin welcomed me with open arms and a €250-a-month flat. I built a houseboat on the Spree, DJ’d at hidden warehouse parties, and learned how to spot a dodgy döner stand from a block away.</p>
-                    <p class="mb-4">This guide is your roadmap to the perfect week in Berlin, blending must-see landmarks, offbeat gems, day trips, and nightlife tips. Whether it’s your first time or your fifth, I’ve poured my decade of living here into these recommendations to help you feel Berlin’s soul—not just see it.</p>
-                </section>
-
-                <!-- Where to Stay -->
-                <section>
-                    <h2 class="heading-font text-2xl font-semibold mb-4 text-yellow-500">Where to Stay: The Real Local Zones</h2>
-                    <p class="mb-4">Your first question is probably: Where should I stay? Skip the touristy hotels in Mitte and head to the border of <strong>Friedrichshain</strong> and <strong>Kreuzberg</strong>, near Warschauer Straße. These districts are Berlin’s beating heart—gritty, vibrant, and packed with street art, riverside bars, and nightlife that doesn’t quit. You’ll be steps from clubs, cheap eats, and the U-Bahn for easy city access.</p>
-                    <ul class="list-disc list-inside space-y-2 mb-4">
-                        <li><strong>NUMA Stays</strong>: I’ve crashed here when friends’ couches weren’t available. It’s modern, clean, and perfectly located. Not the cheapest (Berlin’s no longer a backpacker secret), but great value for the vibe. Expect €80–€150/night depending on the season.</li>
-                        <li><strong>Sunflower Hostel Berlin</strong>: A budget gem for younger travelers or solo adventurers. It’s basic but friendly, with dorms from €25–€40/night. The location near Warschauer Straße puts you in the action.</li>
-                        <li><strong>Airbnb in Prenzlauer Berg</strong>: If you want a quieter, family-friendly vibe, look for apartments here. It’s gentrified but charming, with cafes and parks. Prices range from €60–€120/night for a private flat.</li>
-                    </ul>
-                    <p><strong>Pro Tip</strong>: Berlin’s weather is unpredictable—pack layers. Also, book accommodations early for summer or during events like Berlin Art Week, as prices spike.</p>
-                </section>
-
-                <!-- 7-Day Itinerary -->
-                <section>
-                    <h2 class="heading-font text-2xl font-semibold mb-4 text-yellow-500">Your 7-Day Berlin Itinerary</h2>
-                    <div class="space-y-6">
-                        <!-- Day 1 -->
-                        <div>
-                            <h3 class="text-xl font-medium mb-2">Day 1: East Side & Easy Vibes</h3>
-                            <p class="mb-4">Kick off your trip in Friedrichshain. Drop your bags, take a deep breath, and head to the <strong>East Side Gallery</strong>—a 1.3 km stretch of the Berlin Wall turned into a vibrant art canvas. It’s a symbol of Berlin’s resilience, where history meets rebellion. Snap photos of iconic murals like Dmitri Vrubel’s “Fraternal Kiss.”</p>
-                            <p class="mb-4">Cross the stunning <strong>Oberbaum Bridge</strong> into Kreuzberg, soaking in the Spree River views. Grab a coffee at <strong>Silo Coffee</strong> or a falafel at <strong>Tadim Lahmacun</strong>. In the evening, buy a beer from a <strong>Späti</strong> (Berlin’s 24-hour convenience stores) and sit by the river. No plan needed—just vibe.</p>
-                            <p><strong>Insider Tip</strong>: Spätis are a Berlin institution. Look for ones with a “Biergarten” vibe—tables outside where locals gather. Try Sterni for a cheap, classic Berlin beer.</p>
-                        </div>
-                        <!-- Day 2 -->
-                        <div>
-                            <h3 class="text-xl font-medium mb-2">Day 2: Museum Island & Historical Berlin</h3>
-                            <p class="mb-4">Head to <strong>Museum Island</strong>, a UNESCO World Heritage site in Berlin’s heart. It’s surrounded by canals and home to five world-class museums: <strong>Pergamon</strong> (ancient artifacts), <strong>Neues Museum</strong> (Egyptian treasures, including Nefertiti’s bust), <strong>Alte Nationalgalerie</strong> (19th-century art), and more. A combo ticket (€18–€20) lets you explore multiple museums.</p>
-                            <p class="mb-4">Stroll past the majestic <strong>Berliner Dom</strong>, then grab lunch at <strong>Hackescher Markt</strong>. Try currywurst at <strong>Curry 36</strong> or vegan bites at <strong>1990 Vegan Living</strong>. Wander through the trendy <strong>Hackesche Höfe</strong>, a series of interconnected courtyards with boutiques and cafes. This is “classic Berlin”—I’ve taken my mum and aunt here, and they loved it.</p>
-                        </div>
-                        <!-- Day 3 -->
-                        <div>
-                            <h3 class="text-xl font-medium mb-2">Day 3: Mauerpark Sunday Market</h3>
-                            <p class="mb-4">If it’s Sunday, <strong>Mauerpark Flea Market</strong> is non-negotiable. What started as a small market is now a Berlin institution, drawing up to 80,000 people in summer. Expect street performers, food trucks, vintage clothes, handmade jewelry, and epic busking sessions—think karaoke with thousands cheering. Bring a blanket, some Späti drinks, and chill on the grassy hill.</p>
-                            <p class="mb-4">Afterward, explore <strong>Prenzlauer Berg</strong> nearby. Grab a craft beer at <strong>Prater Garten</strong>, Berlin’s oldest beer garden, or a pastry at <strong>Zeit für Brot</strong>. This day is Berlin at its most communal and carefree.</p>
-                        </div>
-                        <!-- Day 4 -->
-                        <div>
-                            <h3 class="text-xl font-medium mb-2">Day 4: Sachsenhausen Memorial</h3>
-                            <p class="mb-4">Take the S-Bahn to Oranienburg (40 minutes, €4–€5 one-way) for a sobering visit to the <strong>Sachsenhausen Concentration Camp Memorial</strong>. This well-preserved site is a haunting reminder of the Third Reich’s atrocities. Free guided tours (donations appreciated) provide context about WWII and the Holocaust. It’s emotionally heavy but essential for understanding Germany’s history.</p>
-                            <p class="mb-4">Back in Berlin, decompress at <strong>Treptower Park</strong>. Walk along the Spree or visit the Soviet War Memorial for a quiet moment. Alternatively, head to <strong>Insel der Jugend</strong>, a tiny island with a cozy cafe—perfect for reflection.</p>
-                        </div>
-                        <!-- Day 5 -->
-                        <div>
-                            <h3 class="text-xl font-medium mb-2">Day 5: Day Trip to Potsdam</h3>
-                            <p class="mb-4">Hop on a train to <strong>Potsdam</strong> (45 minutes, ABC ticket required, €8–€10 round-trip). This “royal cousin” of Berlin is home to <strong>Sanssouci Palace</strong>, a rococo masterpiece with sprawling gardens rivaling Versailles. Explore the palace (€14 entry) and wander the <strong>New Palace</strong> or <strong>Orangery</strong>. Potsdam’s charm lies in its calm—it’s a favorite for history buffs, nature lovers, or a low-key date.</p>
-                            <p class="mb-4">Grab lunch at <strong>Café Heider</strong> in Potsdam’s Dutch Quarter. I’ve brought family here multiple times, and it’s always a hit. Return to Berlin by evening for a relaxed dinner at <strong>Markthalle Neun</strong> in Kreuzberg if it’s Thursday (Street Food Thursday).</p>
-                        </div>
-                        <!-- Day 6 -->
-                        <div>
-                            <h3 class="text-xl font-medium mb-2">Day 6: Kreuzberg Culture + Spree Boat Ride</h3>
-                            <p class="mb-4">Dive into <strong>Kreuzberg</strong>, Berlin’s soul—gritty, proud, and full of contradictions. Start at the <strong>Türkischer Markt</strong> (Tuesday/Friday) along the Maybachufer canal for fresh produce, Turkish snacks, and vibrant chaos. Wander graffiti-covered streets, grab a coffee at <strong>Five Elephant</strong>, or explore <strong>SO36</strong>, a legendary punk venue turned cultural hub.</p>
-                            <p class="mb-4">In the afternoon, book a <strong>Spree boat tour</strong> near the East Side Gallery (€15–€25, 1–2 hours). You’ll glide past landmarks like the <strong>Reichstag</strong>, <strong>Museum Island</strong>, and <strong>Berlin Cathedral</strong>, seeing the city from a new angle. End the day with dinner at <strong>Burgermeister</strong> under the U-Bahn tracks—a Berlin classic.</p>
-                        </div>
-                        <!-- Day 7 -->
-                        <div>
-                            <h3 class="text-xl font-medium mb-2">Day 7: Berlin After Dark</h3>
-                            <p class="mb-4">Berlin’s nightlife is legendary, and you can’t leave without diving in. For techno lovers, <strong>Berghain</strong> is the holy grail—though good luck getting past the door (dress low-key, go late, and don’t act like a tourist). <strong>Sisyphos</strong> offers riverside vibes with a more relaxed entry, while <strong>Golden Gate</strong> is raw, underground madness. Prefer something chill? Try <strong>Klunkerkranich</strong>, a rooftop bar with sunset views, or <strong>Prater Garten</strong> for beers.</p>
-                            <p class="mb-4">Berlin doesn’t do “closing hours”—parties can last days. Pace yourself, stay hydrated, and embrace the chaos. I’ve seen sunrises outside clubs and on museum steps, and both are pure Berlin magic.</p>
-                        </div>
-                    </div>
-                </section>
-
-                <!-- Video Embed -->
-                <section>
-                    <h2 class="heading-font text-2xl font-semibold mb-4 text-yellow-500">See Berlin Through My Eyes</h2>
-                    <div class="responsive-video mb-8">
-                        <iframe src="https://www.youtube.com/embed/qT4uDZ4MyZk" title="Berlin Travel Highlights" class="w-full h-64 md:h-96 rounded-lg shadow-lg" frameborder="0" allowfullscreen></iframe>
-                    </div>
-                </section>
-
-                <!-- Scams & Tourist Traps -->
-                <section>
-                    <h2 class="heading-font text-2xl font-semibold mb-4 text-yellow-500">Scams & Tourist Traps to Avoid</h2>
-                    <p class="mb-4">Berlin is safe, but tourists can be targets. Here’s what to watch for:</p>
-                    <ul class="list-disc list-inside space-y-2 mb-4">
-                        <li><strong>Signature Collectors</strong>: Around landmarks like Brandenburg Gate, people ask you to sign petitions. It’s a distraction for pickpocketing. Politely say “Nein” and keep walking.</li>
-                        <li><strong>Fake Charity Donations</strong>: “Volunteers” claiming to collect for deaf children or international causes are often scams. Legit charities don’t operate this way in Berlin.</li>
-                        <li><strong>Card Readers/ATMs</strong>: Check ATMs for skimmers, especially in tourist areas. Avoid “helpful” strangers offering to guide you—trust your gut.</li>
-                        <li><strong>Overpriced Döner</strong>: A good döner should cost €4–€6. If it’s €10 near Alexanderplatz, you’re being ripped off. Head to Kreuzberg for the real deal.</li>
-                    </ul>
-                    <p><strong>Pro Tip</strong>: If someone’s performance feels too polished and involves money, it’s probably a hustle. Berliners are direct—trust that vibe.</p>
-                </section>
-
-                <!-- Final Tips -->
-                <section>
-                    <h2 class="heading-font text-2xl font-semibold mb-4 text-yellow-500">Final Tips for Your Berlin Adventure</h2>
-                    <ul class="list-disc list-inside space-y-2 mb-4">
-                        <li><strong>Pack Layers</strong>: Berlin’s weather can flip from sunny to stormy in minutes. A light jacket and scarf are your friends.</li>
-                        <li><strong>Cash is King</strong>: Many cafes, Spätis, and even some restaurants don’t take cards. Carry €20–€50 in small bills.</li>
-                        <li><strong>Public Transport</strong>: Get a weekly <strong>AB ticket</strong> (€30–€40) for unlimited U-Bahn, S-Bahn, trams, and buses in central Berlin. Add an <strong>ABC ticket</strong> for day trips to Potsdam or Oranienburg.</li>
-                        <li><strong>Stay Flexible</strong>: Berlin’s best moments are spontaneous—a random Späti hangout, a street party, or a chat with a stranger. Leave room for serendipity.</li>
-                        <li><strong>Learn a Few Words</strong>: “Danke” (thank you), “Bitte” (please), and “Entschuldigung” (sorry) go a long way. Berliners appreciate the effort.</li>
-                    </ul>
-                    <p class="mb-4">One last thought: Berlin isn’t a city you just see—it’s a city you feel. Don’t rush it. Sit by the Spree with a Sterni, talk to a stranger at Mauerpark, watch the sunrise outside a club or on the steps of the Berliner Dom. The real magic of Berlin isn’t on any itinerary—it’s in the in-between moments that stay with you forever.</p>
-                </section>
+    <!-- Highlights Strip -->
+    <section class="py-16 bg-[#101010]">
+        <div class="container mx-auto px-6">
+            <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-4">
+                <div class="highlight-card rounded-3xl p-8">
+                    <div class="text-yellow-400 text-3xl mb-4"><i class="fas fa-landmark"></i></div>
+                    <h3 class="heading-font text-2xl text-white mb-3">Wall Stories</h3>
+                    <p class="text-gray-300 leading-relaxed">Walk the East Side Gallery and absorb Berlin’s street-art protest legacy along the Spree.</p>
+                </div>
+                <div class="highlight-card rounded-3xl p-8">
+                    <div class="text-yellow-400 text-3xl mb-4"><i class="fas fa-music"></i></div>
+                    <h3 class="heading-font text-2xl text-white mb-3">After-Hours Culture</h3>
+                    <p class="text-gray-300 leading-relaxed">From warehouse techno to riverside bars, nightlife here doesn’t believe in curfews.</p>
+                </div>
+                <div class="highlight-card rounded-3xl p-8">
+                    <div class="text-yellow-400 text-3xl mb-4"><i class="fas fa-bread-slice"></i></div>
+                    <h3 class="heading-font text-2xl text-white mb-3">Street Food Icons</h3>
+                    <p class="text-gray-300 leading-relaxed">Snack through currywurst stands, döner legends, and market stalls with local cult followings.</p>
+                </div>
+                <div class="highlight-card rounded-3xl p-8">
+                    <div class="text-yellow-400 text-3xl mb-4"><i class="fas fa-train"></i></div>
+                    <h3 class="heading-font text-2xl text-white mb-3">Day Trip Ready</h3>
+                    <p class="text-gray-300 leading-relaxed">Hop on the S-Bahn for memorial visits, palaces in Potsdam, and quiet canals when you need a breather.</p>
+                </div>
             </div>
+        </div>
+    </section>
 
-            <!-- Right Column: Sidebar with Highlights & Practical Info -->
-            <aside class="space-y-12">
-                <!-- Highlights -->
-                <section class="bg-white p-6 rounded-lg shadow-md">
-                    <h3 class="heading-font text-xl font-semibold mb-4 text-gray-800">Berlin Highlights</h3>
-                    <ul class="list-disc list-inside space-y-2">
-                        <li><strong>Brandenburg Gate</strong>: Iconic symbol of unity and history.</li>
-                        <li><strong>East Side Gallery</strong>: 1.3 km of Berlin Wall covered in vibrant murals.</li>
-                        <li><strong>Museum Island</strong>: Five world-class museums on the Spree River.</li>
-                        <li><strong>Mauerpark Flea Market</strong>: Sunday’s best party with buskers and vintage finds.</li>
-                        <li><strong>Kreuzberg & Friedrichshain</strong>: Gritty neighborhoods with art, food, and nightlife.</li>
-                    </ul>
-                </section>
+    <!-- Main Content -->
+    <main class="bg-[#060606] py-16" id="plan">
+        <div class="container mx-auto px-6">
+            <div class="grid gap-12 lg:grid-cols-[2fr_1fr] items-start">
+                <div class="space-y-10">
+                    <section class="glass-card rounded-3xl p-8 space-y-6">
+                        <h2 class="heading-font text-3xl text-white">Welcome to Berlin: A City Like No Other</h2>
+                        <p class="text-gray-300 leading-relaxed">Berlin isn’t just a city—it’s a vibe. A sprawling metropolis that somehow feels like a village, where history whispers from every corner, and raw creativity spills onto the streets. It’s wild and chaotic one minute, serene and thoughtful the next. When I first moved here in 2011, I was broke, curious, and drawn to Berlin’s magnetic pull—the art, the freedom, the underground scene. Berlin welcomed me with open arms and a €250-a-month flat. I built a houseboat on the Spree, DJ’d at hidden warehouse parties, and learned how to spot a dodgy döner stand from a block away.</p>
+                        <p class="text-gray-300 leading-relaxed">This guide is your roadmap to the perfect week in Berlin, blending must-see landmarks, offbeat gems, day trips, and nightlife tips. Whether it’s your first time or your fifth, I’ve poured my decade of living here into these recommendations to help you feel Berlin’s soul—not just see it.</p>
+                    </section>
 
-                <!-- Practical Information -->
-                <section class="bg-white p-6 rounded-lg shadow-md">
-                    <h3 class="heading-font text-xl font-semibold mb-4 text-gray-800">Practical Information</h3>
-                    <h4 class="font-medium mt-2">Transportation</h4>
-                    <ul class="list-disc list-inside space-y-2 mb-4">
-                        <li><strong>U-Bahn & S-Bahn</strong>: Fast, reliable metro lines. Weekly AB ticket: €30–€40.</li>
-                        <li><strong>Trams & Buses</strong>: Ideal for East Berlin routes, included in AB ticket.</li>
-                        <li><strong>Bike Rentals</strong>: Flat terrain makes cycling easy. Try Nextbike (€1–€3/hour).</li>
-                    </ul>
-                    <h4 class="font-medium mt-2">Accommodation</h4>
-                    <ul class="list-disc list-inside space-y-2 mb-4">
-                        <li><strong>Friedrichshain/Kreuzberg</strong>: Trendy, central, nightlife hub. €25–€150/night.</li>
-                        <li><strong>Prenzlauer Berg</strong>: Quieter, family-friendly, cafe-heavy. €60–€120/night.</li>
-                        <li><strong>Mitte</strong>: Tourist-friendly, near landmarks. €80–€200/night.</li>
-                    </ul>
-                    <h4 class="font-medium mt-2">Budgeting</h4>
-                    <p class="mb-4">Expect <strong>€60–€120/day</strong> for budget travelers (hostel, street food, public transport). Add €50–€100/day for mid-range accommodations and nightlife.</p>
-                    <h4 class="font-medium mt-2">Safety</h4>
-                    <p>Avoid flashy displays of wealth in crowded areas. Stick to well-lit streets at night in edgier neighborhoods like Neukölln.</p>
-                </section>
-            </aside>
+                    <section class="glass-card rounded-3xl p-8 space-y-6">
+                        <h2 class="heading-font text-3xl text-white">Where to Stay: The Real Local Zones</h2>
+                        <p class="text-gray-300 leading-relaxed">Your first question is probably: Where should I stay? Skip the touristy hotels in Mitte and head to the border of <strong>Friedrichshain</strong> and <strong>Kreuzberg</strong>, near Warschauer Straße. These districts are Berlin’s beating heart—gritty, vibrant, and packed with street art, riverside bars, and nightlife that doesn’t quit. You’ll be steps from clubs, cheap eats, and the U-Bahn for easy city access.</p>
+                        <ul class="list-disc list-inside space-y-2 text-gray-300">
+                            <li><strong>NUMA Stays</strong>: I’ve crashed here when friends’ couches weren’t available. It’s modern, clean, and perfectly located. Not the cheapest (Berlin’s no longer a backpacker secret), but great value for the vibe. Expect €80–€150/night depending on the season.</li>
+                            <li><strong>Sunflower Hostel Berlin</strong>: A budget gem for younger travelers or solo adventurers. It’s basic but friendly, with dorms from €25–€40/night. The location near Warschauer Straße puts you in the action.</li>
+                            <li><strong>Airbnb in Prenzlauer Berg</strong>: If you want a quieter, family-friendly vibe, look for apartments here. It’s gentrified but charming, with cafes and parks. Prices range from €60–€120/night for a private flat.</li>
+                        </ul>
+                        <p class="text-gray-300"><strong>Pro Tip</strong>: Berlin’s weather is unpredictable—pack layers. Also, book accommodations early for summer or during events like Berlin Art Week, as prices spike.</p>
+                    </section>
+
+                    <section class="glass-card rounded-3xl p-8 space-y-8">
+                        <h2 class="heading-font text-3xl text-white">Your 7-Day Berlin Itinerary</h2>
+                        <div class="space-y-8">
+                            <div class="border-l-4 border-yellow-500 pl-6 space-y-4">
+                                <h3 class="text-2xl text-white font-semibold">Day 1: East Side &amp; Easy Vibes</h3>
+                                <p class="text-gray-300 leading-relaxed">Kick off your trip in Friedrichshain. Drop your bags, take a deep breath, and head to the <strong>East Side Gallery</strong>—a 1.3 km stretch of the Berlin Wall turned into a vibrant art canvas. It’s a symbol of Berlin’s resilience, where history meets rebellion. Snap photos of iconic murals like Dmitri Vrubel’s “Fraternal Kiss.”</p>
+                                <p class="text-gray-300 leading-relaxed">Cross the stunning <strong>Oberbaum Bridge</strong> into Kreuzberg, soaking in the Spree River views. Grab a coffee at <strong>Silo Coffee</strong> or a falafel at <strong>Tadim Lahmacun</strong>. In the evening, buy a beer from a <strong>Späti</strong> (Berlin’s 24-hour convenience stores) and sit by the river. No plan needed—just vibe.</p>
+                                <p class="text-gray-300"><strong>Insider Tip</strong>: Spätis are a Berlin institution. Look for ones with a “Biergarten” vibe—tables outside where locals gather. Try Sterni for a cheap, classic Berlin beer.</p>
+                            </div>
+                            <div class="border-l-4 border-yellow-500 pl-6 space-y-4">
+                                <h3 class="text-2xl text-white font-semibold">Day 2: Museum Island &amp; Historical Berlin</h3>
+                                <p class="text-gray-300 leading-relaxed">Head to <strong>Museum Island</strong>, a UNESCO World Heritage site in Berlin’s heart. It’s surrounded by canals and home to five world-class museums: <strong>Pergamon</strong> (ancient artifacts), <strong>Neues Museum</strong> (Egyptian treasures, including Nefertiti’s bust), <strong>Alte Nationalgalerie</strong> (19th-century art), and more. A combo ticket (€18–€20) lets you explore multiple museums.</p>
+                                <p class="text-gray-300 leading-relaxed">Stroll past the majestic <strong>Berliner Dom</strong>, then grab lunch at <strong>Hackescher Markt</strong>. Try currywurst at <strong>Curry 36</strong> or vegan bites at <strong>1990 Vegan Living</strong>. Wander through the trendy <strong>Hackesche Höfe</strong>, a series of interconnected courtyards with boutiques and cafes. This is “classic Berlin”—I’ve taken my mum and aunt here, and they loved it.</p>
+                            </div>
+                            <div class="border-l-4 border-yellow-500 pl-6 space-y-4">
+                                <h3 class="text-2xl text-white font-semibold">Day 3: Mauerpark Sunday Market</h3>
+                                <p class="text-gray-300 leading-relaxed">If it’s Sunday, <strong>Mauerpark Flea Market</strong> is non-negotiable. What started as a small market is now a Berlin institution, drawing up to 80,000 people in summer. Expect street performers, food trucks, vintage clothes, handmade jewelry, and epic busking sessions—think karaoke with thousands cheering. Bring a blanket, some Späti drinks, and chill on the grassy hill.</p>
+                                <p class="text-gray-300 leading-relaxed">Afterward, explore <strong>Prenzlauer Berg</strong> nearby. Grab a craft beer at <strong>Prater Garten</strong>, Berlin’s oldest beer garden, or a pastry at <strong>Zeit für Brot</strong>. This day is Berlin at its most communal and carefree.</p>
+                            </div>
+                            <div class="border-l-4 border-yellow-500 pl-6 space-y-4">
+                                <h3 class="text-2xl text-white font-semibold">Day 4: Sachsenhausen Memorial</h3>
+                                <p class="text-gray-300 leading-relaxed">Take the S-Bahn to Oranienburg (40 minutes, €4–€5 one-way) for a sobering visit to the <strong>Sachsenhausen Concentration Camp Memorial</strong>. This well-preserved site is a haunting reminder of the Third Reich’s atrocities. Free guided tours (donations appreciated) provide context about WWII and the Holocaust. It’s emotionally heavy but essential for understanding Germany’s history.</p>
+                                <p class="text-gray-300 leading-relaxed">Back in Berlin, decompress at <strong>Treptower Park</strong>. Walk along the Spree or visit the Soviet War Memorial for a quiet moment. Alternatively, head to <strong>Insel der Jugend</strong>, a tiny island with a cozy cafe—perfect for reflection.</p>
+                            </div>
+                            <div class="border-l-4 border-yellow-500 pl-6 space-y-4">
+                                <h3 class="text-2xl text-white font-semibold">Day 5: Day Trip to Potsdam</h3>
+                                <p class="text-gray-300 leading-relaxed">Hop on a train to <strong>Potsdam</strong> (45 minutes, ABC ticket required, €8–€10 round-trip). This “royal cousin” of Berlin is home to <strong>Sanssouci Palace</strong>, a rococo masterpiece with sprawling gardens rivaling Versailles. Explore the palace (€14 entry) and wander the <strong>New Palace</strong> or <strong>Orangery</strong>. Potsdam’s charm lies in its calm—it’s a favorite for history buffs, nature lovers, or a low-key date.</p>
+                                <p class="text-gray-300 leading-relaxed">Grab lunch at <strong>Café Heider</strong> in Potsdam’s Dutch Quarter. I’ve brought family here multiple times, and it’s always a hit. Return to Berlin by evening for a relaxed dinner at <strong>Markthalle Neun</strong> in Kreuzberg if it’s Thursday (Street Food Thursday).</p>
+                            </div>
+                            <div class="border-l-4 border-yellow-500 pl-6 space-y-4">
+                                <h3 class="text-2xl text-white font-semibold">Day 6: Kreuzberg Culture + Spree Boat Ride</h3>
+                                <p class="text-gray-300 leading-relaxed">Dive into <strong>Kreuzberg</strong>, Berlin’s soul—gritty, proud, and full of contradictions. Start at the <strong>Türkischer Markt</strong> (Tuesday/Friday) along the Maybachufer canal for fresh produce, Turkish snacks, and vibrant chaos. Wander graffiti-covered streets, grab a coffee at <strong>Five Elephant</strong>, or explore <strong>SO36</strong>, a legendary punk venue turned cultural hub.</p>
+                                <p class="text-gray-300 leading-relaxed">In the afternoon, book a <strong>Spree boat tour</strong> near the East Side Gallery (€15–€25, 1–2 hours). You’ll glide past landmarks like the <strong>Reichstag</strong>, <strong>Museum Island</strong>, and <strong>Berlin Cathedral</strong>, seeing the city from a new angle. End the day with dinner at <strong>Burgermeister</strong> under the U-Bahn tracks—a Berlin classic.</p>
+                            </div>
+                            <div class="border-l-4 border-yellow-500 pl-6 space-y-4">
+                                <h3 class="text-2xl text-white font-semibold">Day 7: Berlin After Dark</h3>
+                                <p class="text-gray-300 leading-relaxed">Berlin’s nightlife is legendary, and you can’t leave without diving in. For techno lovers, <strong>Berghain</strong> is the holy grail—though good luck getting past the door (dress low-key, go late, and don’t act like a tourist). <strong>Sisyphos</strong> offers riverside vibes with a more relaxed entry, while <strong>Golden Gate</strong> is raw, underground madness. Prefer something chill? Try <strong>Klunkerkranich</strong>, a rooftop bar with sunset views, or <strong>Prater Garten</strong> for beers.</p>
+                                <p class="text-gray-300 leading-relaxed">Berlin doesn’t do “closing hours”—parties can last days. Pace yourself, stay hydrated, and embrace the chaos. I’ve seen sunrises outside clubs and on museum steps, and both are pure Berlin magic.</p>
+                            </div>
+                        </div>
+                    </section>
+
+                    <section class="glass-card rounded-3xl p-8 space-y-6" id="video">
+                        <h2 class="heading-font text-3xl text-white">See Berlin Through My Eyes</h2>
+                        <div class="relative aspect-video rounded-2xl overflow-hidden shadow-2xl">
+                            <iframe class="absolute inset-0 w-full h-full" src="https://www.youtube.com/embed/qT4uDZ4MyZk" title="Berlin Travel Highlights" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+                        </div>
+                    </section>
+
+                    <section class="glass-card rounded-3xl p-8 space-y-6">
+                        <h2 class="heading-font text-3xl text-white">Scams &amp; Tourist Traps to Avoid</h2>
+                        <p class="text-gray-300 leading-relaxed">Berlin is safe, but tourists can be targets. Here’s what to watch for:</p>
+                        <ul class="list-disc list-inside space-y-3 text-gray-300">
+                            <li><strong>Signature Collectors</strong>: Around landmarks like Brandenburg Gate, people ask you to sign petitions. It’s a distraction for pickpocketing. Politely say “Nein” and keep walking.</li>
+                            <li><strong>Fake Charity Donations</strong>: “Volunteers” claiming to collect for deaf children or international causes are often scams. Legit charities don’t operate this way in Berlin.</li>
+                            <li><strong>Card Readers/ATMs</strong>: Check ATMs for skimmers, especially in tourist areas. Avoid “helpful” strangers offering to guide you—trust your gut.</li>
+                            <li><strong>Overpriced Döner</strong>: A good döner should cost €4–€6. If it’s €10 near Alexanderplatz, you’re being ripped off. Head to Kreuzberg for the real deal.</li>
+                        </ul>
+                        <p class="text-gray-300"><strong>Pro Tip</strong>: If someone’s performance feels too polished and involves money, it’s probably a hustle. Berliners are direct—trust that vibe.</p>
+                    </section>
+
+                    <section class="glass-card rounded-3xl p-8 space-y-6">
+                        <h2 class="heading-font text-3xl text-white">Final Tips for Your Berlin Adventure</h2>
+                        <ul class="list-disc list-inside space-y-3 text-gray-300">
+                            <li><strong>Pack Layers</strong>: Berlin’s weather can flip from sunny to stormy in minutes. A light jacket and scarf are your friends.</li>
+                            <li><strong>Cash is King</strong>: Many cafes, Spätis, and even some restaurants don’t take cards. Carry €20–€50 in small bills.</li>
+                            <li><strong>Public Transport</strong>: Get a weekly <strong>AB ticket</strong> (€30–€40) for unlimited U-Bahn, S-Bahn, trams, and buses in central Berlin. Add an <strong>ABC ticket</strong> for day trips to Potsdam or Oranienburg.</li>
+                            <li><strong>Stay Flexible</strong>: Berlin’s best moments are spontaneous—a random Späti hangout, a street party, or a chat with a stranger. Leave room for serendipity.</li>
+                            <li><strong>Learn a Few Words</strong>: “Danke” (thank you), “Bitte” (please), and “Entschuldigung” (sorry) go a long way. Berliners appreciate the effort.</li>
+                        </ul>
+                        <p class="text-gray-300 leading-relaxed">One last thought: Berlin isn’t a city you just see—it’s a city you feel. Don’t rush it. Sit by the Spree with a Sterni, talk to a stranger at Mauerpark, watch the sunrise outside a club or on the steps of the Berliner Dom. The real magic of Berlin isn’t on any itinerary—it’s in the in-between moments that stay with you forever.</p>
+                    </section>
+                </div>
+
+                <aside class="space-y-8">
+                    <section class="glass-card rounded-3xl p-8 space-y-4">
+                        <h3 class="heading-font text-2xl text-white">Berlin Highlights</h3>
+                        <ul class="list-disc list-inside space-y-2 text-gray-300">
+                            <li><strong>Brandenburg Gate</strong>: Iconic symbol of unity and history.</li>
+                            <li><strong>East Side Gallery</strong>: 1.3 km of Berlin Wall covered in vibrant murals.</li>
+                            <li><strong>Museum Island</strong>: Five world-class museums on the Spree River.</li>
+                            <li><strong>Mauerpark Flea Market</strong>: Sunday’s best party with buskers and vintage finds.</li>
+                            <li><strong>Kreuzberg &amp; Friedrichshain</strong>: Gritty neighborhoods with art, food, and nightlife.</li>
+                        </ul>
+                    </section>
+
+                    <section class="glass-card rounded-3xl p-8 space-y-4">
+                        <h3 class="heading-font text-2xl text-white">Practical Information</h3>
+                        <div>
+                            <h4 class="text-yellow-400 font-semibold uppercase tracking-wide text-xs">Transportation</h4>
+                            <ul class="list-disc list-inside space-y-2 text-gray-300 mt-2">
+                                <li><strong>U-Bahn &amp; S-Bahn</strong>: Fast, reliable metro lines. Weekly AB ticket: €30–€40.</li>
+                                <li><strong>Trams &amp; Buses</strong>: Ideal for East Berlin routes, included in AB ticket.</li>
+                                <li><strong>Bike Rentals</strong>: Flat terrain makes cycling easy. Try Nextbike (€1–€3/hour).</li>
+                            </ul>
+                        </div>
+                        <div>
+                            <h4 class="text-yellow-400 font-semibold uppercase tracking-wide text-xs">Accommodation</h4>
+                            <ul class="list-disc list-inside space-y-2 text-gray-300 mt-2">
+                                <li><strong>Friedrichshain/Kreuzberg</strong>: Trendy, central, nightlife hub. €25–€150/night.</li>
+                                <li><strong>Prenzlauer Berg</strong>: Quieter, family-friendly, cafe-heavy. €60–€120/night.</li>
+                                <li><strong>Mitte</strong>: Tourist-friendly, near landmarks. €80–€200/night.</li>
+                            </ul>
+                        </div>
+                        <div>
+                            <h4 class="text-yellow-400 font-semibold uppercase tracking-wide text-xs">Budgeting</h4>
+                            <p class="text-gray-300 leading-relaxed mt-2">Expect <strong>€60–€120/day</strong> for budget travelers (hostel, street food, public transport). Add €50–€100/day for mid-range accommodations and nightlife.</p>
+                        </div>
+                        <div>
+                            <h4 class="text-yellow-400 font-semibold uppercase tracking-wide text-xs">Safety</h4>
+                            <p class="text-gray-300 leading-relaxed mt-2">Avoid flashy displays of wealth in crowded areas. Stick to well-lit streets at night in edgier neighborhoods like Neukölln.</p>
+                        </div>
+                    </section>
+                </aside>
+            </div>
         </div>
     </main>
 
     <!-- Travel Essentials & Creator Gear -->
-    <section class="py-16 bg-gray-100">
+    <section class="py-16 bg-[#0b0b0b]">
         <div class="container mx-auto px-6">
             <div class="text-center mb-12">
-                <h2 class="heading-font text-3xl md:text-4xl font-bold text-gray-800 mb-4">Travel Essentials &amp; Creator Gear</h2>
-                <div class="w-20 h-1 bg-yellow-500 mx-auto"></div>
+                <span class="section-title text-yellow-400 uppercase text-xs">Creator Corner</span>
+                <h2 class="heading-font text-3xl md:text-4xl text-white mt-4">Travel Essentials &amp; Creator Gear</h2>
+                <p class="text-gray-400 mt-3 max-w-2xl mx-auto">Gear and resources I use on every European city run—from instant connectivity to the camera kit that captures Berlin’s glow.</p>
             </div>
-            <div class="max-w-3xl mx-auto space-y-10">
-                <div>
-                    <h3 class="text-xl font-bold text-gray-800 mb-4">🌍 TRAVEL ESSENTIALS</h3>
-                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+            <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-4">
+                <div class="glass-card rounded-3xl p-8 space-y-4">
+                    <h3 class="heading-font text-2xl text-white">Travel Essentials</h3>
+                    <ul class="list-disc list-inside text-gray-300 space-y-2">
                         <li>Saily eSIM (200+ countries): Use code <span class="font-semibold">CARLRI5370</span> for $5 off (I receive $5 credit)</li>
-                        <li>Wise (multi-currency card): <a href="https://wise.com/invite/irhc/carlt62" class="text-yellow-500 hover:text-yellow-600">Sign up here</a></li>
+                        <li>Wise (multi-currency card): <a href="https://wise.com/invite/irhc/carlt62" class="text-yellow-500 hover:text-yellow-400">Sign up here</a></li>
                     </ul>
                 </div>
-                <div>
-                    <h3 class="text-xl font-bold text-gray-800 mb-4">🎬 CREATOR TOOLS</h3>
-                    <ul class="list-disc list-inside text-gray-600 space-y-2">
-                        <li>Dehancer (film emulation): Code <span class="font-semibold">CARLTRAVELS</span> for 10% off → <a href="https://www.dehancer.com/subscribe" class="text-yellow-500 hover:text-yellow-600">dehancer.com/subscribe</a></li>
-                        <li>Adobe Enhance VO (FREE): <a href="https://podcast.adobe.com/en/enhance" class="text-yellow-500 hover:text-yellow-600">podcast.adobe.com/en/enhance</a></li>
+                <div class="glass-card rounded-3xl p-8 space-y-4">
+                    <h3 class="heading-font text-2xl text-white">Creator Tools</h3>
+                    <ul class="list-disc list-inside text-gray-300 space-y-2">
+                        <li>Dehancer (film emulation): Code <span class="font-semibold">CARLTRAVELS</span> for 10% off → <a href="https://www.dehancer.com/subscribe" class="text-yellow-500 hover:text-yellow-400">dehancer.com/subscribe</a></li>
+                        <li>Adobe Enhance VO (FREE): <a href="https://podcast.adobe.com/en/enhance" class="text-yellow-500 hover:text-yellow-400">podcast.adobe.com/en/enhance</a></li>
                     </ul>
                 </div>
-                <div>
-                    <h3 class="text-xl font-bold text-gray-800 mb-4">🧰 MY GEAR — US LINKS</h3>
-                    <ul class="list-disc list-inside text-gray-600 space-y-2">
-                        <li><a href="https://amzn.to/45iZULT" class="text-yellow-500 hover:text-yellow-600">DJI Flip</a></li>
-                        <li><a href="https://amzn.to/4mHhQ8H" class="text-yellow-500 hover:text-yellow-600">Sony A7C II</a></li>
-                        <li><a href="https://amzn.to/4miS3UJ" class="text-yellow-500 hover:text-yellow-600">DJI Pocket 3</a></li>
-                        <li><a href="https://amzn.to/4lvd1hI" class="text-yellow-500 hover:text-yellow-600">Tamron 28–200</a></li>
-                        <li><a href="https://amzn.to/4oHMXTy" class="text-yellow-500 hover:text-yellow-600">RØDE Wireless PRO</a></li>
-                        <li><a href="https://amzn.to/467fEAU" class="text-yellow-500 hover:text-yellow-600">Think Tank Backpack</a></li>
+                <div class="glass-card rounded-3xl p-8 space-y-4">
+                    <h3 class="heading-font text-2xl text-white">My Gear – US Links</h3>
+                    <ul class="list-disc list-inside text-gray-300 space-y-2">
+                        <li><a href="https://amzn.to/45iZULT" class="text-yellow-500 hover:text-yellow-400">DJI Flip</a></li>
+                        <li><a href="https://amzn.to/4mHhQ8H" class="text-yellow-500 hover:text-yellow-400">Sony A7C II</a></li>
+                        <li><a href="https://amzn.to/4miS3UJ" class="text-yellow-500 hover:text-yellow-400">DJI Pocket 3</a></li>
+                        <li><a href="https://amzn.to/4lvd1hI" class="text-yellow-500 hover:text-yellow-400">Tamron 28–200</a></li>
+                        <li><a href="https://amzn.to/4oHMXTy" class="text-yellow-500 hover:text-yellow-400">RØDE Wireless PRO</a></li>
+                        <li><a href="https://amzn.to/467fEAU" class="text-yellow-500 hover:text-yellow-400">Think Tank Backpack</a></li>
                     </ul>
                 </div>
-                <div>
-                    <h3 class="text-xl font-bold text-gray-800 mb-4">🧰 MY GEAR — AU LINKS</h3>
-                    <ul class="list-disc list-inside text-gray-600 space-y-2">
-                        <li><a href="https://amzn.to/41zmAVV" class="text-yellow-500 hover:text-yellow-600">DJI Flip</a></li>
-                        <li><a href="https://amzn.to/45Qk2Fw" class="text-yellow-500 hover:text-yellow-600">Sony A7C II</a></li>
-                        <li><a href="https://amzn.to/4gaYLJZ" class="text-yellow-500 hover:text-yellow-600">DJI Osmo Pocket 3</a></li>
-                        <li><a href="https://amzn.to/4n73D5P" class="text-yellow-500 hover:text-yellow-600">Tamron 24–200</a></li>
-                        <li><a href="https://amzn.to/46kv8CG" class="text-yellow-500 hover:text-yellow-600">RØDE Wireless PRO</a></li>
-                        <li><a href="https://amzn.to/3I5mApV" class="text-yellow-500 hover:text-yellow-600">Think Tank Backpack</a></li>
+                <div class="glass-card rounded-3xl p-8 space-y-4">
+                    <h3 class="heading-font text-2xl text-white">My Gear – AU Links</h3>
+                    <ul class="list-disc list-inside text-gray-300 space-y-2">
+                        <li><a href="https://amzn.to/41zmAVV" class="text-yellow-500 hover:text-yellow-400">DJI Flip</a></li>
+                        <li><a href="https://amzn.to/45Qk2Fw" class="text-yellow-500 hover:text-yellow-400">Sony A7C II</a></li>
+                        <li><a href="https://amzn.to/4gaYLJZ" class="text-yellow-500 hover:text-yellow-400">DJI Osmo Pocket 3</a></li>
+                        <li><a href="https://amzn.to/4n73D5P" class="text-yellow-500 hover:text-yellow-400">Tamron 24–200</a></li>
+                        <li><a href="https://amzn.to/46kv8CG" class="text-yellow-500 hover:text-yellow-400">RØDE Wireless PRO</a></li>
+                        <li><a href="https://amzn.to/3I5mApV" class="text-yellow-500 hover:text-yellow-400">Think Tank Backpack</a></li>
                     </ul>
                 </div>
             </div>

--- a/osakatravelguide.html
+++ b/osakatravelguide.html
@@ -70,12 +70,12 @@
         }
         .navbar {
             backdrop-filter: blur(10px);
-            background-color: rgba(255, 255, 255, 0.9);
+            background-color: rgba(26, 26, 26, 0.9);
             transition: all 0.3s ease;
         }
         .navbar.scrolled {
-            background-color: rgba(255, 255, 255, 0.98);
-            box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+            background-color: rgba(26, 26, 26, 0.98);
+            box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.3);
         }
         .mobile-menu {
             max-height: 0;
@@ -85,26 +85,29 @@
         .mobile-menu.open {
             max-height: 500px;
         }
-        .wave-shape {
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            width: 100%;
-            overflow: hidden;
-            line-height: 0;
+        .hero-overlay {
+            background: linear-gradient(180deg, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.7) 65%, rgba(0, 0, 0, 0.92) 100%);
         }
-        .wave-shape svg {
-            position: relative;
-            display: block;
-            width: calc(100% + 1.3px);
-            height: 150px;
+        .glass-card {
+            background: rgba(26, 26, 26, 0.68);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            backdrop-filter: blur(14px);
         }
-        .wave-shape .shape-fill {
-            fill: #FFFFFF;
+        .highlight-card {
+            background: rgba(15, 15, 15, 0.75);
+            border: 1px solid rgba(255, 255, 255, 0.06);
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
+        }
+        .highlight-card:hover {
+            transform: translateY(-6px);
+            box-shadow: 0 20px 45px -20px rgba(0, 0, 0, 0.5);
+        }
+        .section-title {
+            letter-spacing: 0.35em;
         }
     </style>
 </head>
-<body class="bg-gray-50 text-gray-800">
+<body class="text-gray-300">
     <!-- Navigation -->
     <nav id="navbar" class="navbar fixed w-full z-50 shadow-sm transition-all duration-300">
         <div class="container mx-auto px-6 py-3">
@@ -116,277 +119,301 @@
                     <span class="heading-font bg-gradient-to-r from-yellow-500 to-amber-600 bg-clip-text text-transparent">Carl Travels</span>
                 </a>
                 <div class="hidden md:flex items-center space-x-8">
-                    <a href="index.html" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">Home</a>
+                    <a href="index.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Home</a>
                     <a href="destinations.html" class="text-yellow-500 font-medium transition-colors">Destinations</a>
-                    <a href="videos/index.html" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">Watch</a>
-                    <a href="blog.html" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">Blog</a>
-                    <a href="gear.html" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">Gear</a>
-                    <a href="#about" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">About</a>
-                    <a href="donate.html" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">Donate</a>
-                    <a href="#contact" class="px-4 py-2 bg-gradient-to-r from-yellow-500 to-amber-600 text-white rounded-full hover:shadow-lg transition-all">Contact</a>
+                    <a href="videos/index.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Watch</a>
+                    <a href="blog.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Blog</a>
+                    <a href="gear.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Gear</a>
+                    <a href="#about" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">About</a>
+                    <a href="donate.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Donate</a>
+                    <a href="#contact" class="px-4 py-2 bg-gradient-to-r from-yellow-500 to-amber-600 text-black rounded-full hover:shadow-lg transition-all">Contact</a>
                 </div>
-                <button id="mobile-menu-button" class="md:hidden text-gray-700 focus:outline-none">
+                <button id="mobile-menu-button" class="md:hidden text-gray-300 focus:outline-none">
                     <i class="fas fa-bars text-2xl"></i>
                 </button>
             </div>
             <!-- Mobile Menu -->
             <div id="mobile-menu" class="mobile-menu md:hidden">
                 <div class="pt-4 pb-2 space-y-2">
-                    <a href="index.html" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">Home</a>
+                    <a href="index.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Home</a>
                     <a href="destinations.html" class="block px-3 py-2 rounded-md bg-yellow-900 text-yellow-500 font-medium">Destinations</a>
-                    <a href="videos/index.html" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">Watch</a>
-                    <a href="blog.html" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">Blog</a>
-                    <a href="gear.html" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">Gear</a>
-                    <a href="#about" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">About</a>
-                    <a href="donate.html" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">Donate</a>
-                    <a href="#contact" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">Contact</a>
+                    <a href="videos/index.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Watch</a>
+                    <a href="blog.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Blog</a>
+                    <a href="gear.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Gear</a>
+                    <a href="#about" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">About</a>
+                    <a href="donate.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Donate</a>
+                    <a href="#contact" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Contact</a>
                 </div>
             </div>
         </div>
     </nav>
 
     <!-- Hero Section -->
-    <section class="hero-gradient relative overflow-hidden min-h-[60vh] flex items-center pt-20">
-        <div class="wave-shape">
-            <svg data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 120" preserveAspectRatio="none">
-                <path d="M321.39,56.44c58-10.79,114.16-30.13,172-41.86,82.39-16.72,168.19-17.73,250.45-.39C823.78,31,906.67,72,985.66,92.83c70.05,18.48,146.53,26.09,214.34,3V0H0V27.35A600.21,600.21,0,0,0,321.39,56.44Z" class="shape-fill"></path>
-            </svg>
-        </div>
-        <div class="container mx-auto px-6 py-12 text-center text-white relative z-10">
-            <div class="bg-black bg-opacity-50 px-6 py-12 max-w-3xl mx-auto rounded-2xl">
-                <h1 class="heading-font text-4xl md:text-5xl font-bold mb-4">Your Ultimate Guide to a Week in Osaka</h1>
-                <p class="text-lg">Street food, side quests, and the raw pulse of Japan—discover Osaka’s unfiltered soul with insider tips from a martial arts journey.</p>
+    <section class="relative min-h-[70vh] flex items-end pt-24" style="background-image: url('https://img.youtube.com/vi/5qCfcpFk38I/maxresdefault.jpg'); background-size: cover; background-position: center;">
+        <div class="absolute inset-0 hero-overlay"></div>
+        <div class="container mx-auto px-6 py-20 relative z-10">
+            <div class="max-w-3xl">
+                <span class="section-title text-yellow-400 uppercase text-xs">Japan Street Pulse</span>
+                <h1 class="heading-font text-4xl md:text-6xl text-white mt-4 mb-6 leading-tight">Osaka: Neon, Noodles &amp; Next-Level Energy</h1>
+                <p class="text-lg md:text-xl text-gray-200 leading-relaxed">A seven-day playbook to Osaka’s wild heart—from takoyaki smoke in Dotonbori to sunrise train rides for Kyoto temples, pulled from the month I lived and trained across Kansai.</p>
+                <div class="mt-8 flex flex-wrap gap-4">
+                    <a href="#plan" class="px-6 py-3 bg-yellow-500 text-black rounded-full font-semibold hover:bg-yellow-400 transition">Build Your Osaka Week</a>
+                    <a href="#watch" class="px-6 py-3 border border-yellow-500 text-yellow-500 rounded-full font-semibold hover:bg-yellow-500 hover:text-black transition">Preview the Nightlife</a>
+                </div>
             </div>
         </div>
     </section>
 
-    <!-- Main Content with Two-Column Layout -->
-    <main id="main-content" class="max-w-7xl mx-auto px-4 py-16">
-        <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
-            <!-- Left Column: Main Sections -->
-            <div class="md:col-span-2 space-y-12">
-                <!-- Introduction -->
-                <section>
-                    <h2 class="heading-font text-2xl font-semibold mb-4 text-yellow-500">Welcome to Osaka: Japan’s Unfiltered Wildcard</h2>
-                    <p class="mb-4">I didn’t expect to fall for Osaka. Tokyo was the headliner, Kyoto the classic—but Osaka? It’s the wildcard that stole my heart. Loud, gritty, funny, and unapologetically local, it’s the Japan that doesn’t care about impressing you—it just is. I spent a month here during my martial arts journey across Japan, training in dojos and wandering neon-lit streets. That first week felt like coming home. Osaka’s unfiltered energy, from sizzling takoyaki stalls to back-alley bars with locals cracking jokes, hooked me.</p>
-                    <p class="mb-4">This 7-day guide is your ticket to Osaka’s soul, packed with street food, cultural gems, day trips, and tips only someone who’s lived it would know. Whether you’re chasing authentic Japan or just here for the chaos, let’s dive into the city with the biggest heart and the best eats.</p>
-                </section>
-
-                <!-- Where to Stay -->
-                <section>
-                    <h2 class="heading-font text-2xl font-semibold mb-4 text-yellow-500">Where to Stay: Dive into Osaka’s Core</h2>
-                    <p class="mb-4">For the full Osaka experience, stay in <strong>Namba</strong> or <strong>Shinsaibashi</strong>. These areas pulse with energy—think neon signs, street food stalls, and easy access to trains. I stayed near <strong>Suminoe</strong> for a month, a quieter residential spot with killer local ramen joints and a 15-minute train ride to the center. It’s great for a more “lived-in” vibe, but Namba’s chaos is hard to beat for first-timers.</p>
-                    <ul class="list-disc list-inside space-y-2 mb-4">
-                        <li><strong>Swissotel Nankai Osaka</strong>: Right above Namba Station, this upscale hotel is perfect for convenience and comfort. Rooms start at ¥15,000–¥25,000/night, ideal for couples or families.</li>
-                        <li><strong>Hostel Mitsuwaya Osaka</strong>: A budget-friendly gem in Shinsaibashi with dorms from ¥3,000–¥5,000/night. It’s clean, social, and steps from Dotonbori’s madness.</li>
-                        <li><strong>Airbnb in Umeda</strong>: For a business-like vibe with skyline views, Umeda offers modern apartments. Expect ¥7,000–¥12,000/night for a private flat.</li>
-                    </ul>
-                    <p><strong>Pro Tip</strong>: Get an <strong>ICOCA card</strong> (¥2,000, including ¥1,500 credit) for seamless travel on trains, buses, and even convenience stores across Kansai. Osaka’s weather can be humid—pack light, breathable clothes.</p>
-                </section>
-
-                <!-- 7-Day Itinerary -->
-                <section>
-                    <h2 class="heading-font text-2xl font-semibold mb-4 text-yellow-500">Your 7-Day Osaka Itinerary</h2>
-                    <div class="space-y-6">
-                        <!-- Day 1 -->
-                        <div>
-                            <h3 class="text-xl font-medium mb-2">Day 1: Dotonbori’s Neon Wonderland</h3>
-                            <p class="mb-4">Start in <strong>Dotonbori</strong>, Osaka’s chaotic heart. Neon signs scream for attention, and the air smells of takoyaki and okonomiyaki. Grab octopus balls from <strong>Aizuya</strong>, the OG takoyaki spot (¥600–¥800), and snap a pic with the <strong>Glico Running Man</strong>. Wander into <strong>Hozenji Yokocho</strong>, a narrow alley with tiny bars where locals sip sake next to stray cats. I spent my first night here, squeezed into a four-seat izakaya, laughing with salarymen over cheap highballs.</p>
-                            <p class="mb-4">End the night at <strong>Bar Nayuta</strong>, a cozy cocktail spot with Osaka’s best whiskey selection. Budget ¥2,000–¥3,000 for food and drinks—this is Osaka’s welcome party. Tap the dedicated watch page to feel Dotonbori’s electric vibe at night.</p>
-                            <div id="osaka-watch" class="mb-6 border border-yellow-400/40 rounded-2xl overflow-hidden bg-white/60">
-                                <div class="grid md:grid-cols-5">
-                                    <div class="md:col-span-2">
-                                        <img src="https://img.youtube.com/vi/5qCfcpFk38I/hqdefault.jpg" alt="Neon reflections along the Dotonbori canal" class="w-full h-full object-cover">
-                                    </div>
-                                    <div class="md:col-span-3 p-5 flex flex-col h-full">
-                                        <h4 class="text-lg font-semibold text-gray-800">Watch: Dotonbori at Night</h4>
-                                        <p class="text-gray-700 text-sm mt-2 flex-1">A neon-soaked walk through Osaka’s loudest street with canal cruises, takoyaki tips, and camera settings for low light.</p>
-                                        <a href="videos/osaka-dotonbori-at-night.html" class="mt-4 inline-flex items-center justify-center px-4 py-2 text-sm font-semibold rounded-full bg-gradient-to-r from-yellow-500 to-amber-500 text-white shadow hover:shadow-lg transition-all">
-                                            Open the watch page
-                                            <i class="fas fa-arrow-right ml-2"></i>
-                                        </a>
-                                    </div>
-                                </div>
-                            </div>
-                            <p><strong>Insider Tip</strong>: Dotonbori gets packed by 7 PM. Eat early (5–6 PM) to avoid lines, and watch your wallet in crowds.</p>
-                        </div>
-                        <!-- Day 2 -->
-                        <div>
-                            <h3 class="text-xl font-medium mb-2">Day 2: Osaka Castle and Chill</h3>
-                            <p class="mb-4">Head to <strong>Osaka Castle</strong> (¥600 entry), a reconstructed 16th-century fortress surrounded by a massive park. The museum inside covers the castle’s history, but the real draw is the view from the top—Osaka’s skyline framed by moats and cherry trees. In spring, the park explodes with sakura; I picnicked here with a bento from <strong>Lawson</strong> (¥500–¥800) and felt the city pause.</p>
-                            <p class="mb-4">Afterward, stroll to <strong>Tamatsukuri</strong> for quiet cafes like <strong>Lilo Coffee Roasters</strong>. Grab dinner at <strong>Okonomiyaki Mizuno</strong> in Dotonbori for savory pancakes (¥1,200–¥2,000). This day balances history and calm.</p>
-                        </div>
-                        <!-- Day 3 -->
-                        <div>
-                            <h3 class="text-xl font-medium mb-2">Day 3: Kuromon Market & Den Den Town</h3>
-                            <p class="mb-4">Spend the morning at <strong>Kuromon Ichiba Market</strong>, Osaka’s foodie paradise. Sample <strong>wagyu skewers</strong> (¥1,000–¥2,000), <strong>grilled eel</strong> (¥800), or <strong>sea urchin</strong> straight from the shell (¥1,500). It’s touristy but worth it—just confirm prices before eating. I got hooked on fresh tuna sashimi here, scarfing it down between stalls.</p>
-                            <p class="mb-4">Then hit <strong>Den Den Town</strong>, Osaka’s nerd haven. Think retro Game Boys, anime figurines, and electronics shops like <strong>Super Potato</strong>. It’s less intense than Tokyo’s Akihabara but just as fun. End with ramen at <strong>Ichiran</strong> in Namba (¥1,000–¥1,500)—customize your spice level and slurp away.</p>
-                        </div>
-                        <!-- Day 4 -->
-                        <div>
-                            <h3 class="text-xl font-medium mb-2">Day 4: Expo '70 Commemorative Park</h3>
-                            <p class="mb-4">Take the Osaka Monorail from Senri-Chuo Station to <strong>Expo '70 Commemorative Park</strong> (30–40 minutes, ¥400–¥600 round-trip). This retro-futuristic park, site of the 1970 World Expo, feels like a sci-fi movie set. The <strong>Tower of the Sun</strong> by Taro Okamoto is a bizarre, iconic statue—part creepy, part awe-inspiring. Explore Japanese gardens, the <strong>National Museum of Ethnology</strong> (¥600), or just wander the quiet paths. With Expo 2025 coming, it’s a cool preview of Osaka’s global stage—watch the dedicated film before you go.</p>
-                            <div class="mb-6 border border-yellow-400/40 rounded-2xl overflow-hidden bg-white/60">
-                                <div class="grid md:grid-cols-5">
-                                    <div class="md:col-span-2">
-                                        <img src="https://img.youtube.com/vi/mZF3X5DSxIM/hqdefault.jpg" alt="Tower of the Sun at Expo '70 Park" class="w-full h-full object-cover">
-                                    </div>
-                                    <div class="md:col-span-3 p-5 flex flex-col h-full">
-                                        <h4 class="text-lg font-semibold text-gray-800">Watch: Expo '70 Park Daytrip</h4>
-                                        <p class="text-gray-700 text-sm mt-2 flex-1">Ride the monorail, learn the park’s world-fair history, and stroll tea gardens in this narrated field guide.</p>
-                                        <a href="videos/osaka-expo-70-park-journey.html" class="mt-4 inline-flex items-center justify-center px-4 py-2 text-sm font-semibold rounded-full bg-gradient-to-r from-yellow-500 to-amber-500 text-white shadow hover:shadow-lg transition-all">
-                                            Open the watch page
-                                            <i class="fas fa-arrow-right ml-2"></i>
-                                        </a>
-                                    </div>
-                                </div>
-                            </div>
-                            <p class="mb-4">Entry is ¥260, with extra fees for exhibits. Pack a picnic from a <strong>7-Eleven</strong> to save cash. Back in Osaka, relax at <strong>Spa World</strong> in Shinsekai for themed onsen baths (¥1,500–¥2,000).</p>
-                        </div>
-                        <!-- Day 5 -->
-                        <div>
-                            <h3 class="text-xl font-medium mb-2">Day 5: Day Trip to Kobe</h3>
-                            <p class="mb-4">Catch a JR Special Rapid from Osaka Station to Kobe (25–30 minutes, ¥410 one-way). Skip the aquarium and head to <strong>Harborland</strong> for waterfront views and the <strong>Kobe Earthquake Memorial</strong>, a poignant reminder of the 1995 disaster. Stroll through <strong>Nankinmachi</strong> (Chinatown) for steamed buns (¥300–¥500).</p>
-                            <p class="mb-4">If budget allows, try <strong>Kobe beef</strong> at <strong>Steakland Kobe</strong>—lunch sets start at ¥3,000 for a small portion of that melt-in-your-mouth magic. I splurged here once and still dream about it—watch the full Kobe beef pilgrimage for the experience. Return to Osaka for drinks at <strong>Bar K</strong> in Shinsaibashi, a hidden gem for craft cocktails (¥1,000–¥2,000).</p>
-                            <div class="mb-6 border border-yellow-400/40 rounded-2xl overflow-hidden bg-white/60">
-                                <div class="grid md:grid-cols-5">
-                                    <div class="md:col-span-2">
-                                        <img src="https://img.youtube.com/vi/GuSrgoggQCI/hqdefault.jpg" alt="Chef searing Kobe beef on a teppanyaki grill" class="w-full h-full object-cover">
-                                    </div>
-                                    <div class="md:col-span-3 p-5 flex flex-col h-full">
-                                        <h4 class="text-lg font-semibold text-gray-800">Watch: Kobe Beef Pilgrimage</h4>
-                                        <p class="text-gray-700 text-sm mt-2 flex-1">Ride the JR Special Rapid, sit ringside at the teppan, and learn how to order authentic Kobe beef without surprises.</p>
-                                        <a href="videos/osaka-kobe-beef-experience.html" class="mt-4 inline-flex items-center justify-center px-4 py-2 text-sm font-semibold rounded-full bg-gradient-to-r from-yellow-500 to-amber-500 text-white shadow hover:shadow-lg transition-all">
-                                            Open the watch page
-                                            <i class="fas fa-arrow-right ml-2"></i>
-                                        </a>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <!-- Day 6 -->
-                        <div>
-                            <h3 class="text-xl font-medium mb-2">Day 6: Day Trip to Kyoto</h3>
-                            <p class="mb-4">Kyoto’s just 30 minutes away via JR Special Rapid or Keihan Main Line (¥420–¥570 one-way). Pick one or two spots to avoid overwhelm: <strong>Fushimi Inari Shrine</strong> for its iconic red torii gates (arrive by 7 AM to beat crowds), <strong>Gion</strong> for geisha-spotting in historic alleys, <strong>Kiyomizu-dera</strong> for temple views, or the serene <strong>Philosopher’s Path</strong>. I meditated at a small temple near Gion during my martial arts trip—Kyoto’s calm was the perfect counterpoint to Osaka’s chaos.</p>
-                            <p class="mb-4">Grab lunch at <strong>Nishiki Market</strong> (try tamago sandwiches, ¥400–¥600). Back in Osaka, dine at <strong>Yakiniku M</strong> in Namba for DIY grilled meat (¥2,000–¥3,000).</p>
-                        </div>
-                        <!-- Day 7 -->
-                        <div>
-                            <h3 class="text-xl font-medium mb-2">Day 7: Shinsekai & Umeda Sky Building</h3>
-                            <p class="mb-4">Explore <strong>Shinsekai</strong>, a retro neighborhood frozen in the 1960s. Munch on <strong>kushikatsu</strong> (fried skewers, ¥100–¥300 each) at <strong>Yaekatsu</strong>, try your luck at crane games, or climb <strong>Tsutenkaku Tower</strong> (¥900) for quirky views. This area feels like Osaka’s soul—gruff but warm.</p>
-                            <p class="mb-4">End your week at the <strong>Umeda Sky Building</strong>’s Floating Garden Observatory (¥1,500). The 360° sunset views are unreal—I watched the city light up here and felt Osaka’s heartbeat. Celebrate with drinks at <strong>The 33rd Tea & Bar</strong> nearby (¥1,000–¥2,000).</p>
-                        </div>
-                    </div>
-                </section>
-
-                <!-- Common Tourist Mistakes -->
-                <section>
-                    <h2 class="heading-font text-2xl font-semibold mb-4 text-yellow-500">Common Tourist Mistakes to Avoid</h2>
-                    <p class="mb-4">Osaka’s welcoming, but a few missteps can trip you up:</p>
-                    <ul class="list-disc list-inside space-y-2 mb-4">
-                        <li><strong>Bar Scams in Namba</strong>: “Friendly locals” may invite you to bars with hidden fees (¥10,000+ bills). Stick to reputable spots or ask for prices upfront.</li>
-                        <li><strong>Overpaying at Markets</strong>: Kuromon vendors sometimes charge tourists extra. Confirm prices before ordering—¥1,000 for a skewer is standard, not ¥3,000.</li>
-                        <li><strong>Train Confusion</strong>: Osaka’s rail system (JR, Keihan, Hankyu) is layered. Use Google Maps, but verify if it’s a Local, Rapid, or Limited Express train to avoid delays.</li>
-                        <li><strong>Women-Only Carriages</strong>: During rush hours (7–9 AM, 5–7 PM), some trains have women-only cars. Look for pink signs to avoid embarrassment.</li>
-                        <li><strong>Ignoring Etiquette</strong>: Don’t eat or talk loudly on trains. Bow slightly when thanking shop staff—it’s appreciated.</li>
-                    </ul>
-                    <p><strong>Pro Tip</strong>: If someone’s overly pushy about a bar or deal, politely decline with “Daijoubu desu” (I’m okay) and walk away.</p>
-                </section>
-
-                <!-- Bonus Tips -->
-                <section>
-                    <h2 class="heading-font text-2xl font-semibold mb-4 text-yellow-500">Bonus Tips for Your Osaka Adventure</h2>
-                    <ul class="list-disc list-inside space-y-2 mb-4">
-                        <li><strong>Cash is King</strong>: Many small eateries and shops don’t take cards. Carry ¥5,000–¥10,000 in cash daily; ATMs at <strong>7-Eleven</strong> or <strong>Japan Post</strong> are reliable.</li>
-                        <li><strong>Last Trains</strong>: Trains stop around midnight. Check Hyperdia or Google Maps for your last train to avoid pricey taxis (¥2,000–¥5,000).</li>
-                        <li><strong>Convenience Stores</strong>: <strong>7-Eleven</strong>, <strong>Lawson</strong>, and <strong>FamilyMart</strong> are lifesavers for snacks (onigiri, ¥150–¥300), SIM cards, ATMs, and umbrellas (¥500).</li>
-                        <li><strong>Learn Basic Japanese</strong>: “Arigatou” (thank you), “Sumimasen” (excuse me), and “Oishii” (delicious) win smiles. Locals love when you try.</li>
-                        <li><strong>Stay Curious</strong>: Osaka rewards spontaneity. Follow a random alley, chat with a vendor, or join a late-night izakaya table—that’s where the magic happens.</li>
-                    </ul>
-                    <p class="mb-4">Final thought: Osaka has a heartbeat. It’s not polished like Kyoto or intense like Tokyo. It’s the drunk uncle with the best food, the worst jokes, and the biggest heart. From the retro-futurism of Expo ’70 to the raw flavors of Kuromon and the serenity of Kyoto’s temples, Osaka feels like the real Japan. Don’t just visit—live it, even for a week. You’ll leave wanting to come back.</p>
-                </section>
+    <!-- Highlights Strip -->
+    <section class="py-16 bg-[#101010]">
+        <div class="container mx-auto px-6">
+            <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-4">
+                <div class="highlight-card rounded-3xl p-8">
+                    <div class="text-yellow-400 text-3xl mb-4"><i class="fas fa-bowl-rice"></i></div>
+                    <h3 class="heading-font text-2xl text-white mb-3">Street Food Capital</h3>
+                    <p class="text-gray-300 leading-relaxed">Takoyaki, okonomiyaki, kushikatsu—Osaka serves Japan’s boldest flavors at every corner stall.</p>
+                </div>
+                <div class="highlight-card rounded-3xl p-8">
+                    <div class="text-yellow-400 text-3xl mb-4"><i class="fas fa-city"></i></div>
+                    <h3 class="heading-font text-2xl text-white mb-3">Neon Playground</h3>
+                    <p class="text-gray-300 leading-relaxed">Dive into Dotonbori’s glow, retro Shinsekai arcades, and rooftop cocktails above the skyline.</p>
+                </div>
+                <div class="highlight-card rounded-3xl p-8">
+                    <div class="text-yellow-400 text-3xl mb-4"><i class="fas fa-train-subway"></i></div>
+                    <h3 class="heading-font text-2xl text-white mb-3">Day Trip Hub</h3>
+                    <p class="text-gray-300 leading-relaxed">Launch into Kyoto, Kobe, and Expo ’70 Park with easy rapid trains and monorail hops.</p>
+                </div>
+                <div class="highlight-card rounded-3xl p-8">
+                    <div class="text-yellow-400 text-3xl mb-4"><i class="fas fa-hand-fist"></i></div>
+                    <h3 class="heading-font text-2xl text-white mb-3">Martial Arts Roots</h3>
+                    <p class="text-gray-300 leading-relaxed">Find dojos, wellness onsens, and quiet alleys that balance the city’s high-voltage pace.</p>
+                </div>
             </div>
+        </div>
+    </section>
 
-            <!-- Right Column: Sidebar with Highlights & Practical Info -->
-            <aside class="space-y-12">
-                <!-- Highlights -->
-                <section class="bg-white p-6 rounded-lg shadow-md">
-                    <h3 class="heading-font text-xl font-semibold mb-4 text-gray-800">Osaka Highlights</h3>
-                    <ul class="list-disc list-inside space-y-2">
-                        <li><strong>Dotonbori</strong>: Neon-lit chaos with takoyaki and back-alley bars.</li>
-                        <li><strong>Osaka Castle</strong>: Historic fortress with serene park views.</li>
-                        <li><strong>Kuromon Market</strong>: Street food haven for wagyu and seafood.</li>
-                        <li><strong>Shinsekai</strong>: Retro 1960s vibe with kushikatsu and Tsutenkaku Tower.</li>
-                        <li><strong>Umeda Sky Building</strong>: Panoramic sunset views from a futuristic observatory.</li>
-                    </ul>
-                </section>
+    <!-- Main Content -->
+    <main class="bg-[#060606] py-16" id="plan">
+        <div class="container mx-auto px-6">
+            <div class="grid gap-12 lg:grid-cols-[2fr_1fr] items-start">
+                <div class="space-y-10">
+                    <section class="glass-card rounded-3xl p-8 space-y-6">
+                        <h2 class="heading-font text-3xl text-white">Welcome to Osaka: Japan’s Unfiltered Wildcard</h2>
+                        <p class="text-gray-300 leading-relaxed">I didn’t expect to fall for Osaka. Tokyo was the headliner, Kyoto the classic—but Osaka? It’s the wildcard that stole my heart. Loud, gritty, funny, and unapologetically local, it’s the Japan that doesn’t care about impressing you—it just is. I spent a month here during my martial arts journey across Japan, training in dojos and wandering neon-lit streets. That first week felt like coming home. Osaka’s unfiltered energy, from sizzling takoyaki stalls to back-alley bars with locals cracking jokes, hooked me.</p>
+                        <p class="text-gray-300 leading-relaxed">This 7-day guide is your ticket to Osaka’s soul, packed with street food, cultural gems, day trips, and tips only someone who’s lived it would know. Whether you’re chasing authentic Japan or just here for the chaos, let’s dive into the city with the biggest heart and the best eats.</p>
+                    </section>
 
-                <!-- Practical Information -->
-                <section class="bg-white p-6 rounded-lg shadow-md">
-                    <h3 class="heading-font text-xl font-semibold mb-4 text-gray-800">Practical Information</h3>
-                    <h4 class="font-medium mt-2">Transportation</h4>
-                    <ul class="list-disc list-inside space-y-2 mb-4">
-                        <li><strong>Subway & JR</strong>: Fast and reliable. ICOCA card (¥2,000) covers most routes.</li>
-                        <li><strong>Osaka Monorail</strong>: For Expo ’70 Park. ¥200–¥400 one-way.</li>
-                        <li><strong>Buses</strong>: Useful for Shinsekai. Included in ICOCA.</li>
-                    </ul>
-                    <h4 class="font-medium mt-2">Accommodation</h4>
-                    <ul class="list-disc list-inside space-y-2 mb-4">
-                        <li><strong>Namba/Shinsaibashi</strong>: Central, vibrant. ¥3,000–¥25,000/night.</li>
-                        <li><strong>Umeda</strong>: Modern, skyline views. ¥7,000–¥15,000/night.</li>
-                        <li><strong>Suminoe</strong>: Quiet, local vibe. ¥5,000–¥10,000/night.</li>
-                    </ul>
-                    <h4 class="font-medium mt-2">Budgeting</h4>
-                    <p class="mb-4">Expect <strong>¥8,000–¥15,000/day</strong> for budget travelers (hostel, street food, ICOCA). Add ¥5,000–¥10,000/day for mid-range stays and dining.</p>
-                    <h4 class="font-medium mt-2">Safety</h4>
-                    <p>Osaka is very safe, but avoid flashing valuables in crowded Dotonbori. Stick to well-lit areas in Shinsekai at night.</p>
-                </section>
-            </aside>
+                    <section class="glass-card rounded-3xl p-8 space-y-6">
+                        <h2 class="heading-font text-3xl text-white">Where to Stay: Dive into Osaka’s Core</h2>
+                        <p class="text-gray-300 leading-relaxed">For the full Osaka experience, stay in <strong>Namba</strong> or <strong>Shinsaibashi</strong>. These areas pulse with energy—think neon signs, street food stalls, and easy access to trains. I stayed near <strong>Suminoe</strong> for a month, a quieter residential spot with killer local ramen joints and a 15-minute train ride to the center. It’s great for a more “lived-in” vibe, but Namba’s chaos is hard to beat for first-timers.</p>
+                        <ul class="list-disc list-inside space-y-2 text-gray-300">
+                            <li><strong>Swissotel Nankai Osaka</strong>: Right above Namba Station, this upscale hotel is perfect for convenience and comfort. Rooms start at ¥15,000–¥25,000/night, ideal for couples or families.</li>
+                            <li><strong>Hostel Mitsuwaya Osaka</strong>: A budget-friendly gem in Shinsaibashi with dorms from ¥3,000–¥5,000/night. It’s clean, social, and steps from Dotonbori’s madness.</li>
+                            <li><strong>Airbnb in Umeda</strong>: For a business-like vibe with skyline views, Umeda offers modern apartments. Expect ¥7,000–¥12,000/night for a private flat.</li>
+                        </ul>
+                        <p class="text-gray-300"><strong>Pro Tip</strong>: Get an <strong>ICOCA card</strong> (¥2,000, including ¥1,500 credit) for seamless travel on trains, buses, and even convenience stores across Kansai. Osaka’s weather can be humid—pack light, breathable clothes.</p>
+                    </section>
+
+                    <section class="glass-card rounded-3xl p-8 space-y-8">
+                        <h2 class="heading-font text-3xl text-white">Your 7-Day Osaka Itinerary</h2>
+                        <div class="space-y-8">
+                            <div class="border-l-4 border-yellow-500 pl-6 space-y-4" id="watch">
+                                <h3 class="text-2xl text-white font-semibold">Day 1: Dotonbori’s Neon Wonderland</h3>
+                                <p class="text-gray-300 leading-relaxed">Start in <strong>Dotonbori</strong>, Osaka’s chaotic heart. Neon signs scream for attention, and the air smells of takoyaki and okonomiyaki. Grab octopus balls from <strong>Aizuya</strong>, the OG takoyaki spot (¥600–¥800), and snap a pic with the <strong>Glico Running Man</strong>. Wander into <strong>Hozenji Yokocho</strong>, a narrow alley with tiny bars where locals sip sake next to stray cats. I spent my first night here, squeezed into a four-seat izakaya, laughing with salarymen over cheap highballs.</p>
+                                <p class="text-gray-300 leading-relaxed">End the night at <strong>Bar Nayuta</strong>, a cozy cocktail spot with Osaka’s best whiskey selection. Budget ¥2,000–¥3,000 for food and drinks—this is Osaka’s welcome party. Tap the dedicated watch page to feel Dotonbori’s electric vibe at night.</p>
+                                <div class="glass-card border border-yellow-500/30 rounded-2xl overflow-hidden p-0">
+                                    <div class="grid md:grid-cols-5">
+                                        <div class="md:col-span-2">
+                                            <img src="https://img.youtube.com/vi/5qCfcpFk38I/hqdefault.jpg" alt="Neon reflections along the Dotonbori canal" class="w-full h-full object-cover">
+                                        </div>
+                                        <div class="md:col-span-3 p-6 flex flex-col h-full bg-black/40">
+                                            <h4 class="text-lg font-semibold text-white">Watch: Dotonbori at Night</h4>
+                                            <p class="text-gray-300 text-sm mt-2 flex-1">A neon-soaked walk through Osaka’s loudest street with canal cruises, takoyaki tips, and camera settings for low light.</p>
+                                            <a href="videos/osaka-dotonbori-at-night.html" class="mt-4 inline-flex items-center justify-center px-4 py-2 text-sm font-semibold rounded-full bg-gradient-to-r from-yellow-500 to-amber-500 text-black shadow hover:shadow-lg transition-all">
+                                                Open the watch page
+                                                <i class="fas fa-arrow-right ml-2"></i>
+                                            </a>
+                                        </div>
+                                    </div>
+                                </div>
+                                <p class="text-gray-300"><strong>Insider Tip</strong>: Dotonbori gets packed by 7 PM. Eat early (5–6 PM) to avoid lines, and watch your wallet in crowds.</p>
+                            </div>
+                            <div class="border-l-4 border-yellow-500 pl-6 space-y-4">
+                                <h3 class="text-2xl text-white font-semibold">Day 2: Osaka Castle and Chill</h3>
+                                <p class="text-gray-300 leading-relaxed">Head to <strong>Osaka Castle</strong> (¥600 entry), a reconstructed 16th-century fortress surrounded by a massive park. The museum inside covers the castle’s history, but the real draw is the view from the top—Osaka’s skyline framed by moats and cherry trees. In spring, the park explodes with sakura; I picnicked here with a bento from <strong>Lawson</strong> (¥500–¥800) and felt the city pause.</p>
+                                <p class="text-gray-300 leading-relaxed">Afterward, stroll to <strong>Tamatsukuri</strong> for quiet cafes like <strong>Lilo Coffee Roasters</strong>. Grab dinner at <strong>Okonomiyaki Mizuno</strong> in Dotonbori for savory pancakes (¥1,200–¥2,000). This day balances history and calm.</p>
+                            </div>
+                            <div class="border-l-4 border-yellow-500 pl-6 space-y-4">
+                                <h3 class="text-2xl text-white font-semibold">Day 3: Kuromon Market &amp; Den Den Town</h3>
+                                <p class="text-gray-300 leading-relaxed">Spend the morning at <strong>Kuromon Ichiba Market</strong>, Osaka’s foodie paradise. Sample <strong>wagyu skewers</strong> (¥1,000–¥2,000), <strong>grilled eel</strong> (¥800), or <strong>sea urchin</strong> straight from the shell (¥1,500). It’s touristy but worth it—just confirm prices before eating. I got hooked on fresh tuna sashimi here, scarfing it down between stalls.</p>
+                                <p class="text-gray-300 leading-relaxed">Then hit <strong>Den Den Town</strong>, Osaka’s nerd haven. Think retro Game Boys, anime figurines, and electronics shops like <strong>Super Potato</strong>. It’s less intense than Tokyo’s Akihabara but just as fun. End with ramen at <strong>Ichiran</strong> in Namba (¥1,000–¥1,500)—customize your spice level and slurp away.</p>
+                            </div>
+                            <div class="border-l-4 border-yellow-500 pl-6 space-y-4">
+                                <h3 class="text-2xl text-white font-semibold">Day 4: Expo '70 Commemorative Park</h3>
+                                <p class="text-gray-300 leading-relaxed">Take the Osaka Monorail from Senri-Chuo Station to <strong>Expo '70 Commemorative Park</strong> (30–40 minutes, ¥400–¥600 round-trip). This retro-futuristic park, site of the 1970 World Expo, feels like a sci-fi movie set. The <strong>Tower of the Sun</strong> by Taro Okamoto is a bizarre, iconic statue—part creepy, part awe-inspiring. Explore Japanese gardens, the <strong>National Museum of Ethnology</strong> (¥600), or just wander the quiet paths. With Expo 2025 coming, it’s a cool preview of Osaka’s global stage—watch the dedicated film before you go.</p>
+                                <div class="glass-card border border-yellow-500/30 rounded-2xl overflow-hidden p-0">
+                                    <div class="grid md:grid-cols-5">
+                                        <div class="md:col-span-2">
+                                            <img src="https://img.youtube.com/vi/mZF3X5DSxIM/hqdefault.jpg" alt="Tower of the Sun at Expo '70 Park" class="w-full h-full object-cover">
+                                        </div>
+                                        <div class="md:col-span-3 p-6 flex flex-col h-full bg-black/40">
+                                            <h4 class="text-lg font-semibold text-white">Watch: Expo '70 Park Daytrip</h4>
+                                            <p class="text-gray-300 text-sm mt-2 flex-1">Ride the monorail, learn the park’s world-fair history, and stroll tea gardens in this narrated field guide.</p>
+                                            <a href="videos/osaka-expo-70-park-journey.html" class="mt-4 inline-flex items-center justify-center px-4 py-2 text-sm font-semibold rounded-full bg-gradient-to-r from-yellow-500 to-amber-500 text-black shadow hover:shadow-lg transition-all">
+                                                Open the watch page
+                                                <i class="fas fa-arrow-right ml-2"></i>
+                                            </a>
+                                        </div>
+                                    </div>
+                                </div>
+                                <p class="text-gray-300 leading-relaxed">Entry is ¥260, with extra fees for exhibits. Pack a picnic from a <strong>7-Eleven</strong> to save cash. Back in Osaka, relax at <strong>Spa World</strong> in Shinsekai for themed onsen baths (¥1,500–¥2,000).</p>
+                            </div>
+                            <div class="border-l-4 border-yellow-500 pl-6 space-y-4">
+                                <h3 class="text-2xl text-white font-semibold">Day 5: Day Trip to Kobe</h3>
+                                <p class="text-gray-300 leading-relaxed">Catch a JR Special Rapid from Osaka Station to Kobe (25–30 minutes, ¥410 one-way). Skip the aquarium and head to <strong>Harborland</strong> for waterfront views and the <strong>Kobe Earthquake Memorial</strong>, a poignant reminder of the 1995 disaster. Stroll through <strong>Nankinmachi</strong> (Chinatown) for steamed buns (¥300–¥500).</p>
+                                <p class="text-gray-300 leading-relaxed">If budget allows, try <strong>Kobe beef</strong> at <strong>Steakland Kobe</strong>—lunch sets start at ¥3,000 for a small portion of that melt-in-your-mouth magic. I splurged here once and still dream about it—watch the full Kobe beef pilgrimage for the experience. Return to Osaka for drinks at <strong>Bar K</strong> in Shinsaibashi, a hidden gem for craft cocktails (¥1,000–¥2,000).</p>
+                                <div class="glass-card border border-yellow-500/30 rounded-2xl overflow-hidden p-0">
+                                    <div class="grid md:grid-cols-5">
+                                        <div class="md:col-span-2">
+                                            <img src="https://img.youtube.com/vi/GuSrgoggQCI/hqdefault.jpg" alt="Chef searing Kobe beef on a teppanyaki grill" class="w-full h-full object-cover">
+                                        </div>
+                                        <div class="md:col-span-3 p-6 flex flex-col h-full bg-black/40">
+                                            <h4 class="text-lg font-semibold text-white">Watch: Kobe Beef Pilgrimage</h4>
+                                            <p class="text-gray-300 text-sm mt-2 flex-1">Ride the JR Special Rapid, sit ringside at the teppan, and learn how to order authentic Kobe beef without surprises.</p>
+                                            <a href="videos/osaka-kobe-beef-experience.html" class="mt-4 inline-flex items-center justify-center px-4 py-2 text-sm font-semibold rounded-full bg-gradient-to-r from-yellow-500 to-amber-500 text-black shadow hover:shadow-lg transition-all">
+                                                Open the watch page
+                                                <i class="fas fa-arrow-right ml-2"></i>
+                                            </a>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="border-l-4 border-yellow-500 pl-6 space-y-4">
+                                <h3 class="text-2xl text-white font-semibold">Day 6: Day Trip to Kyoto</h3>
+                                <p class="text-gray-300 leading-relaxed">Kyoto’s just 30 minutes away via JR Special Rapid or Keihan Main Line (¥420–¥570 one-way). Pick one or two spots to avoid overwhelm: <strong>Fushimi Inari Shrine</strong> for its iconic red torii gates (arrive by 7 AM to beat crowds), <strong>Gion</strong> for geisha-spotting in historic alleys, <strong>Kiyomizu-dera</strong> for temple views, or the serene <strong>Philosopher’s Path</strong>. I meditated at a small temple near Gion during my martial arts trip—Kyoto’s calm was the perfect counterpoint to Osaka’s chaos.</p>
+                                <p class="text-gray-300 leading-relaxed">Grab lunch at <strong>Nishiki Market</strong> (try tamago sandwiches, ¥400–¥600). Back in Osaka, dine at <strong>Yakiniku M</strong> in Namba for DIY grilled meat (¥2,000–¥3,000).</p>
+                            </div>
+                            <div class="border-l-4 border-yellow-500 pl-6 space-y-4">
+                                <h3 class="text-2xl text-white font-semibold">Day 7: Shinsekai &amp; Umeda Sky Building</h3>
+                                <p class="text-gray-300 leading-relaxed">Explore <strong>Shinsekai</strong>, a retro neighborhood frozen in the 1960s. Munch on <strong>kushikatsu</strong> (fried skewers, ¥100–¥300 each) at <strong>Yaekatsu</strong>, try your luck at crane games, or climb <strong>Tsutenkaku Tower</strong> (¥900) for quirky views. This area feels like Osaka’s soul—gruff but warm.</p>
+                                <p class="text-gray-300 leading-relaxed">End your week at the <strong>Umeda Sky Building</strong>’s Floating Garden Observatory (¥1,500). The 360° sunset views are unreal—I watched the city light up here and felt Osaka’s heartbeat. Celebrate with drinks at <strong>The 33rd Tea &amp; Bar</strong> nearby (¥1,000–¥2,000).</p>
+                            </div>
+                        </div>
+                    </section>
+
+                    <section class="glass-card rounded-3xl p-8 space-y-6">
+                        <h2 class="heading-font text-3xl text-white">Common Tourist Mistakes to Avoid</h2>
+                        <p class="text-gray-300 leading-relaxed">Osaka’s welcoming, but a few missteps can trip you up:</p>
+                        <ul class="list-disc list-inside space-y-3 text-gray-300">
+                            <li><strong>Bar Scams in Namba</strong>: “Friendly locals” may invite you to bars with hidden fees (¥10,000+ bills). Stick to reputable spots or ask for prices upfront.</li>
+                            <li><strong>Overpaying at Markets</strong>: Kuromon vendors sometimes charge tourists extra. Confirm prices before ordering—¥1,000 for a skewer is standard, not ¥3,000.</li>
+                            <li><strong>Train Confusion</strong>: Osaka’s rail system (JR, Keihan, Hankyu) is layered. Use Google Maps, but verify if it’s a Local, Rapid, or Limited Express train to avoid delays.</li>
+                            <li><strong>Women-Only Carriages</strong>: During rush hours (7–9 AM, 5–7 PM), some trains have women-only cars. Look for pink signs to avoid embarrassment.</li>
+                            <li><strong>Ignoring Etiquette</strong>: Don’t eat or talk loudly on trains. Bow slightly when thanking shop staff—it’s appreciated.</li>
+                        </ul>
+                        <p class="text-gray-300"><strong>Pro Tip</strong>: If someone’s overly pushy about a bar or deal, politely decline with “Daijoubu desu” (I’m okay) and walk away.</p>
+                    </section>
+
+                    <section class="glass-card rounded-3xl p-8 space-y-6">
+                        <h2 class="heading-font text-3xl text-white">Bonus Tips for Your Osaka Adventure</h2>
+                        <ul class="list-disc list-inside space-y-3 text-gray-300">
+                            <li><strong>Cash is King</strong>: Many small eateries and shops don’t take cards. Carry ¥5,000–¥10,000 in cash daily; ATMs at <strong>7-Eleven</strong> or <strong>Japan Post</strong> are reliable.</li>
+                            <li><strong>Last Trains</strong>: Trains stop around midnight. Check Hyperdia or Google Maps for your last train to avoid pricey taxis (¥2,000–¥5,000).</li>
+                            <li><strong>Convenience Stores</strong>: <strong>7-Eleven</strong>, <strong>Lawson</strong>, and <strong>FamilyMart</strong> are lifesavers for snacks (onigiri, ¥150–¥300), SIM cards, ATMs, and umbrellas (¥500).</li>
+                            <li><strong>Learn Basic Japanese</strong>: “Arigatou” (thank you), “Sumimasen” (excuse me), and “Oishii” (delicious) win smiles. Locals love when you try.</li>
+                            <li><strong>Stay Curious</strong>: Osaka rewards spontaneity. Follow a random alley, chat with a vendor, or join a late-night izakaya table—that’s where the magic happens.</li>
+                        </ul>
+                        <p class="text-gray-300 leading-relaxed">Final thought: Osaka has a heartbeat. It’s not polished like Kyoto or intense like Tokyo. It’s the drunk uncle with the best food, the worst jokes, and the biggest heart. From the retro-futurism of Expo ’70 to the raw flavors of Kuromon and the serenity of Kyoto’s temples, Osaka feels like the real Japan. Don’t just visit—live it, even for a week. You’ll leave wanting to come back.</p>
+                    </section>
+                </div>
+
+                <aside class="space-y-8">
+                    <section class="glass-card rounded-3xl p-8 space-y-4">
+                        <h3 class="heading-font text-2xl text-white">Osaka Highlights</h3>
+                        <ul class="list-disc list-inside space-y-2 text-gray-300">
+                            <li><strong>Dotonbori</strong>: Neon-lit chaos with takoyaki and back-alley bars.</li>
+                            <li><strong>Osaka Castle</strong>: Historic fortress with serene park views.</li>
+                            <li><strong>Kuromon Market</strong>: Street food haven for wagyu and seafood.</li>
+                            <li><strong>Shinsekai</strong>: Retro 1960s vibe with kushikatsu and Tsutenkaku Tower.</li>
+                            <li><strong>Umeda Sky Building</strong>: Panoramic sunset views from a futuristic observatory.</li>
+                        </ul>
+                    </section>
+
+                    <section class="glass-card rounded-3xl p-8 space-y-4">
+                        <h3 class="heading-font text-2xl text-white">Practical Information</h3>
+                        <div>
+                            <h4 class="text-yellow-400 font-semibold uppercase tracking-wide text-xs">Transportation</h4>
+                            <ul class="list-disc list-inside space-y-2 text-gray-300 mt-2">
+                                <li><strong>Subway &amp; JR</strong>: Fast and reliable. ICOCA card (¥2,000) covers most routes.</li>
+                                <li><strong>Osaka Monorail</strong>: For Expo ’70 Park. ¥200–¥400 one-way.</li>
+                                <li><strong>Buses</strong>: Useful for Shinsekai. Included in ICOCA.</li>
+                            </ul>
+                        </div>
+                        <div>
+                            <h4 class="text-yellow-400 font-semibold uppercase tracking-wide text-xs">Accommodation</h4>
+                            <ul class="list-disc list-inside space-y-2 text-gray-300 mt-2">
+                                <li><strong>Namba/Shinsaibashi</strong>: Central, vibrant. ¥3,000–¥25,000/night.</li>
+                                <li><strong>Umeda</strong>: Modern, skyline views. ¥7,000–¥15,000/night.</li>
+                                <li><strong>Suminoe</strong>: Quiet, local vibe. ¥5,000–¥10,000/night.</li>
+                            </ul>
+                        </div>
+                        <div>
+                            <h4 class="text-yellow-400 font-semibold uppercase tracking-wide text-xs">Budgeting</h4>
+                            <p class="text-gray-300 leading-relaxed mt-2">Expect <strong>¥8,000–¥15,000/day</strong> for budget travelers (hostel, street food, ICOCA). Add ¥5,000–¥10,000/day for mid-range stays and dining.</p>
+                        </div>
+                        <div>
+                            <h4 class="text-yellow-400 font-semibold uppercase tracking-wide text-xs">Safety</h4>
+                            <p class="text-gray-300 leading-relaxed mt-2">Osaka is very safe, but avoid flashing valuables in crowded Dotonbori. Stick to well-lit areas in Shinsekai at night.</p>
+                        </div>
+                    </section>
+                </aside>
+            </div>
         </div>
     </main>
 
     <!-- Travel Essentials & Creator Gear -->
-    <section class="py-16 bg-gray-100">
+    <section class="py-16 bg-[#0b0b0b]" id="essentials">
         <div class="container mx-auto px-6">
             <div class="text-center mb-12">
-                <h2 class="heading-font text-3xl md:text-4xl font-bold text-gray-800 mb-4">Travel Essentials &amp; Creator Gear</h2>
-                <div class="w-20 h-1 bg-yellow-500 mx-auto"></div>
+                <span class="section-title text-yellow-400 uppercase text-xs">Creator Corner</span>
+                <h2 class="heading-font text-3xl md:text-4xl text-white mt-4">Travel Essentials &amp; Creator Gear</h2>
+                <p class="text-gray-400 mt-3 max-w-2xl mx-auto">Trusted links, tools, and camera kit that keep Kansai trips smooth—from instant data to the rigs I use in Japan’s humidity.</p>
             </div>
-            <div class="max-w-3xl mx-auto space-y-10">
-                <div>
-                    <h3 class="text-xl font-bold text-gray-800 mb-4">🌍 TRAVEL ESSENTIALS</h3>
-                    <ul class="list-disc list-inside text-gray-600 space-y-2">
+            <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-4">
+                <div class="glass-card rounded-3xl p-8 space-y-4">
+                    <h3 class="heading-font text-2xl text-white">Travel Essentials</h3>
+                    <ul class="list-disc list-inside text-gray-300 space-y-2">
                         <li>Saily eSIM (200+ countries): Use code <span class="font-semibold">CARLRI5370</span> for $5 off (I receive $5 credit)</li>
-                        <li>Wise (multi-currency card): <a href="https://wise.com/invite/irhc/carlt62" class="text-yellow-500 hover:text-yellow-600">Sign up here</a></li>
+                        <li>Wise (multi-currency card): <a href="https://wise.com/invite/irhc/carlt62" class="text-yellow-500 hover:text-yellow-400">Sign up here</a></li>
                     </ul>
                 </div>
-                <div>
-                    <h3 class="text-xl font-bold text-gray-800 mb-4">🎬 CREATOR TOOLS</h3>
-                    <ul class="list-disc list-inside text-gray-600 space-y-2">
-                        <li>Dehancer (film emulation): Code <span class="font-semibold">CARLTRAVELS</span> for 10% off → <a href="https://www.dehancer.com/subscribe" class="text-yellow-500 hover:text-yellow-600">dehancer.com/subscribe</a></li>
-                        <li>Adobe Enhance VO (FREE): <a href="https://podcast.adobe.com/en/enhance" class="text-yellow-500 hover:text-yellow-600">podcast.adobe.com/en/enhance</a></li>
+                <div class="glass-card rounded-3xl p-8 space-y-4">
+                    <h3 class="heading-font text-2xl text-white">Creator Tools</h3>
+                    <ul class="list-disc list-inside text-gray-300 space-y-2">
+                        <li>Dehancer (film emulation): Code <span class="font-semibold">CARLTRAVELS</span> for 10% off → <a href="https://www.dehancer.com/subscribe" class="text-yellow-500 hover:text-yellow-400">dehancer.com/subscribe</a></li>
+                        <li>Adobe Enhance VO (FREE): <a href="https://podcast.adobe.com/en/enhance" class="text-yellow-500 hover:text-yellow-400">podcast.adobe.com/en/enhance</a></li>
                     </ul>
                 </div>
-                <div>
-                    <h3 class="text-xl font-bold text-gray-800 mb-4">🧰 MY GEAR — US LINKS</h3>
-                    <ul class="list-disc list-inside text-gray-600 space-y-2">
-                        <li><a href="https://amzn.to/45iZULT" class="text-yellow-500 hover:text-yellow-600">DJI Flip</a></li>
-                        <li><a href="https://amzn.to/4mHhQ8H" class="text-yellow-500 hover:text-yellow-600">Sony A7C II</a></li>
-                        <li><a href="https://amzn.to/4miS3UJ" class="text-yellow-500 hover:text-yellow-600">DJI Pocket 3</a></li>
-                        <li><a href="https://amzn.to/4lvd1hI" class="text-yellow-500 hover:text-yellow-600">Tamron 28–200</a></li>
-                        <li><a href="https://amzn.to/4oHMXTy" class="text-yellow-500 hover:text-yellow-600">RØDE Wireless PRO</a></li>
-                        <li><a href="https://amzn.to/467fEAU" class="text-yellow-500 hover:text-yellow-600">Think Tank Backpack</a></li>
+                <div class="glass-card rounded-3xl p-8 space-y-4">
+                    <h3 class="heading-font text-2xl text-white">My Gear – US Links</h3>
+                    <ul class="list-disc list-inside text-gray-300 space-y-2">
+                        <li><a href="https://amzn.to/45iZULT" class="text-yellow-500 hover:text-yellow-400">DJI Flip</a></li>
+                        <li><a href="https://amzn.to/4mHhQ8H" class="text-yellow-500 hover:text-yellow-400">Sony A7C II</a></li>
+                        <li><a href="https://amzn.to/4miS3UJ" class="text-yellow-500 hover:text-yellow-400">DJI Pocket 3</a></li>
+                        <li><a href="https://amzn.to/4lvd1hI" class="text-yellow-500 hover:text-yellow-400">Tamron 28–200</a></li>
+                        <li><a href="https://amzn.to/4oHMXTy" class="text-yellow-500 hover:text-yellow-400">RØDE Wireless PRO</a></li>
+                        <li><a href="https://amzn.to/467fEAU" class="text-yellow-500 hover:text-yellow-400">Think Tank Backpack</a></li>
                     </ul>
                 </div>
-                <div>
-                    <h3 class="text-xl font-bold text-gray-800 mb-4">🧰 MY GEAR — AU LINKS</h3>
-                    <ul class="list-disc list-inside text-gray-600 space-y-2">
-                        <li><a href="https://amzn.to/41zmAVV" class="text-yellow-500 hover:text-yellow-600">DJI Flip</a></li>
-                        <li><a href="https://amzn.to/45Qk2Fw" class="text-yellow-500 hover:text-yellow-600">Sony A7C II</a></li>
-                        <li><a href="https://amzn.to/4gaYLJZ" class="text-yellow-500 hover:text-yellow-600">DJI Osmo Pocket 3</a></li>
-                        <li><a href="https://amzn.to/4n73D5P" class="text-yellow-500 hover:text-yellow-600">Tamron 24–200</a></li>
-                        <li><a href="https://amzn.to/46kv8CG" class="text-yellow-500 hover:text-yellow-600">RØDE Wireless PRO</a></li>
-                        <li><a href="https://amzn.to/3I5mApV" class="text-yellow-500 hover:text-yellow-600">Think Tank Backpack</a></li>
+                <div class="glass-card rounded-3xl p-8 space-y-4">
+                    <h3 class="heading-font text-2xl text-white">My Gear – AU Links</h3>
+                    <ul class="list-disc list-inside text-gray-300 space-y-2">
+                        <li><a href="https://amzn.to/41zmAVV" class="text-yellow-500 hover:text-yellow-400">DJI Flip</a></li>
+                        <li><a href="https://amzn.to/45Qk2Fw" class="text-yellow-500 hover:text-yellow-400">Sony A7C II</a></li>
+                        <li><a href="https://amzn.to/4gaYLJZ" class="text-yellow-500 hover:text-yellow-400">DJI Osmo Pocket 3</a></li>
+                        <li><a href="https://amzn.to/4n73D5P" class="text-yellow-500 hover:text-yellow-400">Tamron 24–200</a></li>
+                        <li><a href="https://amzn.to/46kv8CG" class="text-yellow-500 hover:text-yellow-400">RØDE Wireless PRO</a></li>
+                        <li><a href="https://amzn.to/3I5mApV" class="text-yellow-500 hover:text-yellow-400">Think Tank Backpack</a></li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Rebuilt the Berlin destination guide with the new hero layout, highlight cards, glass-card itinerary sections, and dark-themed navigation to match recent destination posts.
- Applied the same refreshed visual system to the Osaka travel guide, including reorganized watch cards, itinerary timeline, and updated travel essentials grid.
- Updated shared components such as call-to-action buttons, practical info sidebars, and creator gear sections to the consistent muted gold/dark palette.

## Testing
- Not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68ea107615548323921f1e94fb59d666