### PR TITLE
Add Ninh Binh travel guide page and destinations card

### DIFF
--- a/destinations.html
+++ b/destinations.html
@@ -361,6 +361,33 @@
                         </div>
                     </div>
                 </div>
+                <!-- Destination 6a: Ninh Bình -->
+                <div class="destination-card rounded-xl overflow-hidden shadow-lg">
+                    <div class="destination-card-inner">
+                        <div class="relative overflow-hidden h-64">
+                            <img src="https://img.youtube.com/vi/Hict_8lPMvw/maxresdefault.jpg" alt="Ninh Bình limestone peaks" class="w-full h-full object-cover transform hover:scale-110 transition-transform duration-500">
+                            <div class="absolute inset-0 bg-gradient-to-t from-black via-transparent to-transparent opacity-70"></div>
+                            <div class="absolute bottom-0 left-0 p-6 text-white">
+                                <h3 class="text-xl font-bold">Ninh Bình</h3>
+                                <p class="text-sm">Tràng An • Tam Cốc</p>
+                            </div>
+                            <span class="absolute top-4 right-4 bg-yellow-500 text-black text-xs px-3 py-1 rounded-full">New</span>
+                        </div>
+                        <div class="p-6 bg-white">
+                            <div class="flex justify-between items-center mb-3">
+                                <span class="text-gray-500 text-sm"><i class="fas fa-map-marker-alt mr-1 text-yellow-500"></i> Asia</span>
+                                <div class="flex items-center">
+                                    <i class="fas fa-star text-yellow-400 mr-1"></i>
+                                    <span class="font-medium">5.0</span>
+                                </div>
+                            </div>
+                            <p class="text-gray-600 mb-4">Sail Tràng An’s cave rivers, cycle rice fields, and climb the Múa Cave dragon staircase just two hours from Hanoi.</p>
+                            <a href="ninhbinhtravelguide.html" class="text-yellow-500 font-medium hover:text-yellow-500 inline-flex items-center">
+                                View Details <i class="fas fa-arrow-right ml-2"></i>
+                            </a>
+                        </div>
+                    </div>
+                </div>
                 <!-- Destination 6b: Hà Giang Loop -->
                 <div class="destination-card rounded-xl overflow-hidden shadow-lg">
                     <div class="destination-card-inner">

