### PR TITLE
Fix speaker article image reference

### DIFF
--- a/bose-s1pro-plus-vs-everse8-the-best-portable-speaker.html
+++ b/bose-s1pro-plus-vs-everse8-the-best-portable-speaker.html
@@ -21,14 +21,14 @@
     <!-- Open Graph Meta Tags -->
     <meta property="og:title" content="Bose S1 Pro Plus vs. Everse 8: Best Portable PA Speaker? - Carl Travels">
     <meta property="og:description" content="Carl compares the Bose S1 Pro Plus and Electro-Voice Everse 8 to help you choose the best portable PA for your needs.">
-    <meta property="og:image" content="https://www.carltravels.com/images/busking.jpg">
+    <meta property="og:image" content="https://www.carltravels.com/bose.jpeg">
     <meta property="og:url" content="https://www.carltravels.com/bose-s1pro-plus-vs-everse8-the-best-portable-speaker.html">
     <meta property="og:type" content="article">
     <!-- Twitter Card Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Bose S1 Pro Plus vs. Everse 8: Best Portable PA Speaker? - Carl Travels">
     <meta name="twitter:description" content="Carl compares the Bose S1 Pro Plus and Electro-Voice Everse 8 to help you choose the best portable PA for your needs.">
-    <meta name="twitter:image" content="https://www.carltravels.com/images/busking.jpg">
+    <meta name="twitter:image" content="https://www.carltravels.com/bose.jpeg">
     <!-- External Resources -->
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
@@ -170,7 +170,7 @@
                         <div class="absolute -top-6 -left-6 w-32 h-32 bg-yellow-300 rounded-full opacity-20 animate-pulse"></div>
                         <div class="absolute -bottom-6 -right-6 w-32 h-32 bg-yellow-300 rounded-full opacity-20 animate-pulse delay-300"></div>
                         <div class="relative rounded-2xl overflow-hidden shadow-2xl border-8 border-white transform rotate-2">
-                            <img src="images/busking.jpg" alt="Bose S1 Pro Plus and Everse 8" class="w-full h-auto">
+                            <img src="bose.jpeg" alt="Bose S1 Pro Plus and Everse 8" class="w-full h-auto">
                             <div class="absolute inset-0 bg-gradient-to-t from-yellow-500 to-transparent opacity-70"></div>
                             <div class="absolute bottom-0 left-0 p-6 text-white">
                                 <h3 class="text-xl font-bold">Portable PA Showdown</h3>


### PR DESCRIPTION
### Motivation
- The review page referenced an incorrect image path for the hero and social previews, causing a missing or wrong image when sharing or viewing the article. 
- The repository contains `bose.jpeg` in the project root which should be used for the article hero and social metadata. 
- Updating the references fixes on-page visuals and social share previews.

### Description
- Replaced `og:image` value with `https://www.carltravels.com/bose.jpeg` in `bose-s1pro-plus-vs-everse8-the-best-portable-speaker.html`.
- Replaced `twitter:image` value with `https://www.carltravels.com/bose.jpeg` in the same file.
- Updated the hero `<img>` `src` from `images/busking.jpg` to `bose.jpeg` inside `bose-s1pro-plus-vs-everse8-the-best-portable-speaker.html`.

### Testing
- No automated tests were run for this static content change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69489d04c7948323893f9f919daebb0e)