### PR TITLE
Add Ho Chi Minh City guide and update destinations map

### DIFF
--- a/destinations.html
+++ b/destinations.html
@@ -7,8 +7,8 @@
     <!-- Cookiebot for GDPR Compliance -->
     <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="e44b7cd2-126b-4f49-8aee-22495afe3ece" type="text/javascript" async></script>
     <!-- SEO Meta Tags -->
-    <meta name="description" content="Explore top travel destinations with Carl Travels. From Berlin’s vibrant history to Bali’s tropical allure, discover itineraries for Osaka, Melbourne, Phuket, Hanoi, Da Nang, Tokyo, Kyoto, and more.">
-    <meta name="keywords" content="Travel, Destinations, Berlin, Osaka, Melbourne, Cairns, Phuket, Hanoi, Da Nang, Tokyo, Kyoto, Prague, Korcula, Budva, Bali, Carl Travels, Adventure, Itineraries">
+    <meta name="description" content="Explore top travel destinations with Carl Travels. From Berlin’s vibrant history to Bali’s tropical allure, discover itineraries for Ho Chi Minh City, Osaka, Melbourne, Phuket, Hanoi, Da Nang, Tokyo, Kyoto, and more.">
+    <meta name="keywords" content="Travel, Destinations, Berlin, Osaka, Melbourne, Cairns, Phuket, Hanoi, Ho Chi Minh City, Saigon, Da Nang, Tokyo, Kyoto, Prague, Korcula, Budva, Bali, Carl Travels, Adventure, Itineraries">
     <!-- Open Graph -->
     <meta property="og:title" content="Destinations – Carl Travels: Explore the World’s Best Cities and Hidden Gems">
     <meta property="og:description" content="Explore top travel destinations with Carl Travels. From Berlin’s vibrant history to Bali’s tropical allure, discover itineraries for Osaka, Melbourne, Phuket, Hanoi, Da Nang, Tokyo, Kyoto, and more.">
@@ -26,7 +26,7 @@
         "@context": "https://schema.org",
         "@type": "WebPage",
         "name": "Destinations – Carl Travels",
-        "description": "Explore top travel destinations with Carl Travels. From Berlin’s vibrant history to Bali’s tropical allure, discover itineraries for Osaka, Melbourne, Phuket, Hanoi, Da Nang, Tokyo, Kyoto, and more.",
+        "description": "Explore top travel destinations with Carl Travels. From Berlin’s vibrant history to Bali’s tropical allure, discover itineraries for Ho Chi Minh City, Osaka, Melbourne, Phuket, Hanoi, Da Nang, Tokyo, Kyoto, and more.",
         "publisher": { "@type": "Organization", "name": "Carl Travels", "logo": { "@type": "ImageObject", "url": "https://www.carltravels.com/images/logo.png" } },
         "url": "https://www.carltravels.com/destinations.html"
     }
@@ -302,6 +302,15 @@
                                     <span class="text-yellow-500"><i class="fas fa-play"></i></span>
                                 </div>
                             </button>
+                            <button class="map-destination-item w-full text-left px-4 py-3 rounded-xl bg-white" data-map-destination="hcmc">
+                                <div class="flex items-center justify-between">
+                                    <div>
+                                        <p class="text-sm text-gray-500">Vietnam</p>
+                                        <p class="font-semibold text-gray-900">Ho Chi Minh City</p>
+                                    </div>
+                                    <span class="text-yellow-500"><i class="fas fa-play"></i></span>
+                                </div>
+                            </button>
                             <button class="map-destination-item w-full text-left px-4 py-3 rounded-xl bg-white" data-map-destination="danang">
                                 <div class="flex items-center justify-between">
                                     <div>
@@ -325,6 +334,24 @@
                                     <div>
                                         <p class="text-sm text-gray-500">Japan</p>
                                         <p class="font-semibold text-gray-900">Kyoto</p>
+                                    </div>
+                                    <span class="text-yellow-500"><i class="fas fa-play"></i></span>
+                                </div>
+                            </button>
+                            <button class="map-destination-item w-full text-left px-4 py-3 rounded-xl bg-white" data-map-destination="budva">
+                                <div class="flex items-center justify-between">
+                                    <div>
+                                        <p class="text-sm text-gray-500">Montenegro</p>
+                                        <p class="font-semibold text-gray-900">Budva</p>
+                                    </div>
+                                    <span class="text-yellow-500"><i class="fas fa-play"></i></span>
+                                </div>
+                            </button>
+                            <button class="map-destination-item w-full text-left px-4 py-3 rounded-xl bg-white" data-map-destination="korcula">
+                                <div class="flex items-center justify-between">
+                                    <div>
+                                        <p class="text-sm text-gray-500">Croatia</p>
+                                        <p class="font-semibold text-gray-900">Korčula</p>
                                     </div>
                                     <span class="text-yellow-500"><i class="fas fa-play"></i></span>
                                 </div>