--- a/ninhbinhtravelguide.html
+++ b/ninhbinhtravelguide.html
@@ -1,0 +1,373 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ninh Bình Travel Guide 2025 – Tràng An, Tam Cốc & Múa Cave | Carl Travels</title>
+    <!-- Cookiebot for GDPR Compliance -->
+    <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="e44b7cd2-126b-4f49-8aee-22495afe3ece" type="text/javascript" async></script>
+    <!-- SEO Meta Tags -->
+    <meta name="description" content="Plan a cinematic day trip to Ninh Bình: Tràng An caves, Tam Cốc rice fields, Múa Cave viewpoint, cycling paths, and how to get there from Hanoi by limousine bus.">
+    <meta name="keywords" content="Ninh Binh travel guide, Trang An, Tam Coc, Mua Cave, Hanoi day trip 2025, Vietnam limestone mountains, Carl Travels">
+    <!-- Open Graph -->
+    <meta property="og:title" content="Ninh Bình Travel Guide 2025 – Tràng An, Tam Cốc & Múa Cave">
+    <meta property="og:description" content="Sail through caves, climb the dragon staircase, cycle rice fields, and stay riverside on this easy escape from Hanoi.">
+    <meta property="og:image" content="https://img.youtube.com/vi/Hict_8lPMvw/maxresdefault.jpg">
+    <meta property="og:url" content="https://www.carltravels.com/ninhbinhtravelguide.html">
+    <meta property="og:type" content="article">
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Ninh Bình Travel Guide 2025 – Tràng An, Tam Cốc & Múa Cave">
+    <meta name="twitter:description" content="Peaceful riverside homestays, cave boat rides, cycling lanes, and the best viewpoints in Northern Vietnam.">
+    <meta name="twitter:image" content="https://img.youtube.com/vi/Hict_8lPMvw/maxresdefault.jpg">
+    <!-- Structured Data -->
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "TravelArticle",
+        "headline": "Ninh Bình Travel Guide 2025 – Tràng An, Tam Cốc & Múa Cave",
+        "description": "Discover Ninh Bình’s rivers, caves, rice fields, homestays, and viewpoints on a Hanoi day trip or overnight stay.",
+        "image": "https://img.youtube.com/vi/Hict_8lPMvw/maxresdefault.jpg",
+        "author": { "@type": "Person", "name": "Carl Tomich" },
+        "publisher": {
+            "@type": "Organization",
+            "name": "Carl Travels",
+            "logo": { "@type": "ImageObject", "url": "https://www.carltravels.com/carlcircle.png" }
+        },
+        "mainEntityOfPage": { "@type": "WebPage", "@id": "https://www.carltravels.com/ninhbinhtravelguide.html" }
+    }
+    </script>
+    <!-- Ads & Analytics -->
+    <script async src="https://pagead2.googlesyndication.com/pagead/js?client=ca-pub-6483721386563068" crossorigin="anonymous"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-G72KT5ZW2J"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);} 
+        gtag('js', new Date());
+        gtag('config', 'G-G72KT5ZW2J');
+    </script>
+    <!-- Tailwind & Icons -->
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <!-- Fonts -->
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700&family=Bebas+Neue&display=swap" rel="stylesheet">
+    <!-- Custom Styles -->
+    <style>
+        :root {
+            --primary: #facc15;
+            --secondary: #1f2937;
+            --dark: #0f172a;
+            --light: #e2e8f0;
+        }
+        body {
+            font-family: 'Montserrat', sans-serif;
+            background-color: var(--dark);
+            color: var(--light);
+            scroll-behavior: smooth;
+        }
+        .hero {
+            background: radial-gradient(circle at top left, rgba(250, 204, 21, 0.16), transparent 60%),
+                        radial-gradient(circle at bottom right, rgba(59, 130, 246, 0.12), transparent 55%),
+                        linear-gradient(135deg, rgba(15, 23, 42, 0.95), rgba(15, 23, 42, 0.78));
+        }
+        .heading-font {
+            font-family: 'Bebas Neue', sans-serif;
+        }
+        .info-card {
+            background: rgba(30, 41, 59, 0.85);
+            border: 1px solid rgba(148, 163, 184, 0.2);
+            border-radius: 1.25rem;
+            padding: 1.75rem;
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
+        }
+        .info-card:hover {
+            transform: translateY(-4px);
+            box-shadow: 0 25px 45px -15px rgba(56, 189, 248, 0.35);
+        }
+        .responsive-video {
+            position: relative;
+            width: 100%;
+            padding-bottom: 56.25%;
+            border-radius: 1.5rem;
+            overflow: hidden;
+            box-shadow: 0 35px 65px -25px rgba(59, 130, 246, 0.35);
+        }
+        .responsive-video iframe {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            border: none;
+        }
+        .badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            background: rgba(248, 250, 252, 0.08);
+            border: 1px solid rgba(148, 163, 184, 0.25);
+            padding: 0.45rem 1rem;
+            border-radius: 9999px;
+            font-size: 0.75rem;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+        }
+        .navbar {
+            backdrop-filter: blur(12px);
+            background-color: rgba(15, 23, 42, 0.82);
+            transition: all 0.3s ease;
+        }
+        .navbar.scrolled {
+            background-color: rgba(15, 23, 42, 0.95);
+            box-shadow: 0 8px 30px -12px rgba(0, 0, 0, 0.45);
+        }
+    </style>
+</head>
+<body class="text-gray-100">
+    <!-- Navigation -->
+    <nav id="navbar" class="navbar fixed w-full z-50">
+        <div class="container mx-auto px-6 py-4 flex justify-between items-center">
+            <a href="index.html" class="flex items-center space-x-3">
+                <div class="w-10 h-10 rounded-full bg-gradient-to-r from-yellow-500 to-amber-600 flex items-center justify-center">
+                    <i class="fas fa-plane text-white text-lg transform -rotate-45"></i>
+                </div>
+                <span class="heading-font text-2xl">Carl Travels</span>
+            </a>
+            <div class="hidden md:flex items-center space-x-8 text-sm font-medium">
+                <a href="index.html" class="hover:text-yellow-400">Home</a>
+                <a href="destinations.html" class="text-yellow-400">Destinations</a>
+                <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="hover:text-yellow-400">Videos</a>
+                <a href="blog.html" class="hover:text-yellow-400">Blog</a>
+                <a href="gear.html" class="hover:text-yellow-400">Gear</a>
+                <a href="index.html#about" class="hover:text-yellow-400">About</a>
+            </div>
+        </div>
+    </nav>
+
+    <!-- Hero Section -->
+    <header class="hero pt-28 pb-16">
+        <div class="container mx-auto px-6 grid lg:grid-cols-2 gap-10 items-center">
+            <div class="space-y-6">
+                <div class="space-x-3">
+                    <span class="badge"><i class="fas fa-map-marker-alt text-yellow-400"></i> North Vietnam</span>
+                    <span class="badge"><i class="fas fa-clock text-yellow-400"></i> 1–2 day trip</span>
+                </div>
+                <h1 class="heading-font text-4xl md:text-5xl font-bold leading-tight">
+                    Ninh Bình Travel Guide 2025<br>Tràng An • Tam Cốc • Múa Cave
+                </h1>
+                <p class="text-gray-300 leading-relaxed text-lg">
+                    Just two hours south of Hanoi, Ninh Bình quietly unveils limestone mountains, calm rivers, rice fields, and caves that feel like “Hạ Long Bay on land.” Escape the city for boat rides, cycling paths, and the dragon staircase views at Múa Cave.
+                </p>
+                <div class="flex flex-wrap gap-4">
+                    <a href="#video" class="px-6 py-3 bg-gradient-to-r from-yellow-500 to-amber-600 text-gray-900 font-semibold rounded-full shadow-lg hover:shadow-2xl transition">Watch the Guide</a>
+                    <a href="#plan" class="px-6 py-3 border border-yellow-400 text-yellow-400 font-semibold rounded-full hover:bg-yellow-500 hover:text-gray-900 transition">Plan Your Day Trip</a>
+                </div>
+                <div class="flex items-center space-x-4 text-sm text-gray-300">
+                    <span class="flex items-center"><i class="fas fa-bus text-yellow-400 mr-2"></i>Limousine bus via Vexere</span>
+                    <span class="flex items-center"><i class="fas fa-house text-yellow-400 mr-2"></i>Riverside homestays</span>
+                    <span class="flex items-center"><i class="fas fa-mountain text-yellow-400 mr-2"></i>Karst viewpoints</span>
+                </div>
+            </div>
+            <div class="relative">
+                <div class="overflow-hidden rounded-2xl shadow-2xl border border-gray-700">
+                    <img src="https://img.youtube.com/vi/Hict_8lPMvw/maxresdefault.jpg" alt="Ninh Bình travel guide thumbnail" class="w-full h-full object-cover">
+                </div>
+            </div>
+        </div>
+    </header>
+
+    <!-- Video Section -->
+    <section id="video" class="py-16 bg-gray-900/60">
+        <div class="container mx-auto px-6 grid lg:grid-cols-2 gap-12 items-center">
+            <div class="space-y-6">
+                <p class="badge"><i class="fas fa-play text-yellow-400"></i> Cinematic Travel Guide</p>
+                <h2 class="heading-font text-3xl md:text-4xl font-bold">Sail, cycle, and climb through Ninh Bình</h2>
+                <p class="text-gray-300 leading-relaxed">
+                    In this video, we base at a peaceful riverside homestay, ride boats through the Tràng An cave system, climb the dragon staircase at Múa Cave, and cycle quiet lanes between rice fields and villages. It’s the perfect reset from Hanoi’s buzz.
+                </p>
+                <ul class="grid sm:grid-cols-2 gap-4 text-gray-300">
+                    <li class="flex items-start space-x-3"><i class="fas fa-water text-yellow-400 mt-1"></i><span>Tràng An river routes and mountain tunnels rowed by locals.</span></li>
+                    <li class="flex items-start space-x-3"><i class="fas fa-route text-yellow-400 mt-1"></i><span>Bike-friendly roads through rice fields and limestone peaks.</span></li>
+                    <li class="flex items-start space-x-3"><i class="fas fa-dragon text-yellow-400 mt-1"></i><span>Múa Cave’s iconic dragon staircase viewpoint.</span></li>
+                    <li class="flex items-start space-x-3"><i class="fas fa-bed text-yellow-400 mt-1"></i><span>Affordable homestays with pools, gardens, and mountain views.</span></li>
+                </ul>
+            </div>
+            <div class="responsive-video shadow-2xl">
+                <iframe src="https://www.youtube.com/embed/Hict_8lPMvw" title="Ninh Bình Travel Guide" allowfullscreen loading="lazy"></iframe>
+            </div>
+        </div>
+    </section>
+
+    <!-- Planning Section -->
+    <section id="plan" class="py-16">
+        <div class="container mx-auto px-6 grid lg:grid-cols-3 gap-10">
+            <div class="lg:col-span-2 space-y-8">
+                <div class="info-card">
+                    <div class="flex items-center space-x-3 mb-4">
+                        <span class="badge"><i class="fas fa-map text-yellow-400"></i> Why Go</span>
+                        <span class="badge"><i class="fas fa-leaf text-yellow-400"></i> Nature & History</span>
+                    </div>
+                    <p class="text-gray-200 leading-relaxed">
+                        Ninh Bình was the heart of Vietnam’s first capital at Hoa Lư in the 10th century. Today it’s a peaceful patchwork of rivers, karsts, wetlands, and rice paddies where life moves slower than Hanoi. Even a single day here brings nature, temples, and countryside calm.
+                    </p>
+                </div>
+
+                <div class="info-card grid md:grid-cols-2 gap-8">
+                    <div>
+                        <h3 class="heading-font text-2xl mb-3">Top highlights</h3>
+                        <ul class="space-y-3 text-gray-200">
+                            <li class="flex items-start"><i class="fas fa-ship text-yellow-400 mr-3 mt-1"></i>Tràng An cave boats with local rowers guiding through limestone tunnels.</li>
+                            <li class="flex items-start"><i class="fas fa-person-hiking text-yellow-400 mr-3 mt-1"></i>Múa Cave (Hang Múa) viewpoint with the dragon staircase.</li>
+                            <li class="flex items-start"><i class="fas fa-bicycle text-yellow-400 mr-3 mt-1"></i>Tam Cốc cycling lanes past rice fields, lotus ponds, and village roads.</li>
+                            <li class="flex items-start"><i class="fas fa-spa text-yellow-400 mr-3 mt-1"></i>Riverside homestays with pools, gardens, and mountain backdrops.</li>
+                        </ul>
+                    </div>
+                    <div>
+                        <h3 class="heading-font text-2xl mb-3">Getting there</h3>
+                        <ul class="space-y-3 text-gray-200">
+                            <li class="flex items-start"><i class="fas fa-bus-alt text-yellow-400 mr-3 mt-1"></i>Hanoi to Ninh Bình: ~2 hours by bus/limousine. Book via the Vexere app (I used Khanh An Limousine).</li>
+                            <li class="flex items-start"><i class="fas fa-train text-yellow-400 mr-3 mt-1"></i>Morning departures reach before lunch; return after sunset or stay overnight.</li>
+                            <li class="flex items-start"><i class="fas fa-compass text-yellow-400 mr-3 mt-1"></i>Homestays can arrange boat tickets, bikes, and transfers to Tràng An or Tam Cốc.</li>
+                        </ul>
+                    </div>
+                </div>
+
+                <div class="info-card grid md:grid-cols-2 gap-8">
+                    <div>
+                        <h3 class="heading-font text-2xl mb-3">Sample 1-day plan</h3>
+                        <ul class="space-y-3 text-gray-200">
+                            <li><strong>07:00</strong> – Depart Hanoi (limousine bus).</li>
+                            <li><strong>09:30</strong> – Check into riverside homestay, coffee by the water.</li>
+                            <li><strong>10:30</strong> – Tràng An boat tour (caves + pagodas).</li>
+                            <li><strong>14:30</strong> – Cycle Tam Cốc rice fields and village roads.</li>
+                            <li><strong>16:30</strong> – Climb Múa Cave dragon staircase for sunset.</li>
+                            <li><strong>19:00</strong> – Dinner, bus back to Hanoi or overnight stay.</li>
+                        </ul>
+                    </div>
+                    <div>
+                        <h3 class="heading-font text-2xl mb-3">Overnight tips</h3>
+                        <ul class="space-y-3 text-gray-200">
+                            <li><strong>Stay:</strong> Homestays with pools and mountain views near Tam Cốc or Tràng An.</li>
+                            <li><strong>Extra stops:</strong> Bích Động pagoda, Hoa Lư temples, bird-watching at Van Long wetlands.</li>
+                            <li><strong>Pack:</strong> Light rain jacket, sunscreen, hat, breathable clothes, cash for tickets.</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+
+            <aside class="space-y-6">
+                <div class="info-card">
+                    <h3 class="heading-font text-2xl mb-4">Fast facts</h3>
+                    <ul class="space-y-3 text-gray-200">
+                        <li class="flex items-start"><i class="fas fa-hourglass-half text-yellow-400 mr-3 mt-1"></i>Best done as a day trip or 1–2 night escape.</li>
+                        <li class="flex items-start"><i class="fas fa-cloud-sun text-yellow-400 mr-3 mt-1"></i>Best light: sunrise paddies, sunset at Múa Cave.</li>
+                        <li class="flex items-start"><i class="fas fa-ticket-alt text-yellow-400 mr-3 mt-1"></i>Carry small cash for boat tickets and cave entrance.</li>
+                        <li class="flex items-start"><i class="fas fa-shoe-prints text-yellow-400 mr-3 mt-1"></i>Stairs at Múa are steep—wear grippy shoes and bring water.</li>
+                    </ul>
+                </div>
+                <div class="info-card">
+                    <h3 class="heading-font text-2xl mb-4">Need-to-know</h3>
+                    <ul class="space-y-3 text-gray-200">
+                        <li class="flex items-start"><i class="fas fa-camera text-yellow-400 mr-3 mt-1"></i>Use a circular polarizer to cut glare on the river and saturate greens.</li>
+                        <li class="flex items-start"><i class="fas fa-life-ring text-yellow-400 mr-3 mt-1"></i>Life vests are provided on boats; keep cameras wrist-strapped.</li>
+                        <li class="flex items-start"><i class="fas fa-seedling text-yellow-400 mr-3 mt-1"></i>Respect local rice fields—stick to paths and avoid drones near temples.</li>
+                        <li class="flex items-start"><i class="fas fa-motorcycle text-yellow-400 mr-3 mt-1"></i>Renting a scooter? Stick to daylight and paved roads; rain makes gravel slick.</li>
+                    </ul>
+                </div>
+                <div class="info-card">
+                    <h3 class="heading-font text-2xl mb-4">Share the adventure</h3>
+                    <div class="flex space-x-4 text-xl text-yellow-400">
+                        <a href="https://www.youtube.com/watch?v=Hict_8lPMvw" target="_blank" aria-label="Watch on YouTube" class="hover:text-white"><i class="fab fa-youtube"></i></a>
+                        <a href="https://www.instagram.com/carlostomich" target="_blank" aria-label="Instagram" class="hover:text-white"><i class="fab fa-instagram"></i></a>
+                        <a href="https://www.facebook.com/thecarlostomich/" target="_blank" aria-label="Facebook" class="hover:text-white"><i class="fab fa-facebook-f"></i></a>
+                    </div>
+                </div>
+            </aside>
+        </div>
+    </section>
+
+    <!-- Footer -->
+    <footer class="bg-gray-900 text-white py-12">
+        <div class="container mx-auto px-6">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
+                <div>
+                    <a href="index.html" class="text-2xl font-bold flex items-center mb-6">
+                        <div class="w-10 h-10 rounded-full bg-gradient-to-r from-yellow-500 to-amber-600 flex items-center justify-center mr-2">
+                            <i class="fas fa-plane text-white text-lg transform -rotate-45"></i>
+                        </div>
+                        <span class="heading-font">Carl Travels</span>
+                    </a>
+                    <p class="text-gray-400 mb-4">
+                        Inspiring meaningful travel through authentic storytelling and cinematic guides.
+                    </p>
+                    <div class="flex space-x-4">
+                        <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="text-gray-400 hover:text-white transition-colors"><i class="fab fa-youtube"></i></a>
+                        <a href="https://www.youtube.com/@carltomichtech" target="_blank" class="text-gray-400 hover:text-white transition-colors"><i class="fab fa-youtube"></i></a>
+                        <a href="https://www.youtube.com/@globetraveladventures" target="_blank" class="text-gray-400 hover:text-white transition-colors"><i class="fab fa-youtube"></i></a>
+                        <a href="https://www.instagram.com/carlostomich" target="_blank" class="text-gray-400 hover:text-white transition-colors"><i class="fab fa-instagram"></i></a>
+                        <a href="https://www.facebook.com/thecarlostomich/" target="_blank" class="text-gray-400 hover:text-white transition-colors"><i class="fab fa-facebook-f"></i></a>
+                    </div>
+                </div>
+                <div>
+                    <h3 class="text-lg font-semibold mb-6">Quick Links</h3>
+                    <ul class="space-y-3">
+                        <li><a href="index.html" class="text-gray-400 hover:text-white transition-colors">Home</a></li>
+                        <li><a href="destinations.html" class="text-gray-400 hover:text-white transition-colors">Destinations</a></li>
+                        <li><a href="https://www.youtube.com/@thecarltomich" target="_blank" class="text-gray-400 hover:text-white transition-colors">Videos</a></li>
+                        <li><a href="blog.html" class="text-gray-400 hover:text-white transition-colors">Blog</a></li>
+                        <li><a href="index.html#about" class="text-gray-400 hover:text-white transition-colors">About</a></li>
+                        <li><a href="donate.html" class="text-gray-400 hover:text-white transition-colors">Donate</a></li>
+                        <li><a href="index.html#contact" class="text-gray-400 hover:text-white transition-colors">Contact</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-lg font-semibold mb-6">Destinations</h3>
+                    <ul class="space-y-3">
+                        <li><a href="balitravelguide.html" class="text-gray-400 hover:text-white transition-colors">Bali</a></li>
+                        <li><a href="Berlin.html" class="text-gray-400 hover:text-white transition-colors">Berlin</a></li>
+                        <li><a href="melbournetravelguide.html" class="text-gray-400 hover:text-white transition-colors">Melbourne</a></li>
+                        <li><a href="cairnstravelguide.html" class="text-gray-400 hover:text-white transition-colors">Cairns</a></li>
+                        <li><a href="hanoitravelguide.html" class="text-gray-400 hover:text-white transition-colors">Hanoi</a></li>
+                        <li><a href="Hagiangloop.html" class="text-gray-400 hover:text-white transition-colors">Hà Giang Loop</a></li>
+                        <li><a href="danangtravelguide.html" class="text-gray-400 hover:text-white transition-colors">Da Nang</a></li>
+                        <li><a href="tokyotravelguide.html" class="text-gray-400 hover:text-white transition-colors">Tokyo</a></li>
+                        <li><a href="kyototravelguide.html" class="text-gray-400 hover:text-white transition-colors">Kyoto</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="text-lg font-semibold mb-6">Newsletter</h3>
+                    <p class="text-gray-400 mb-4">Subscribe to get travel tips and exclusive content directly in your inbox.</p>
+                    <form action="https://formspree.io/f/mnnnoogg" method="POST" class="flex">
+                        <input type="email" name="_replyto" placeholder="Your email" class="px-4 py-2 rounded-l-lg bg-gray-800 text-white focus:outline-none focus:ring-1 focus:ring-yellow-500 w-full" required>
+                        <input type="hidden" name="_subject" value="Newsletter Subscription from Carl Travels">
+                        <input type="hidden" name="_next" value="https://www.carltravels.com/thankyou.html">
+                        <input type="hidden" name="_captcha" value="false">
+                        <input type="text" name="_gotcha" style="display:none">
+                        <button type="submit" class="px-4 py-2 bg-gradient-to-r from-yellow-500 to-amber-600 text-white rounded-r-lg hover:shadow-lg transition-all">
+                            <i class="fas fa-paper-plane"></i>
+                        </button>
+                    </form>
+                </div>
+            </div>
+            <div class="border-t border-gray-800 mt-12 pt-8 flex flex-col md:flex-row justify-between items-center">
+                <p class="text-gray-400 text-sm mb-4 md:mb-0">© 2025 Carl Travels. All rights reserved.</p>
+                <div class="flex space-x-6">
+                    <a href="privacy-policy.html" class="text-gray-400 hover:text-white transition-colors text-sm">Privacy Policy</a>
+                    <a href="terms-and-conditions.html" class="text-gray-400 hover:text-white transition-colors text-sm">Terms & Conditions</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script>
+        const navbar = document.getElementById('navbar');
+        window.addEventListener('scroll', () => {
+            if (window.scrollY > 40) {
+                navbar.classList.add('scrolled');
+            } else {
+                navbar.classList.remove('scrolled');
+            }
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add dedicated Ninh Binh travel guide page with embedded YouTube video and planning tips
- include SEO/social metadata and consistent layout with existing travel guides
- feature the new guide on destinations page with a Ninh Binh card and link

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a614948508323a645bd4372df1d5d)