### PR TITLE
Add Hiroshima travel guide and update destinations listing

### DIFF
--- a/destinations.html
+++ b/destinations.html
@@ -652,6 +652,33 @@
                         </div>
                     </div>
                 </div>
+                <!-- Destination 14: Hiroshima -->
+                <div class="destination-card rounded-xl overflow-hidden shadow-lg">
+                    <div class="destination-card-inner">
+                        <div class="relative overflow-hidden h-64">
+                            <img src="https://img.youtube.com/vi/M3B07rdRGVs/maxresdefault.jpg" alt="Hiroshima Peace Memorial Park" class="w-full h-full object-cover transform hover:scale-110 transition-transform duration-500">
+                            <div class="absolute inset-0 bg-gradient-to-t from-black via-transparent to-transparent opacity-70"></div>
+                            <div class="absolute bottom-0 left-0 p-6 text-white">
+                                <h3 class="text-xl font-bold">Hiroshima</h3>
+                                <p class="text-sm">Peace Memorial Park</p>
+                            </div>
+                            <span class="absolute top-4 right-4 bg-yellow-500 text-black text-xs px-3 py-1 rounded-full">New</span>
+                        </div>
+                        <div class="p-6 bg-white">
+                            <div class="flex justify-between items-center mb-3">
+                                <span class="text-gray-500 text-sm"><i class="fas fa-map-marker-alt mr-1 text-yellow-500"></i> Asia</span>
+                                <div class="flex items-center">
+                                    <i class="fas fa-star text-yellow-400 mr-1"></i>
+                                    <span class="font-medium">5.0</span>
+                                </div>
+                            </div>
+                            <p class="text-gray-600 mb-4">Ride the 90-minute Shinkansen from Osaka to honor hibakusha stories, explore the Peace Memorial Museum, and sail to Miyajima for coastal serenity.</p>
+                            <a href="hiroshima-travel-guide.html" class="text-yellow-500 font-medium hover:text-yellow-500 inline-flex items-center">
+                                View Details <i class="fas fa-arrow-right ml-2"></i>
+                            </a>
+                        </div>
+                    </div>
+                </div>
             </div>
             <div class="text-center mt-12">
                 <a href="#" class="inline-flex items-center px-6 py-3 border border-yellow-500 text-yellow-500 rounded-full font-medium hover:bg-yellow-900 transition-all">