@@ -503,6 +530,33 @@
                             </div>
                             <p class="text-gray-600 mb-4">Discover Hanoi's rich history, bustling streets, and authentic Vietnamese culture.</p>
                             <a href="hanoitravelguide.html" class="text-yellow-500 font-medium hover:text-yellow-500 inline-flex items-center">
+                                View Details <i class="fas fa-arrow-right ml-2"></i>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+                <!-- Destination 6b: Ho Chi Minh City -->
+                <div class="destination-card rounded-xl overflow-hidden shadow-lg" data-destination-id="hcmc">
+                    <div class="destination-card-inner">
+                        <div class="relative overflow-hidden h-64">
+                            <img src="/southeastasia.jpg" alt="Ho Chi Minh City skyline" class="w-full h-full object-cover transform hover:scale-110 transition-transform duration-500">
+                            <div class="absolute inset-0 bg-gradient-to-t from-black via-transparent to-transparent opacity-70"></div>
+                            <div class="absolute bottom-0 left-0 p-6 text-white">
+                                <h3 class="text-xl font-bold">Ho Chi Minh City</h3>
+                                <p class="text-sm">District 1</p>
+                            </div>
+                            <span class="absolute top-4 right-4 bg-yellow-9000 text-white text-xs px-3 py-1 rounded-full">New</span>
+                        </div>
+                        <div class="p-6 bg-white">
+                            <div class="flex justify-between items-center mb-3">
+                                <span class="text-gray-500 text-sm"><i class="fas fa-map-marker-alt mr-1 text-yellow-500"></i> Asia</span>
+                                <div class="flex items-center">
+                                    <i class="fas fa-star text-yellow-400 mr-1"></i>
+                                    <span class="font-medium">4.7</span>
+                                </div>
+                            </div>
+                            <p class="text-gray-600 mb-4">Follow a realistic one-day Saigon loop from Ben Thanh Market to Bitexco's skydeck and Bui Vien's neon chaos.</p>
+                            <a href="one-day-in-hcmc-guide.html" class="text-yellow-500 font-medium hover:text-yellow-500 inline-flex items-center">
                                 View Details <i class="fas fa-arrow-right ml-2"></i>
                             </a>
                         </div>
@@ -721,7 +775,7 @@
                     </div>
                 </div>
                 <!-- Destination 9: Korcula -->
-                <div class="destination-card rounded-xl overflow-hidden shadow-lg">
+                <div class="destination-card rounded-xl overflow-hidden shadow-lg" data-destination-id="korcula">
                     <div class="destination-card-inner">
                         <div class="relative overflow-hidden h-64">
                             <img src="/korculalogo.jpg" alt="Korcula" class="w-full h-full object-cover transform hover:scale-110 transition-transform duration-500">
@@ -747,7 +801,7 @@
                     </div>
                 </div>
                 <!-- Destination 10: Budva -->
-                <div class="destination-card rounded-xl overflow-hidden shadow-lg">
+                <div class="destination-card rounded-xl overflow-hidden shadow-lg" data-destination-id="budva">
                     <div class="destination-card-inner">
                         <div class="relative overflow-hidden h-64">
                             <img src="/budvalogo.jpg" alt="Budva Old Town and Adriatic Coast" class="w-full h-full object-cover transform hover:scale-110 transition-transform duration-500">
@@ -942,6 +996,7 @@
                         <li><a href="cairnstravelguide.html" class="text-gray-400 hover:text-white transition-colors">Cairns</a></li>
                         <li><a href="phuketravelguide.html" class="text-gray-400 hover:text-white transition-colors">Phuket</a></li>
                         <li><a href="hanoitravelguide.html" class="text-gray-400 hover:text-white transition-colors">Hanoi</a></li>
+                        <li><a href="one-day-in-hcmc-guide.html" class="text-gray-400 hover:text-white transition-colors">Ho Chi Minh City</a></li>
                         <li><a href="osakatravelguide.html" class="text-gray-400 hover:text-white transition-colors">Osaka</a></li>
                         <li><a href="korcula.html" class="text-gray-400 hover:text-white transition-colors">Korčula</a></li>
                         <li><a href="budvatravelguide.html" class="text-gray-400 hover:text-white transition-colors">Budva</a></li>
