### PR TITLE
Embed YESIM walkthrough video on guide page

### DIFF
--- a/yesim-guide.html
+++ b/yesim-guide.html
@@ -54,6 +54,23 @@
             border: 1px solid rgba(255,255,255,0.08);
             backdrop-filter: blur(12px);
         }
+        .video-container {
+            position: relative;
+            width: 100%;
+            padding-bottom: 56.25%;
+            height: 0;
+            background: rgba(0, 0, 0, 0.4);
+            border: 1px solid rgba(250, 204, 21, 0.2);
+            box-shadow: 0 20px 50px rgba(0, 0, 0, 0.35);
+        }
+        .video-container iframe {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            border: 0;
+        }
     </style>
 </head>
 <body class="text-gray-800">
@@ -114,9 +131,14 @@
                             See How It Works
                         </a>
                     </div>
-                    <div class="flex items-center text-sm text-gray-300">
-                        <i class="fas fa-video mr-3 text-yellow-400"></i>
-                        <span>Video walkthrough coming soon — I’ll show the full setup in an upcoming upload.</span>
+                    <div class="w-full mt-8">
+                        <div class="video-container rounded-3xl overflow-hidden">
+                            <iframe src="https://www.youtube.com/embed/2sqMujqTYxM" title="YESIM eSIM guide - what it is, why I use it, and how to install it" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+                        </div>
+                        <p class="flex items-center text-sm text-gray-300 mt-4">
+                            <i class="fas fa-video mr-3 text-yellow-400"></i>
+                            <span>Watch my full YESIM walkthrough — what it is, why I rely on it while traveling, and how to install it step by step.</span>
+                        </p>
                     </div>
                 </div>
                 <div class="lg:w-1/2 w-full relative">


### PR DESCRIPTION
## Summary
- embed the YESIM walkthrough YouTube video directly within the hero section
- add responsive video container styling to preserve aspect ratio and match the existing design

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_69064cd50b648323816f3045943c0e75