--- a/hiroshima-travel-guide.html
+++ b/hiroshima-travel-guide.html
@@ -1,0 +1,450 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hiroshima Travel Guide – Shinkansen Journey, Peace Memorial & Miyajima Day Trip | Carl Travels</title>
+    <!-- Cookiebot for GDPR Compliance -->
+    <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="e44b7cd2-126b-4f49-8aee-22495afe3ece" type="text/javascript" async></script>
+    <!-- SEO Meta Tags -->
+    <meta name="description" content="Ride the Shinkansen from Osaka to Hiroshima, visit the Peace Memorial Museum, honor hibakusha stories, and plan side trips to Miyajima with Carl Travels." />
+    <meta name="keywords" content="Hiroshima travel guide, Hiroshima Peace Memorial Park, Shinkansen Osaka to Hiroshima, Miyajima day trip, Atomic Bomb Dome, Carl Travels" />
+    <!-- Open Graph -->
+    <meta property="og:title" content="Hiroshima Travel Guide – Shinkansen Journey, Peace Memorial & Miyajima" />
+    <meta property="og:description" content="Join Carl Travels on a 90-minute bullet train ride from Osaka to Hiroshima to reflect at the Peace Memorial, meet hibakusha stories, and explore Miyajima." />
+    <meta property="og:image" content="https://img.youtube.com/vi/M3B07rdRGVs/maxresdefault.jpg" />
+    <meta property="og:url" content="https://www.carltravels.com/hiroshima-travel-guide.html" />
+    <meta property="og:type" content="article" />
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Hiroshima Travel Guide – Peace Memorial Reflections" />
+    <meta name="twitter:description" content="Travel from Osaka to Hiroshima on the Shinkansen, stand at the A-Bomb Dome, and discover Miyajima with Carl Travels." />
+    <meta name="twitter:image" content="https://img.youtube.com/vi/M3B07rdRGVs/maxresdefault.jpg" />
+    <!-- Structured Data -->
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "TravelArticle",
+        "headline": "Hiroshima Travel Guide – Shinkansen Journey, Peace Memorial & Miyajima Day Trip",
+        "description": "Plan a respectful visit to Hiroshima: 90-minute bullet train from Osaka, Peace Memorial Park reflections, hibakusha testimonies, and side trips to Miyajima.",
+        "image": "https://img.youtube.com/vi/M3B07rdRGVs/maxresdefault.jpg",
+        "author": { "@type": "Person", "name": "Carl Tomich" },
+        "publisher": {
+            "@type": "Organization",
+            "name": "Carl Travels",
+            "logo": { "@type": "ImageObject", "url": "https://www.carltravels.com/carlcircle.png" }
+        },
+        "mainEntityOfPage": { "@type": "WebPage", "@id": "https://www.carltravels.com/hiroshima-travel-guide.html" }
+    }
+    </script>
+    <!-- Ads & Analytics -->
+    <script async src="https://pagead2.googlesyndication.com/pagead/js?client=ca-pub-6483721386563068" crossorigin="anonymous"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-G72KT5ZW2J"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-G72KT5ZW2J');
+    </script>
+    <!-- Tailwind & Icons -->
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <!-- Fonts -->
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700&family=Bebas+Neue&display=swap" rel="stylesheet">
+    <!-- Custom Styles -->
+    <style>
+        :root {
+            --primary: #f5c518;
+            --secondary: #2a2a2a;
+            --dark: #1a1a1a;
+            --light: #d4d4d4;
+        }
+        body {
+            font-family: 'Montserrat', sans-serif;
+            background-color: var(--dark);
+            color: var(--light);
+            scroll-behavior: smooth;
+        }
+        .heading-font {
+            font-family: 'Bebas Neue', sans-serif;
+            letter-spacing: 2px;
+        }
+        .navbar {
+            backdrop-filter: blur(10px);
+            background-color: rgba(26, 26, 26, 0.9);
+            transition: all 0.3s ease;
+        }
+        .navbar.scrolled {
+            background-color: rgba(26, 26, 26, 0.98);
+            box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.3);
+        }
+        .mobile-menu {
+            max-height: 0;
+            overflow: hidden;
+            transition: max-height 0.5s ease-out;
+        }
+        .mobile-menu.open {
+            max-height: 500px;
+        }
+        .hero-overlay {
+            background: linear-gradient(180deg, rgba(0,0,0,0.4) 0%, rgba(0,0,0,0.8) 75%, rgba(0,0,0,0.95) 100%);
+        }
+        .glass-card {
+            background: rgba(26, 26, 26, 0.7);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            backdrop-filter: blur(12px);
+        }
+        .highlight-card {
+            background: rgba(15, 15, 15, 0.65);
+            border: 1px solid rgba(255, 255, 255, 0.06);
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
+        }
+        .highlight-card:hover {
+            transform: translateY(-6px);
+            box-shadow: 0 20px 45px -20px rgba(0, 0, 0, 0.45);
+        }
+    </style>
+</head>
+<body class="text-gray-200">
+    <!-- Navigation -->
+    <nav id="navbar" class="navbar fixed w-full z-50 shadow-sm transition-all duration-300">
+        <div class="container mx-auto px-6 py-3">
+            <div class="flex justify-between items-center">
+                <a href="index.html" class="text-2xl font-bold flex items-center">
+                    <div class="w-10 h-10 rounded-full bg-gradient-to-r from-yellow-500 to-amber-600 flex items-center justify-center mr-2">
+                        <i class="fas fa-compass text-black text-lg"></i>
+                    </div>
+                    <span class="heading-font bg-gradient-to-r from-yellow-500 to-amber-600 bg-clip-text text-transparent">Carl Travels</span>
+                </a>
+                <div class="hidden md:flex items-center space-x-8">
+                    <a href="index.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Home</a>
+                    <a href="destinations.html" class="text-yellow-500 font-medium transition-colors">Destinations</a>
+                    <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Videos</a>
+                    <a href="blog.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Blog</a>
+                    <a href="gear.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Gear</a>
+                    <a href="index.html#about" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">About</a>
+                    <a href="index.html#contact" class="px-4 py-2 bg-gradient-to-r from-yellow-500 to-amber-600 text-black rounded-full hover:shadow-lg transition-all">Contact</a>
+                </div>
+                <button id="mobile-menu-button" class="md:hidden text-gray-300 focus:outline-none">
+                    <i class="fas fa-bars text-2xl"></i>
+                </button>
+            </div>
+            <div id="mobile-menu" class="mobile-menu md:hidden">
+                <div class="pt-4 pb-2 space-y-2">
+                    <a href="index.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Home</a>
+                    <a href="destinations.html" class="block px-3 py-2 rounded-md bg-yellow-900 text-yellow-500 font-medium">Destinations</a>
+                    <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Videos</a>
+                    <a href="blog.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Blog</a>
+                    <a href="gear.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Gear</a>
+                    <a href="index.html#about" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">About</a>
+                    <a href="index.html#contact" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Contact</a>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <!-- Hero Section -->
+    <section class="relative min-h-[70vh] flex items-end pt-24" style="background-image: url('https://img.youtube.com/vi/M3B07rdRGVs/maxresdefault.jpg'); background-size: cover; background-position: center;">
+        <div class="absolute inset-0 hero-overlay"></div>
+        <div class="container mx-auto px-6 py-20 relative z-10">
+            <div class="max-w-3xl">
+                <span class="text-yellow-400 tracking-[0.35em] uppercase text-xs">Japan Reflections Journey</span>
+                <h1 class="heading-font text-4xl md:text-6xl text-white mt-4 mb-6 leading-tight">Hiroshima: Peace Memorial Park & Beyond</h1>
+                <p class="text-lg md:text-xl text-gray-200 leading-relaxed">From a 90-minute Shinkansen dash out of Osaka to standing beneath the Atomic Bomb Dome, this trip is as much about remembrance as it is about resilience. Walk with us through museums, memorials, riverside lanterns, and ferries bound for Miyajima.</p>
+                <div class="mt-8 flex flex-wrap gap-4">
+                    <a href="#video" class="px-6 py-3 bg-yellow-500 text-black rounded-full font-semibold hover:bg-yellow-400 transition">Watch the Journey</a>
+                    <a href="#plan" class="px-6 py-3 border border-yellow-500 text-yellow-500 rounded-full font-semibold hover:bg-yellow-500 hover:text-black transition">Plan Your Visit</a>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Video Section -->
+    <section id="video" class="py-16 bg-secondary">
+        <div class="container mx-auto px-6">
+            <div class="text-center mb-12">
+                <span class="text-yellow-500 font-medium tracking-widest uppercase text-sm">Featured Episode</span>
+                <h2 class="heading-font text-3xl md:text-5xl text-white mt-4">Hiroshima Through the Lens</h2>
+                <p class="text-gray-300 max-w-3xl mx-auto mt-4">The efficiency of the Shinkansen and the solemn quiet of Hiroshima exist in the same breath. Hit play to see how bullet trains, river walks, and moving museum exhibits shaped our time in Japan’s City of Peace.</p>
+            </div>
+            <div class="relative aspect-video rounded-3xl overflow-hidden shadow-2xl">
+                <iframe class="absolute inset-0 w-full h-full" src="https://www.youtube.com/embed/M3B07rdRGVs" title="Hiroshima Travel Guide" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+            </div>
+        </div>
+    </section>
+
+    <!-- Story Section -->
+    <section class="py-16 bg-dark">
+        <div class="container mx-auto px-6 grid lg:grid-cols-3 gap-12 items-start">
+            <div class="lg:col-span-2 space-y-6">
+                <h3 class="heading-font text-3xl md:text-4xl text-white">Why Hiroshima Resonates</h3>
+                <p class="text-gray-300 leading-relaxed">Hiroshima is more than a stop on the Tokaido-Sanyo Line—it’s where history, ethics, and empathy converge. Before Little Boy was dropped on 6 August 1945, the Allies delivered the Potsdam Declaration, warning of “prompt and utter destruction” if Japan did not surrender. Many leaders never imagined the scale of devastation that a nuclear weapon could unleash.</p>
+                <p class="text-gray-300 leading-relaxed">Inside the Hiroshima Peace Memorial Museum you’ll meet the hibakusha—survivors who carried trauma, radiation sickness, and unanswered questions for decades. Displays of scorched school uniforms, melted bottles, and written testimonies sit beside scientific explanations of the Manhattan Project, J. Robert Oppenheimer’s role, and the moral reckoning that followed.</p>
+                <p class="text-gray-300 leading-relaxed">Outside, the A-Bomb Dome, Cenotaph, Children’s Peace Monument, and Peace Flame invite reflection. As lanterns drift down the Motoyasu River at night, you can feel how the city rebuilt itself with a commitment to peace education, community, and compassion.</p>
+                <div class="flex flex-wrap gap-3 text-sm uppercase tracking-wide text-yellow-400">
+                    <span class="bg-secondary px-3 py-1 rounded-full">#Hiroshima</span>
+                    <span class="bg-secondary px-3 py-1 rounded-full">#PeaceMemorial</span>
+                    <span class="bg-secondary px-3 py-1 rounded-full">#Hibakusha</span>
+                    <span class="bg-secondary px-3 py-1 rounded-full">#JapanTravel</span>
+                    <span class="bg-secondary px-3 py-1 rounded-full">#ManhattanProject</span>
+                    <span class="bg-secondary px-3 py-1 rounded-full">#Ethics</span>
+                </div>
+            </div>
+            <div class="glass-card rounded-3xl p-8 shadow-xl">
+                <h4 class="heading-font text-2xl text-white mb-4">Quick Facts</h4>
+                <ul class="space-y-4 text-gray-300">
+                    <li><i class="fas fa-train text-yellow-500 mr-3"></i>Shinkansen: 90 minutes from Osaka, reserved seats from ¥10,000</li>
+                    <li><i class="fas fa-city text-yellow-500 mr-3"></i>Peace Memorial Park spans the former city center leveled in 1945</li>
+                    <li><i class="fas fa-clock text-yellow-500 mr-3"></i>Suggested stay: 2–3 days including Miyajima Island</li>
+                    <li><i class="fas fa-landmark text-yellow-500 mr-3"></i>Highlights: Peace Memorial Museum, A-Bomb Dome, Orizuru Tower</li>
+                    <li><i class="fas fa-utensils text-yellow-500 mr-3"></i>Local bites: Hiroshima-style okonomiyaki & momiji manju</li>
+                </ul>
+            </div>
+        </div>
+    </section>
+
+    <!-- Planning Section -->
+    <section id="plan" class="py-16 bg-secondary">
+        <div class="container mx-auto px-6 grid lg:grid-cols-2 gap-12 items-start">
+            <div class="space-y-6">
+                <h3 class="heading-font text-3xl md:text-4xl text-white">How to Get There</h3>
+                <p class="text-gray-300 leading-relaxed">From Osaka Station, board the Sanyo Shinkansen (Nozomi, Mizuho, or Sakura services) toward Hiroshima. Reserved seats start around ¥10,000, while unreserved cars offer a small discount. With a JR Pass, hop onto any Hikari or Sakura service without extra cost—just book ahead in peak season.</p>
+                <p class="text-gray-300 leading-relaxed">Arriving at Hiroshima Station, follow signs to the south exit for the Hiroshima Electric Railway (Hiroden) streetcars. Line 2 or 6 reaches the Genbaku Dome-mae stop in about 15 minutes, dropping you right beside the Peace Memorial Park. Day passes cover trams, ferries, and buses if you’re extending the journey to Miyajima.</p>
+                <p class="text-gray-300 leading-relaxed">Prefer to slow down? Limited express buses connect Osaka and Hiroshima in five hours, while domestic flights from Tokyo Haneda land at Hiroshima Airport with limousine buses into the city center.</p>
+            </div>
+            <div class="glass-card rounded-3xl p-8 shadow-xl space-y-6">
+                <h4 class="heading-font text-2xl text-white">Travel Logistics</h4>
+                <ul class="space-y-4 text-gray-300">
+                    <li><i class="fas fa-ticket text-yellow-500 mr-3"></i>Book Shinkansen seats 1–2 weeks ahead during Golden Week & Obon.</li>
+                    <li><i class="fas fa-hotel text-yellow-500 mr-3"></i>Stay near Hiroshima Station for easy transit or riverside hotels for quiet evenings.</li>
+                    <li><i class="fas fa-passport text-yellow-500 mr-3"></i>JR West Rail Pass covers Hiroshima, Miyajima, and even onward trips to Fukuoka.</li>
+                    <li><i class="fas fa-sun text-yellow-500 mr-3"></i>Spring & autumn offer mild weather; August 6 memorial events draw large crowds.</li>
+                    <li><i class="fas fa-hand-holding-heart text-yellow-500 mr-3"></i>Maintain silence in memorial halls and ask permission before filming survivors.</li>
+                </ul>
+            </div>
+        </div>
+    </section>
+
+    <!-- Itinerary Section -->
+    <section class="py-16 bg-dark">
+        <div class="container mx-auto px-6 grid lg:grid-cols-3 gap-12 items-start">
+            <div class="lg:col-span-2 space-y-6">
+                <h3 class="heading-font text-3xl md:text-4xl text-white">Suggested 3-Day Itinerary</h3>
+                <p class="text-gray-300 leading-relaxed">Hiroshima rewards slow travel. Here’s how we paced our visit to honor the city’s past and embrace its present.</p>
+                <div class="space-y-6">
+                    <div class="highlight-card rounded-3xl p-6">
+                        <h4 class="heading-font text-2xl text-white mb-2">Day 1 – Peace Memorial Park</h4>
+                        <ul class="list-disc list-inside text-gray-300 space-y-2">
+                            <li>Arrive by late morning, drop bags at your hotel, and rent bikes for the riverside trails.</li>
+                            <li>Spend the afternoon inside the Peace Memorial Museum; allow at least two hours for exhibits.</li>
+                            <li>Pause at the Cenotaph, Children’s Peace Monument, and A-Bomb Dome as the sun sets.</li>
+                            <li>Dine on layered Hiroshima okonomiyaki at Okonomi-mura before a quiet walk along the Motoyasu River.</li>
+                        </ul>
+                    </div>
+                    <div class="highlight-card rounded-3xl p-6">
+                        <h4 class="heading-font text-2xl text-white mb-2">Day 2 – Rebuilding & Reflection</h4>
+                        <ul class="list-disc list-inside text-gray-300 space-y-2">
+                            <li>Start with morning views from Orizuru Tower and fold a paper crane for the memorial collection.</li>
+                            <li>Explore Hiroshima Castle and Shukkeien Garden to see how the city rebuilt post-1945.</li>
+                            <li>Visit the Hiroshima National Peace Memorial Hall for Atomic Bomb Victims for survivor testimonies.</li>
+                            <li>End the evening in the Nagarekawa district with craft cocktails or a tea ceremony experience.</li>
+                        </ul>
+                    </div>
+                    <div class="highlight-card rounded-3xl p-6">
+                        <h4 class="heading-font text-2xl text-white mb-2">Day 3 – Miyajima Island Escape</h4>
+                        <ul class="list-disc list-inside text-gray-300 space-y-2">
+                            <li>Ride the JR Sanyo Line or ferry-inclusive pass to Miyajimaguchi, then sail to Itsukushima.</li>
+                            <li>Capture the floating torii gate at high tide, then hike or cable-car up Mount Misen.</li>
+                            <li>Sample maple-leaf-shaped momiji manju and visit Daisho-in Temple before returning to Hiroshima.</li>
+                            <li>Wrap up with sunset at the Peace Bridge or a cruise on the Hiroshima World Heritage ferry.</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+            <div class="glass-card rounded-3xl p-8 shadow-xl space-y-6">
+                <h4 class="heading-font text-2xl text-white">Need-to-Know</h4>
+                <ul class="space-y-4 text-gray-300">
+                    <li><i class="fas fa-language text-yellow-500 mr-3"></i>Many exhibits offer English audio guides; download the Peace Memorial app for deeper context.</li>
+                    <li><i class="fas fa-dove text-yellow-500 mr-3"></i>August 6 Peace Memorial Ceremony welcomes respectful visitors—arrive before 7 AM.</li>
+                    <li><i class="fas fa-bus text-yellow-500 mr-3"></i>Hiroshima Meipuru~pu loop buses connect major sights and are JR Pass friendly.</li>
+                    <li><i class="fas fa-water text-yellow-500 mr-3"></i>Carry reusable water bottles—refill stations are available inside the park.</li>
+                    <li><i class="fas fa-book text-yellow-500 mr-3"></i>Read “Hiroshima” by John Hersey or watch “Oppenheimer” to contextualize your visit.</li>
+                </ul>
+            </div>
+        </div>
+    </section>
+
+    <!-- Reflection Section -->
+    <section class="py-16 bg-secondary">
+        <div class="container mx-auto px-6 grid lg:grid-cols-2 gap-12 items-start">
+            <div class="space-y-6">
+                <h3 class="heading-font text-3xl md:text-4xl text-white">Lessons from the Manhattan Project</h3>
+                <p class="text-gray-300 leading-relaxed">Scientists working under Oppenheimer believed they were pushing humanity into a new era, yet many wrestled with the sin of pride after Hiroshima and Nagasaki. The project’s secrecy, rapid innovation, and unprecedented scale forced moral questions that still echo across scientific communities today.</p>
+                <p class="text-gray-300 leading-relaxed">Hiroshima’s exhibits don’t shy away from these complexities. Panels outline the race to split the atom, wartime politics, and the debates that followed Japan’s surrender. As visitors, we’re asked to consider how innovation should serve humanity rather than destroy it.</p>
+                <p class="text-gray-300 leading-relaxed">Share your thoughts in the comments or on YouTube—dialogue keeps the memory of Hiroshima alive and pushes us toward empathy, disarmament, and peace-building in our own neighborhoods.</p>
+            </div>
+            <div class="glass-card rounded-3xl p-8 shadow-xl space-y-6">
+                <h4 class="heading-font text-2xl text-white">Conversation Starters</h4>
+                <ul class="space-y-4 text-gray-300">
+                    <li><i class="fas fa-comments text-yellow-500 mr-3"></i>Could the war have ended without atomic weapons? What alternatives existed?</li>
+                    <li><i class="fas fa-people-arrows text-yellow-500 mr-3"></i>How do survivors balance remembrance with rebuilding community?</li>
+                    <li><i class="fas fa-globe text-yellow-500 mr-3"></i>What responsibilities do modern scientists carry when pioneering new technologies?</li>
+                    <li><i class="fas fa-hands-helping text-yellow-500 mr-3"></i>How can travelers support peace education initiatives after leaving Hiroshima?</li>
+                </ul>
+                <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="inline-flex items-center px-5 py-3 bg-yellow-500 text-black rounded-full font-semibold hover:bg-yellow-400 transition"><i class="fab fa-youtube mr-2"></i>Join the Discussion</a>
+            </div>
+        </div>
+    </section>
+
+    <!-- Stay Connected -->
+    <section class="py-16 bg-dark">
+        <div class="container mx-auto px-6 text-center">
+            <h3 class="heading-font text-3xl md:text-4xl text-white mb-6">Keep Exploring with Carl Travels</h3>
+            <p class="text-gray-300 max-w-3xl mx-auto">Thank you for walking through Hiroshima with us. If this story moved you, share it with someone who loves history, and let’s continue advocating for empathy-driven travel.</p>
+            <div class="mt-8 flex flex-wrap justify-center gap-6">
+                <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="px-5 py-3 bg-red-600 hover:bg-red-500 text-white rounded-full font-semibold transition"><i class="fab fa-youtube mr-2"></i>Subscribe on YouTube</a>
+                <a href="https://www.instagram.com/carlostomich" target="_blank" class="px-5 py-3 bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-400 hover:to-pink-400 text-white rounded-full font-semibold transition"><i class="fab fa-instagram mr-2"></i>Follow on Instagram</a>
+                <a href="index.html#contact" class="px-5 py-3 border border-yellow-500 text-yellow-500 rounded-full font-semibold hover:bg-yellow-500 hover:text-black transition"><i class="fas fa-envelope mr-2"></i>Share Your Story</a>
+            </div>
+        </div>
+    </section>
+
+    <!-- Footer -->
+    <footer class="bg-gray-900 text-white py-12">
+        <div class="container mx-auto px-6">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
+                <div>
+                    <a href="index.html" class="text-2xl font-bold flex items-center mb-6">
+                        <div class="w-10 h-10 rounded-full bg-gradient-to-r from-yellow-500 to-amber-600 flex items-center justify-center mr-2">
+                            <i class="fas fa-plane text-white text-lg transform -rotate-45"></i>
+                        </div>
+                        <span class="heading-font">Carl Travels</span>
+                    </a>
+                    <p class="text-gray-400 mb-4">
+                        Inspiring meaningful travel through authentic storytelling and heartfelt reflection.
+                    </p>
+                    <div class="flex space-x-4">
+                        <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="text-gray-400 hover:text-white transition-colors">
+                            <i class="fab fa-youtube"></i>
+                        </a>
+                        <a href="https://www.youtube.com/@carltomichtech" target="_blank" class="text-gray-400 hover:text-white transition-colors">
+                            <i class="fab fa-youtube"></i>
+                        </a>
+                        <a href="https://www.youtube.com/@globetraveladventures" target="_blank" class="text-gray-400 hover:text-white transition-colors">
+                            <i class="fab fa-youtube"></i>
+                        </a>
+                        <a href="https://www.instagram.com/carlostomich" target="_blank" class="text-gray-400 hover:text-white transition-colors">
+                            <i class="fab fa-instagram"></i>
+                        </a>
+                        <a href="https://www.facebook.com/thecarlostomich/" target="_blank" class="text-gray-400 hover:text-white transition-colors">
+                            <i class="fab fa-facebook-f"></i>
+                        </a>
+                    </div>
+                </div>
+                <div>
+                    <h3 class="text-lg font-semibold mb-6">Quick Links</h3>
+                    <ul class="space-y-3">
+                        <li><a href="index.html" class="text-gray-400 hover:text-white transition-colors">Home</a></li>
+                        <li><a href="destinations.html" class="text-gray-400 hover:text-white transition-colors">Destinations</a></li>
+                        <li><a href="https://www.youtube.com/@thecarltomich" target="_blank" class="text-gray-400 hover:text-white transition-colors">Videos</a></li>
+                        <li><a href="blog.html" class="text-gray-400 hover:text-white transition-colors">Blog</a></li>
+                        <li><a href="index.html#about" class="text-gray-400 hover:text-white transition-colors">About</a></li>
+                        <li><a href="donate.html" class="text-gray-400 hover:text-white transition-colors">Donate</a></li>
+                        <li><a href="index.html#contact" class="text-gray-400 hover:text-white transition-colors">Contact</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-lg font-semibold mb-6">Destinations</h3>
+                    <ul class="space-y-3">
+                        <li><a href="hanoitravelguide.html" class="text-gray-400 hover:text-white transition-colors">Hanoi</a></li>
+                        <li><a href="osakatravelguide.html" class="text-gray-400 hover:text-white transition-colors">Osaka</a></li>
+                        <li><a href="kyototravelguide.html" class="text-gray-400 hover:text-white transition-colors">Kyoto</a></li>
+                        <li><a href="tokyotravelguide.html" class="text-gray-400 hover:text-white transition-colors">Tokyo</a></li>
+                        <li><a href="vinwonders-nha-trang.html" class="text-gray-400 hover:text-white transition-colors">VinWonders</a></li>
+                        <li><a href="hon-chong-rocks-nha-trang.html" class="text-gray-400 hover:text-white transition-colors">Hon Chong Rocks</a></li>
+                        <li><a href="Hagiangloop.html" class="text-gray-400 hover:text-white transition-colors">Hà Giang Loop</a></li>
+                        <li><a href="hiroshima-travel-guide.html" class="text-gray-400 hover:text-white transition-colors">Hiroshima</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-lg font-semibold mb-6">Newsletter</h3>
+                    <p class="text-gray-400 mb-4">
+                        Subscribe for new travel films, ethical travel discussions, and itinerary guides straight to your inbox.
+                    </p>
+                    <form action="https://formspree.io/f/mnnnoogg" method="POST" class="flex">
+                        <input type="email" name="_replyto" placeholder="Your email" class="px-4 py-2 rounded-l-lg bg-gray-800 text-white focus:outline-none focus:ring-1 focus:ring-yellow-500 w-full" required>
+                        <input type="hidden" name="_subject" value="Newsletter Subscription from Carl Travels">
+                        <input type="hidden" name="_next" value="https://www.carltravels.com/thankyou.html">
+                        <input type="hidden" name="_captcha" value="false">
+                        <input type="text" name="_gotcha" style="display:none">
+                        <button type="submit" class="px-4 py-2 bg-gradient-to-r from-yellow-500 to-amber-600 text-white rounded-r-lg hover:shadow-lg transition-all">
+                            <i class="fas fa-paper-plane"></i>
+                        </button>
+                    </form>
+                </div>
+            </div>
+            <div class="border-t border-gray-800 mt-12 pt-8 flex flex-col md:flex-row justify-between items-center">
+                <p class="text-gray-400 text-sm mb-4 md:mb-0">
+                    © 2025 Carl Travels. All rights reserved.
+                </p>
+                <div class="flex space-x-6">
+                    <a href="privacy-policy.html" class="text-gray-400 hover:text-white text-sm transition-colors">Privacy Policy</a>
+                    <a href="terms-and-conditions.html" class="text-gray-400 hover:text-white text-sm transition-colors">Terms of Service</a>
+                    <a href="#" class="text-gray-400 hover:text-white text-sm transition-colors">Cookies</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <!-- Back to Top Button -->
+    <button id="back-to-top" class="fixed bottom-8 right-8 w-12 h-12 bg-gradient-to-r from-yellow-500 to-amber-600 text-white rounded-full shadow-lg flex items-center justify-center transition-all opacity-0 invisible">
+        <i class="fas fa-arrow-up"></i>
+    </button>
+
+    <!-- JavaScript with Error Handling -->
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            try {
+                const mobileMenuButton = document.getElementById('mobile-menu-button');
+                const mobileMenu = document.getElementById('mobile-menu');
+                if (mobileMenuButton && mobileMenu) {
+                    mobileMenuButton.addEventListener('click', function() {
+                        mobileMenu.classList.toggle('open');
+                        this.querySelector('i').classList.toggle('fa-bars');
+                        this.querySelector('i').classList.toggle('fa-times');
+                    });
+                }
+
+                const navbar = document.getElementById('navbar');
+                if (navbar) {
+                    window.addEventListener('scroll', function() {
+                        if (window.scrollY > 50) {
+                            navbar.classList.add('scrolled');
+                        } else {
+                            navbar.classList.remove('scrolled');
+                        }
+                    });
+                }
+
+                const backToTopButton = document.getElementById('back-to-top');
+                if (backToTopButton) {
+                    window.addEventListener('scroll', function() {
+                        if (window.scrollY > 300) {
+                            backToTopButton.classList.remove('opacity-0', 'invisible');
+                            backToTopButton.classList.add('opacity-100', 'visible');
+                        } else {
+                            backToTopButton.classList.remove('opacity-100', 'visible');
+                            backToTopButton.classList.add('opacity-0', 'invisible');
+                        }
+                    });
+                    backToTopButton.addEventListener('click', function() {
+                        window.scrollTo({ top: 0, behavior: 'smooth' });
+                    });
+                }
+            } catch (error) {
+                console.error('JavaScript Error in hiroshima-travel-guide.html:', error);
+            }
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated Hiroshima travel guide page with Shinkansen logistics, history context, and itinerary ideas
- feature Hiroshima on the destinations grid with a YouTube thumbnail and link to the new guide

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68eb879486d88323bd4c0abf91cf6334