@@ -1096,6 +1151,13 @@
                             video: 'https://www.youtube.com/embed/lTRbrZT3r9A'
                         },
                         {
+                            id: 'hcmc',
+                            name: 'Ho Chi Minh City, Vietnam',
+                            coords: [10.8231, 106.6297],
+                            url: 'one-day-in-hcmc-guide.html',
+                            video: 'https://www.youtube.com/embed/ULOM2GJDvak'
+                        },
+                        {
                             id: 'danang',
                             name: 'Da Nang, Vietnam',
                             coords: [16.0544, 108.2022],
@@ -1115,6 +1177,20 @@
                             coords: [35.0116, 135.7681],
                             url: 'kyototravelguide.html',
                             video: 'https://www.youtube.com/embed/e-DpOd-QmTk'
+                        },
+                        {
+                            id: 'budva',
+                            name: 'Budva, Montenegro',
+                            coords: [42.287, 18.84],
+                            url: 'budvatravelguide.html',
+                            video: 'https://www.youtube.com/embed/n1pWE7QaCds'
+                        },
+                        {
+                            id: 'korcula',
+                            name: 'Korčula, Croatia',
+                            coords: [42.9634, 17.1351],
+                            url: 'korcula.html',
+                            video: 'https://www.youtube.com/embed/NPpCfDRM2PY'
                         }
                     ];
 

