### PR TITLE
Adjust destination map popup size and destination list text color

### DIFF
--- a/destinations.html
+++ b/destinations.html
@@ -188,7 +188,7 @@
             background: rgba(245, 197, 24, 0.12);
         }
         .map-video-popup {
-            width: min(780px, 90vw);
+            width: min(260px, 90vw);
         }
         .map-video-frame {
             width: 100%;
@@ -200,6 +200,9 @@
         .map-video-frame iframe {
             width: 100%;
             height: 100%;
+        }
+        .map-destination-item .text-gray-900 {
+            color: #ffffff !important;
         }
         .destination-card .bg-white {
             background-color: #0d0d0d !important;


### PR DESCRIPTION
### Motivation
- The video popups on destination map pins became too large after a prior change and should be reduced to roughly one third of the previous width.  
- Destination list city names on the right-hand panel are hard to read on the dark background and need to be forced to white for contrast.  
- Keep the interactive map preview compact and improve overall readability.  

### Description
- Reduced the popup width by changing `.map-video-popup` from `min(780px, 90vw)` to `min(260px, 90vw)` in `destinations.html`.  
- Added a CSS rule `.map-destination-item .text-gray-900 { color: #ffffff !important; }` to ensure city names render in white.  
- Changes were made directly in the single file `destinations.html`.  

### Testing
- Started a local HTTP server with `python -m http.server` to serve the site, which launched successfully.  
- Attempted an automated visual check using Playwright to capture `destinations.html`, but the Playwright run timed out and failed.  
- No unit tests or additional automated test suites were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69483c3779fc8323b0b082df169a21aa)