--- a/one-day-in-hcmc-guide.html
+++ b/one-day-in-hcmc-guide.html
@@ -1,0 +1,428 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>One Day in Ho Chi Minh City (Saigon) – Markets, Skylines & Chaos | Carl Travels</title>
+    <!-- Cookiebot for GDPR Compliance -->
+    <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="e44b7cd2-126b-4f49-8aee-22495afe3ece" type="text/javascript" async></script>
+    <!-- Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-G72KT5ZW2J"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-G72KT5ZW2J');
+    </script>
+    <!-- Meta Tags -->
+    <meta name="description" content="A realistic one-day guide to Ho Chi Minh City (Saigon): Ben Thanh Market, Bitexco Skydeck, District 1 cafes, and Bui Vien's neon chaos.">
+    <meta name="keywords" content="Ho Chi Minh City travel guide, Saigon one day itinerary, Ben Thanh Market, Bitexco Skydeck, Bui Vien Walking Street, Carl Travels">
+    <meta name="author" content="Carl Ostomich">
+    <!-- Open Graph Meta Tags -->
+    <meta property="og:title" content="One Day in Ho Chi Minh City (Saigon) – Markets, Skylines & Chaos">
+    <meta property="og:description" content="Follow a full day in Saigon: morning markets, skyline views, and Bui Vien at night.">
+    <meta property="og:image" content="https://www.carltravels.com/southeastasia.jpg">
+    <meta property="og:url" content="https://www.carltravels.com/one-day-in-hcmc-guide.html">
+    <meta property="og:type" content="article">
+    <!-- Twitter Card Meta Tags -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="One Day in Ho Chi Minh City (Saigon) – Markets, Skylines & Chaos">
+    <meta name="twitter:description" content="A realistic one-day Ho Chi Minh City loop with markets, skyline views, and night chaos.">
+    <meta name="twitter:image" content="https://www.carltravels.com/southeastasia.jpg">
+    <!-- External Resources -->
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700&family=Bebas+Neue&display=swap');
+        :root {
+            --primary: #f5c518;
+            --secondary: #2a2a2a;
+            --dark: #1a1a1a;
+            --light: #d4d4d4;
+        }
+        body {
+            font-family: 'Montserrat', sans-serif;
+            background-color: var(--dark);
+            color: var(--light);
+            scroll-behavior: smooth;
+        }
+        .hero-gradient {
+            background: linear-gradient(135deg, rgba(42, 42, 42, 0.85), rgba(26, 26, 26, 0.85)), url('/southeastasia.jpg') center/cover no-repeat;
+        }
+        .heading-font {
+            font-family: 'Bebas Neue', sans-serif;
+        }
+        .navbar {
+            backdrop-filter: blur(10px);
+            background-color: rgba(255, 255, 255, 0.9);
+            transition: all 0.3s ease;
+        }
+        .navbar.scrolled {
+            background-color: rgba(255, 255, 255, 0.98);
+            box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+        }
+        .section-card {
+            background: #111;
+            border: 1px solid rgba(255, 255, 255, 0.05);
+            border-radius: 18px;
+            box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+        }
+        .section-card h3 {
+            color: #fff;
+        }
+        .accent {
+            color: var(--primary);
+        }
+        .wave-shape {
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            width: 100%;
+            overflow: hidden;
+            line-height: 0;
+        }
+        .wave-shape svg {
+            position: relative;
+            display: block;
+            width: calc(100% + 1.3px);
+            height: 150px;
+        }
+        .wave-shape .shape-fill {
+            fill: #FFFFFF;
+        }
+        .mobile-menu {
+            max-height: 0;
+            overflow: hidden;
+            transition: max-height 0.5s ease-out;
+        }
+        .mobile-menu.open {
+            max-height: 500px;
+        }
+    </style>
+</head>
+<body class="text-gray-100">
+    <!-- Navigation -->
+    <nav id="navbar" class="navbar fixed w-full z-50 shadow-sm transition-all duration-300">
+        <div class="container mx-auto px-6 py-3">
+            <div class="flex justify-between items-center">
+                <a href="index.html" class="text-2xl font-bold flex items-center">
+                    <div class="w-10 h-10 rounded-full bg-gradient-to-r from-yellow-500 to-amber-600 flex items-center justify-center mr-2">
+                        <i class="fas fa-plane text-white text-lg transform -rotate-45"></i>
+                    </div>
+                    <span class="heading-font bg-gradient-to-r from-yellow-500 to-amber-600 bg-clip-text text-transparent">Carl Travels</span>
+                </a>
+                <div class="hidden md:flex items-center space-x-8">
+                    <a href="index.html" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">Home</a>
+                    <a href="destinations.html" class="text-yellow-500 font-medium transition-colors">Destinations</a>
+                    <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">Videos</a>
+                    <a href="blog.html" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">Blog</a>
+                    <a href="gear.html" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">Gear</a>
+                    <a href="index.html#about" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">About</a>
+                    <a href="donate.html" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">Donate</a>
+                    <a href="index.html#contact" class="px-4 py-2 bg-gradient-to-r from-yellow-500 to-amber-600 text-white rounded-full hover:shadow-lg transition-all">Contact</a>
+                </div>
+                <button id="mobile-menu-button" class="md:hidden text-gray-700 focus:outline-none">
+                    <i class="fas fa-bars text-2xl"></i>
+                </button>
+            </div>
+            <!-- Mobile Menu -->
+            <div id="mobile-menu" class="mobile-menu md:hidden">
+                <div class="px-2 pt-2 pb-3 space-y-1">
+                    <a href="index.html" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">Home</a>
+                    <a href="destinations.html" class="block px-3 py-2 rounded-md text-yellow-500 hover:bg-yellow-900">Destinations</a>
+                    <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">Videos</a>
+                    <a href="blog.html" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">Blog</a>
+                    <a href="gear.html" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">Gear</a>
+                    <a href="index.html#about" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">About</a>
+                    <a href="donate.html" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">Donate</a>
+                    <a href="index.html#contact" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">Contact</a>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <!-- Hero Section -->
+    <header class="hero-gradient pt-28 pb-24 relative overflow-hidden">
+        <div class="container mx-auto px-6 flex flex-col lg:flex-row items-center gap-10">
+            <div class="lg:w-1/2 space-y-6">
+                <div class="inline-flex items-center px-3 py-1 rounded-full bg-white/10 border border-white/20 text-xs uppercase tracking-widest text-yellow-200">Vietnam • One-Day Loop</div>
+                <h1 class="heading-font text-4xl md:text-5xl text-white leading-tight">A Full Day in <span class="text-yellow-400">Ho Chi Minh City</span> (Saigon)</h1>
+                <p class="text-lg text-gray-100/90">Markets, skyline views, and neon chaos — a realistic District 1 day that flows, not a rushed checklist.</p>
+                <div class="flex flex-wrap gap-3 text-sm text-gray-100/80">
+                    <span class="px-3 py-2 bg-white/10 rounded-full border border-white/10">Base: A&E Guest House, Đỗ Quang Đẩu</span>
+                    <span class="px-3 py-2 bg-white/10 rounded-full border border-white/10">Morning: Ben Thanh Market</span>
+                    <span class="px-3 py-2 bg-white/10 rounded-full border border-white/10">Afternoon: Bitexco Skydeck</span>
+                    <span class="px-3 py-2 bg-white/10 rounded-full border border-white/10">Night: Bùi Viện Walking Street</span>
+                </div>
+                <a href="#itinerary" class="inline-flex items-center px-5 py-3 bg-gradient-to-r from-yellow-500 to-amber-600 text-white rounded-full shadow-lg hover:shadow-xl transition">Jump to the day <i class="fas fa-arrow-down ml-2"></i></a>
+            </div>
+            <div class="lg:w-1/2">
+                <div class="aspect-video rounded-2xl overflow-hidden shadow-2xl border border-white/10">
+                    <iframe class="w-full h-full" src="https://www.youtube.com/embed/ULOM2GJDvak" title="Ben Thanh Market Walkthrough" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                </div>
+            </div>
+        </div>
+    </header>
+
+    <main class="py-16 relative">
+        <div class="container mx-auto px-6 space-y-12" id="itinerary">
+            <!-- Stay + overview -->
+            <section class="section-card p-8 md:p-10 space-y-6">
+                <div class="flex items-start justify-between gap-6 flex-col md:flex-row">
+                    <div class="space-y-3 md:w-2/3">
+                        <h2 class="heading-font text-3xl text-white">District 1 makes Saigon make sense</h2>
+                        <p class="text-gray-300 leading-relaxed">I based myself at <strong>A&E Guest House</strong> on Đỗ Quang Đẩu. It’s simple, clean, and tucked just far enough off the main drag to sleep, yet close enough to walk or Grab anywhere worth seeing. In Saigon, location beats luxury. From here, everything radiates outward.</p>
+                        <ul class="grid md:grid-cols-2 gap-3 text-gray-300">
+                            <li class="flex items-start space-x-3"><i class="fas fa-walking text-yellow-500 mt-1"></i><span>Walkable to Ben Thanh Market, Bùi Viện, and most District 1 cafes.</span></li>
+                            <li class="flex items-start space-x-3"><i class="fas fa-motorcycle text-yellow-500 mt-1"></i><span>Grab rides stay cheap and quick from this central spot.</span></li>
+                            <li class="flex items-start space-x-3"><i class="fas fa-bed text-yellow-500 mt-1"></i><span>Quiet enough to rest, but you’re still in the thick of it.</span></li>
+                            <li class="flex items-start space-x-3"><i class="fas fa-clock text-yellow-500 mt-1"></i><span>Everything in this guide fits in a single, unhurried day.</span></li>
+                        </ul>
+                    </div>
+                    <div class="md:w-1/3 bg-white/5 rounded-xl p-5 border border-white/10 space-y-3">
+                        <div class="flex items-center space-x-3">
+                            <span class="w-10 h-10 rounded-full bg-yellow-500 flex items-center justify-center text-black font-bold">1</span>
+                            <div>
+                                <p class="text-sm text-gray-400">Trip vibe</p>
+                                <p class="text-white font-semibold">Energy over polish</p>
+                            </div>
+                        </div>
+                        <div class="flex items-center space-x-3">
+                            <span class="w-10 h-10 rounded-full bg-yellow-500 flex items-center justify-center text-black font-bold">2</span>
+                            <div>
+                                <p class="text-sm text-gray-400">Budget</p>
+                                <p class="text-white font-semibold">Mid-range with street food detours</p>
+                            </div>
+                        </div>
+                        <div class="flex items-center space-x-3">
+                            <span class="w-10 h-10 rounded-full bg-yellow-500 flex items-center justify-center text-black font-bold">3</span>
+                            <div>
+                                <p class="text-sm text-gray-400">Essential pace</p>
+                                <p class="text-white font-semibold">~30–45 mins per stop, plenty of resets</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Morning -->
+            <section class="section-card p-8 md:p-10 space-y-6">
+                <div class="flex flex-col lg:flex-row gap-8">
+                    <div class="lg:w-1/2 space-y-4">
+                        <p class="text-sm uppercase tracking-wide text-yellow-400 font-semibold">Morning • Late start</p>
+                        <h3 class="heading-font text-3xl">Ben Thanh Market</h3>
+                        <p class="text-gray-300 leading-relaxed">Ben Thanh looks familiar from every Saigon roundup, but being inside is different. The clock tower, the entrances, the souvenirs on repeat — it’s still worth an hour because it compresses Saigon energy into one building. I looped for about an hour: enough to feel it, not long enough to burn out.</p>
+                        <ul class="space-y-2 text-gray-300">
+                            <li><i class="fas fa-check text-yellow-500 mr-2"></i>Souvenirs, coffee, fabric, and snacks under one roof.</li>
+                            <li><i class="fas fa-check text-yellow-500 mr-2"></i>Vendors have friendly-but-firm sales down to an art.</li>
+                            <li><i class="fas fa-check text-yellow-500 mr-2"></i>Expect the smells: grilled meat, coffee, incense. It’s part of the scene.</li>
+                        </ul>
+                        <p class="text-gray-300 leading-relaxed">Watch my walkthrough before you go so you know how the aisles flow.</p>
+                    </div>
+                    <div class="lg:w-1/2">
+                        <div class="aspect-video rounded-2xl overflow-hidden shadow-xl border border-white/10">
+                            <iframe class="w-full h-full" src="https://www.youtube.com/embed/ULOM2GJDvak" title="Inside Ben Thanh Market" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Midday -->
+            <section class="section-card p-8 md:p-10 space-y-6">
+                <div class="grid lg:grid-cols-2 gap-8 items-center">
+                    <div class="space-y-4">
+                        <p class="text-sm uppercase tracking-wide text-yellow-400 font-semibold">Midday • Reset</p>
+                        <h3 class="heading-font text-3xl">Lunch at Hoàng’s Kitchen</h3>
+                        <p class="text-gray-300 leading-relaxed">Just a short walk from Ben Thanh, Hoàng’s Kitchen on Lê Thánh Tôn nails that sweet spot between local flavor and comfort. Nothing overthought, nothing under-seasoned. This is where you remind yourself Saigon food doesn’t need hype to be good.</p>
+                        <div class="bg-white/5 border border-white/10 rounded-xl p-4 space-y-2 text-gray-200">
+                            <div class="flex items-center"><i class="fas fa-utensils text-yellow-500 mr-2"></i><span>Order what looks busy — turnover keeps dishes fresh.</span></div>
+                            <div class="flex items-center"><i class="fas fa-mug-hot text-yellow-500 mr-2"></i><span>Pair lunch with an iced coffee and slow down the pace.</span></div>
+                            <div class="flex items-center"><i class="fas fa-walking text-yellow-500 mr-2"></i><span>Walk a block off the main road afterward to let the noise fade.</span></div>
+                        </div>
+                    </div>
+                    <div class="space-y-4 text-gray-300">
+                        <h4 class="text-lg font-semibold text-white">Route check</h4>
+                        <p>Everything stays tight around District 1. You’re never far from a cafe or a seat. Use this break to recharge before going vertical at Bitexco.</p>
+                        <ul class="space-y-2">
+                            <li class="flex items-start"><i class="fas fa-map-marker-alt text-yellow-500 mr-2 mt-1"></i><span>Ben Thanh → Hoàng’s Kitchen: ~5–10 minutes on foot.</span></li>
+                            <li class="flex items-start"><i class="fas fa-clock text-yellow-500 mr-2 mt-1"></i><span>Lunch window: keep it to 45 minutes so you can time the skydeck for late afternoon light.</span></li>
+                        </ul>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Afternoon -->
+            <section class="section-card p-8 md:p-10 space-y-6">
+                <div class="flex flex-col lg:flex-row gap-8">
+                    <div class="lg:w-1/2 space-y-4">
+                        <p class="text-sm uppercase tracking-wide text-yellow-400 font-semibold">Afternoon • Perspective</p>
+                        <h3 class="heading-font text-3xl">Bitexco Financial Tower – Saigon Skydeck</h3>
+                        <p class="text-gray-300 leading-relaxed">The Bitexco Skydeck isn’t an all-day thing. It’s a 30–45 minute perspective shift. Walk the viewing floor, grab your photos, and see how huge the city really is. From above, the traffic becomes patterns and the river cuts calm lines through the chaos.</p>
+                        <ul class="space-y-2 text-gray-300">
+                            <li><i class="fas fa-check text-yellow-500 mr-2"></i>Best timed for late afternoon or sunset.</li>
+                            <li><i class="fas fa-check text-yellow-500 mr-2"></i>Expect lines to move quickly outside peak holiday periods.</li>
+                            <li><i class="fas fa-check text-yellow-500 mr-2"></i>Stay flexible — 45 minutes is enough if you’re not lingering for cocktails.</li>
+                        </ul>
+                    </div>
+                    <div class="lg:w-1/2">
+                        <div class="aspect-video rounded-2xl overflow-hidden shadow-xl border border-white/10">
+                            <iframe class="w-full h-full" src="https://www.youtube.com/embed/d9sYNf3EzdI" title="Saigon Skydeck at Bitexco" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Night -->
+            <section class="section-card p-8 md:p-10 space-y-6">
+                <div class="grid lg:grid-cols-2 gap-8 items-center">
+                    <div class="space-y-4">
+                        <p class="text-sm uppercase tracking-wide text-yellow-400 font-semibold">Night • Controlled chaos</p>
+                        <h3 class="heading-font text-3xl">Bùi Viện Walking Street</h3>
+                        <p class="text-gray-300 leading-relaxed">Bùi Viện is loud, crowded, and unapologetic. Neon everywhere, bass from every direction, backpackers, locals, expats, tourists all spilling onto the street. You don’t have to love it, but you should feel it — for about one to three hours is plenty.</p>
+                        <ul class="space-y-2 text-gray-300">
+                            <li><i class="fas fa-check text-yellow-500 mr-2"></i>Pick a vantage point: a low plastic chair or a rooftop bar a block away.</li>
+                            <li><i class="fas fa-check text-yellow-500 mr-2"></i>Keep your plans loose and your valuables zipped up.</li>
+                            <li><i class="fas fa-check text-yellow-500 mr-2"></i>When the novelty wears off, exit quickly — District 1 streets have quieter corners.</li>
+                        </ul>
+                    </div>
+                    <div class="space-y-4">
+                        <div class="aspect-video rounded-2xl overflow-hidden shadow-xl border border-white/10">
+                            <iframe class="w-full h-full" src="https://www.youtube.com/embed/UoV_VVndccs" title="Night walk on Bui Vien" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                        </div>
+                        <p class="text-gray-300 leading-relaxed">This is Saigon’s wild side — experience it, then step back. The city has more layers than its loudest street.</p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Recap -->
+            <section class="section-card p-8 md:p-10 space-y-6">
+                <div class="grid md:grid-cols-2 gap-8">
+                    <div class="space-y-3">
+                        <h3 class="heading-font text-3xl">One-day flow at a glance</h3>
+                        <ul class="space-y-3 text-gray-300">
+                            <li class="flex items-start"><span class="w-8 h-8 rounded-full bg-yellow-500 text-black font-bold flex items-center justify-center mr-3">1</span><span>Late morning: Ben Thanh Market — one-hour loop, soak the sensory overload.</span></li>
+                            <li class="flex items-start"><span class="w-8 h-8 rounded-full bg-yellow-500 text-black font-bold flex items-center justify-center mr-3">2</span><span>Lunch: Hoàng’s Kitchen on Lê Thánh Tôn — simple, solid, nearby.</span></li>
+                            <li class="flex items-start"><span class="w-8 h-8 rounded-full bg-yellow-500 text-black font-bold flex items-center justify-center mr-3">3</span><span>Afternoon: Bitexco Skydeck — 30–45 mins of skyline perspective.</span></li>
+                            <li class="flex items-start"><span class="w-8 h-8 rounded-full bg-yellow-500 text-black font-bold flex items-center justify-center mr-3">4</span><span>Night: Bùi Viện Walking Street — absorb the chaos, then retreat.</span></li>
+                        </ul>
+                    </div>
+                    <div class="bg-white/5 border border-white/10 rounded-2xl p-6 space-y-4">
+                        <h4 class="text-xl font-semibold text-white">Trip tips</h4>
+                        <ul class="space-y-2 text-gray-300">
+                            <li><i class="fas fa-temperature-high text-yellow-500 mr-2"></i>Heat hits fast. Hydrate and duck into cafes for AC resets.</li>
+                            <li><i class="fas fa-bolt text-yellow-500 mr-2"></i>Cross with intent. Traffic moves like a school of fish — be steady, not timid.</li>
+                            <li><i class="fas fa-credit-card text-yellow-500 mr-2"></i>Cash still wins at markets, but cards work at big attractions.</li>
+                            <li><i class="fas fa-route text-yellow-500 mr-2"></i>Keep everything in District 1 for this plan. It keeps transport simple and time on foot.</li>
+                        </ul>
+                        <p class="text-gray-200">Saigon is messy, alive, and layered. You don’t have to love every part — you just have to experience it.</p>
+                    </div>
+                </div>
+            </section>
+        </div>
+    </main>
+
+    <!-- Footer -->
+    <footer class="bg-black pt-16 pb-8">
+        <div class="container mx-auto px-6">
+            <div class="grid md:grid-cols-4 gap-10 mb-12">
+                <div>
+                    <div class="flex items-center mb-4">
+                        <div class="w-10 h-10 rounded-full bg-gradient-to-r from-yellow-500 to-amber-600 flex items-center justify-center mr-2">
+                            <i class="fas fa-plane text-white text-lg transform -rotate-45"></i>
+                        </div>
+                        <span class="heading-font text-2xl text-white">Carl Travels</span>
+                    </div>
+                    <p class="text-gray-400">Realistic travel guides from the road — not polished brochures. Every city, every layer.</p>
+                    <div class="flex space-x-4 mt-4 text-gray-400">
+                        <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="hover:text-white" aria-label="YouTube"><i class="fab fa-youtube"></i></a>
+                        <a href="https://www.instagram.com/carl_ostomich/" target="_blank" class="hover:text-white" aria-label="Instagram"><i class="fab fa-instagram"></i></a>
+                        <a href="https://www.facebook.com/profile.php?id=100090059272980" target="_blank" class="hover:text-white" aria-label="Facebook"><i class="fab fa-facebook"></i></a>
+                    </div>
+                </div>
+                <div>
+                    <h4 class="text-white font-semibold mb-4">Destinations</h4>
+                    <ul class="space-y-2 text-gray-400">
+                        <li><a href="hanoitravelguide.html" class="hover:text-white transition-colors">Hanoi</a></li>
+                        <li><a href="danangtravelguide.html" class="hover:text-white transition-colors">Da Nang</a></li>
+                        <li><a href="one-day-in-hcmc-guide.html" class="hover:text-white transition-colors">Ho Chi Minh City</a></li>
+                        <li><a href="balitravelguide.html" class="hover:text-white transition-colors">Bali</a></li>
+                        <li><a href="budvatravelguide.html" class="hover:text-white transition-colors">Budva</a></li>
+                        <li><a href="korcula.html" class="hover:text-white transition-colors">Korčula</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h4 class="text-white font-semibold mb-4">Explore</h4>
+                    <ul class="space-y-2 text-gray-400">
+                        <li><a href="destinations.html" class="hover:text-white transition-colors">All destinations</a></li>
+                        <li><a href="blog.html" class="hover:text-white transition-colors">Blog</a></li>
+                        <li><a href="gear.html" class="hover:text-white transition-colors">Gear</a></li>
+                        <li><a href="index.html#about" class="hover:text-white transition-colors">About</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h4 class="text-white font-semibold mb-4">Support</h4>
+                    <ul class="space-y-2 text-gray-400">
+                        <li><a href="donate.html" class="hover:text-white transition-colors">Donate</a></li>
+                        <li><a href="privacy-policy.html" class="hover:text-white transition-colors">Privacy Policy</a></li>
+                        <li><a href="terms-and-conditions.html" class="hover:text-white transition-colors">Terms &amp; Conditions</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="border-t border-white/10 pt-6 flex flex-col md:flex-row justify-between items-center text-gray-500 text-sm">
+                <p>© <script>document.write(new Date().getFullYear());</script> Carl Travels. All rights reserved.</p>
+                <div class="flex items-center space-x-6 mt-4 md:mt-0">
+                    <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="hover:text-white transition-colors">YouTube</a>
+                    <a href="https://www.instagram.com/carl_ostomich/" target="_blank" class="hover:text-white transition-colors">Instagram</a>
+                    <a href="https://www.facebook.com/profile.php?id=100090059272980" target="_blank" class="hover:text-white transition-colors">Facebook</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <button id="back-to-top" class="fixed bottom-6 right-6 px-4 py-3 bg-yellow-500 text-white rounded-full shadow-lg hover:bg-yellow-600 transition transform hover:-translate-y-1 opacity-0 invisible">
+        <i class="fas fa-arrow-up"></i>
+    </button>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            // Mobile menu toggle
+            const mobileMenuButton = document.getElementById('mobile-menu-button');
+            const mobileMenu = document.getElementById('mobile-menu');
+            if (mobileMenuButton && mobileMenu) {
+                mobileMenuButton.addEventListener('click', function() {
+                    mobileMenu.classList.toggle('open');
+                });
+            }
+
+            // Navbar scroll effect
+            const navbar = document.getElementById('navbar');
+            if (navbar) {
+                window.addEventListener('scroll', function() {
+                    if (window.scrollY > 50) {
+                        navbar.classList.add('scrolled');
+                    } else {
+                        navbar.classList.remove('scrolled');
+                    }
+                });
+            }
+
+            // Back to top button
+            const backToTopButton = document.getElementById('back-to-top');
+            if (backToTopButton) {
+                window.addEventListener('scroll', function() {
+                    if (window.scrollY > 300) {
+                        backToTopButton.classList.remove('opacity-0', 'invisible');
+                        backToTopButton.classList.add('opacity-100', 'visible');
+                    } else {
+                        backToTopButton.classList.remove('opacity-100', 'visible');
+                        backToTopButton.classList.add('opacity-0', 'invisible');
+                    }
+                });
+                backToTopButton.addEventListener('click', function() {
+                    window.scrollTo({ top: 0, behavior: 'smooth' });
+                });
+            }
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a new one-day Ho Chi Minh City (Saigon) guide page with embedded videos and a District 1-focused itinerary
- feature the Ho Chi Minh City guide across the destinations grid, footer, and interactive map
- restore Budva and Korčula to the interactive map with focused buttons and marker popups

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694191b2df848323a65201d39a29f029)