### PR TITLE
Add Ha Long Bay travel guide page and register it in destinations

### DIFF
--- a/destinations.html
+++ b/destinations.html
@@ -463,6 +463,33 @@
                         </div>
                     </div>
                 </div>
+                <!-- Destination 6a: Ha Long Bay -->
+                <div class="destination-card rounded-xl overflow-hidden shadow-lg" data-destination-id="halongbay">
+                    <div class="destination-card-inner">
+                        <div class="relative overflow-hidden h-64">
+                            <img src="https://img.youtube.com/vi/gWw7ygXH_Eo/maxresdefault.jpg" alt="Ha Long Bay limestone islands" class="w-full h-full object-cover transform hover:scale-110 transition-transform duration-500">
+                            <div class="absolute inset-0 destination-overlay"></div>
+                            <div class="absolute bottom-0 left-0 p-6 text-white">
+                                <h3 class="text-xl font-bold">Ha Long Bay</h3>
+                                <p class="text-sm">Cruises & Karst Lagoons</p>
+                            </div>
+                            <span class="absolute top-4 right-4 bg-yellow-500 text-black text-xs px-3 py-1 rounded-full">New</span>
+                        </div>
+                        <div class="p-6 bg-white">
+                            <div class="flex justify-between items-center mb-3">
+                                <span class="text-gray-500 text-sm"><i class="fas fa-map-marker-alt mr-1 text-yellow-500"></i> Asia</span>
+                                <div class="flex items-center">
+                                    <i class="fas fa-star text-yellow-400 mr-1"></i>
+                                    <span class="font-medium">4.9</span>
+                                </div>
+                            </div>
+                            <p class="text-gray-600 mb-4">Plan the right cruise length, costs, and itinerary for Vietnam’s most iconic bay.</p>
+                            <a href="ha-long-bay-travel-guide/" class="text-yellow-500 font-medium hover:text-yellow-500 inline-flex items-center">
+                                View Details <i class="fas fa-arrow-right ml-2"></i>
+                            </a>
+                        </div>
+                    </div>
+                </div>
                 <!-- Destination 6b: Ho Chi Minh City -->
                 <div class="destination-card rounded-xl overflow-hidden shadow-lg" data-destination-id="hcmc">
                     <div class="destination-card-inner">
@@ -937,6 +964,15 @@
                                         <span class="text-yellow-500"><i class="fas fa-play"></i></span>
                                     </div>
                                 </button>
+                                <button class="map-destination-item w-full text-left px-4 py-3 rounded-xl bg-white" data-map-destination="halongbay">
+                                    <div class="flex items-center justify-between">
+                                        <div>
+                                            <p class="text-sm text-gray-500">Vietnam</p>
+                                            <p class="font-semibold text-gray-900">Ha Long Bay</p>
+                                        </div>
+                                        <span class="text-yellow-500"><i class="fas fa-play"></i></span>
+                                    </div>
+                                </button>
                                 <button class="map-destination-item w-full text-left px-4 py-3 rounded-xl bg-white" data-map-destination="hcmc">
                                     <div class="flex items-center justify-between">
                                         <div>
@@ -1342,6 +1378,13 @@
                             coords: [21.0278, 105.8342],
                             url: 'top-10-things-to-do-in-hanoi.html',
                             video: 'https://www.youtube.com/embed/lTRbrZT3r9A'
+                        },
+                        {
+                            id: 'halongbay',
+                            name: 'Ha Long Bay, Vietnam',
+                            coords: [20.9101, 107.1839],
+                            url: 'ha-long-bay-travel-guide/',
+                            video: 'https://www.youtube.com/embed/gWw7ygXH_Eo'
                         },
                         {
                             id: 'hcmc',

--- a/ha-long-bay-travel-guide/index.html
+++ b/ha-long-bay-travel-guide/index.html
@@ -1,0 +1,485 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ha Long Bay Travel Guide (2026): How to Go, Best Cruises, Costs & Itineraries</title>
+    <!-- Cookiebot for GDPR Compliance -->
+    <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="e44b7cd2-126b-4f49-8aee-22495afe3ece" type="text/javascript" async></script>
+    <!-- SEO Meta Tags -->
+    <meta name="description" content="Plan your Ha Long Bay trip with practical advice on getting there from Hanoi, cruise options, pricing, itineraries, and realistic expectations for 2026." />
+    <meta name="keywords" content="Ha Long Bay travel guide 2026, Ha Long Bay cruises, Lan Ha Bay, Bai Tu Long Bay, Hanoi to Ha Long Bay, Vietnam itinerary" />
+    <!-- Open Graph -->
+    <meta property="og:title" content="Ha Long Bay Travel Guide (2026): How to Go, Best Cruises, Costs & Itineraries" />
+    <meta property="og:description" content="A practical Ha Long Bay travel guide with transport tips, cruise choices, pricing examples, and realistic itineraries for 1, 2, or 3 days." />
+    <meta property="og:image" content="https://img.youtube.com/vi/gWw7ygXH_Eo/maxresdefault.jpg" />
+    <meta property="og:url" content="https://www.carltravels.com/ha-long-bay-travel-guide/" />
+    <meta property="og:type" content="article" />
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Ha Long Bay Travel Guide (2026): How to Go, Best Cruises, Costs & Itineraries" />
+    <meta name="twitter:description" content="How to visit Ha Long Bay without wasting time or money: cruise options, pricing, itineraries, and real-world tips." />
+    <meta name="twitter:image" content="https://img.youtube.com/vi/gWw7ygXH_Eo/maxresdefault.jpg" />
+    <!-- Structured Data -->
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "TravelArticle",
+        "headline": "Ha Long Bay Travel Guide (2026): How to Go, Best Cruises, Costs & Itineraries",
+        "description": "A practical Ha Long Bay travel guide covering transport from Hanoi, cruise options, pricing examples, itineraries, and best time to visit.",
+        "image": "https://img.youtube.com/vi/gWw7ygXH_Eo/maxresdefault.jpg",
+        "author": { "@type": "Person", "name": "Carl Tomich" },
+        "publisher": {
+            "@type": "Organization",
+            "name": "Carl Travels",
+            "logo": { "@type": "ImageObject", "url": "https://www.carltravels.com/carlcircle.png" }
+        },
+        "mainEntityOfPage": { "@type": "WebPage", "@id": "https://www.carltravels.com/ha-long-bay-travel-guide/" }
+    }
+    </script>
+    <!-- Ads & Analytics -->
+    <script async src="https://pagead2.googlesyndication.com/pagead/js?client=ca-pub-6483721386563068" crossorigin="anonymous"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-G72KT5ZW2J"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);} 
+        gtag('js', new Date());
+        gtag('config', 'G-G72KT5ZW2J');
+    </script>
+    <!-- Tailwind & Icons -->
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <!-- Fonts -->
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700&family=Bebas+Neue&display=swap" rel="stylesheet">
+    <!-- Custom Styles -->
+    <style>
+        :root {
+            --primary: #f5c518;
+            --secondary: #2a2a2a;
+            --dark: #1a1a1a;
+            --light: #d4d4d4;
+        }
+        body {
+            font-family: 'Montserrat', sans-serif;
+            background-color: var(--dark);
+            color: var(--light);
+            scroll-behavior: smooth;
+        }
+        .heading-font {
+            font-family: 'Bebas Neue', sans-serif;
+            letter-spacing: 2px;
+        }
+        .navbar {
+            backdrop-filter: blur(10px);
+            background-color: rgba(26, 26, 26, 0.9);
+            transition: all 0.3s ease;
+        }
+        .navbar.scrolled {
+            background-color: rgba(26, 26, 26, 0.98);
+            box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.3);
+        }
+        .mobile-menu {
+            max-height: 0;
+            overflow: hidden;
+            transition: max-height 0.5s ease-out;
+        }
+        .mobile-menu.open {
+            max-height: 500px;
+        }
+        .hero-overlay {
+            background: linear-gradient(180deg, rgba(0,0,0,0.35) 0%, rgba(0,0,0,0.78) 75%, rgba(0,0,0,0.95) 100%);
+        }
+        .glass-card {
+            background: rgba(26, 26, 26, 0.7);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            backdrop-filter: blur(12px);
+        }
+        .highlight-card {
+            background: rgba(15, 15, 15, 0.65);
+            border: 1px solid rgba(255, 255, 255, 0.06);
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
+        }
+        .highlight-card:hover {
+            transform: translateY(-6px);
+            box-shadow: 0 20px 45px -20px rgba(0, 0, 0, 0.45);
+        }
+    </style>
+</head>
+<body class="text-gray-200">
+    <!-- Navigation -->
+    <nav id="navbar" class="navbar fixed w-full z-50 shadow-sm transition-all duration-300">
+        <div class="container mx-auto px-6 py-3">
+            <div class="flex justify-between items-center">
+                <a href="../index.html" class="text-2xl font-bold flex items-center">
+                    <div class="w-10 h-10 rounded-full bg-gradient-to-r from-yellow-500 to-amber-600 flex items-center justify-center mr-2">
+                        <i class="fas fa-compass text-black text-lg"></i>
+                    </div>
+                    <span class="heading-font bg-gradient-to-r from-yellow-500 to-amber-600 bg-clip-text text-transparent">Carl Travels</span>
+                </a>
+                <div class="hidden md:flex items-center space-x-8">
+                    <a href="../index.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Home</a>
+                    <a href="../destinations.html" class="text-yellow-500 font-medium transition-colors">Destinations</a>
+                    <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Videos</a>
+                    <a href="../blog.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Blog</a>
+                    <a href="../gear.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Gear</a>
+                    <a href="../index.html#about" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">About</a>
+                    <a href="../index.html#contact" class="px-4 py-2 bg-gradient-to-r from-yellow-500 to-amber-600 text-black rounded-full hover:shadow-lg transition-all">Contact</a>
+                </div>
+                <button id="mobile-menu-button" class="md:hidden text-gray-300 focus:outline-none">
+                    <i class="fas fa-bars text-2xl"></i>
+                </button>
+            </div>
+            <div id="mobile-menu" class="mobile-menu md:hidden">
+                <div class="pt-4 pb-2 space-y-2">
+                    <a href="../index.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Home</a>
+                    <a href="../destinations.html" class="block px-3 py-2 rounded-md bg-yellow-900 text-yellow-500 font-medium">Destinations</a>
+                    <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Videos</a>
+                    <a href="../blog.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Blog</a>
+                    <a href="../gear.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Gear</a>
+                    <a href="../index.html#about" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">About</a>
+                    <a href="../index.html#contact" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Contact</a>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <!-- Hero Section -->
+    <section class="relative min-h-[70vh] flex items-end pt-24" style="background-image: url('https://img.youtube.com/vi/gWw7ygXH_Eo/maxresdefault.jpg'); background-size: cover; background-position: center;">
+        <div class="absolute inset-0 hero-overlay"></div>
+        <div class="container mx-auto px-6 py-20 relative z-10">
+            <div class="max-w-3xl">
+                <span class="text-yellow-400 tracking-[0.35em] uppercase text-xs">Ha Long Bay Travel Guide</span>
+                <h1 class="heading-font text-4xl md:text-6xl text-white mt-4 mb-6 leading-tight">Ha Long Bay Travel Guide (2026)</h1>
+                <p class="text-lg md:text-xl text-gray-200 leading-relaxed">Ha Long Bay is one of those places that looks unreal in photos and even better in person — but only if you plan it right. This guide breaks down how to get there from Hanoi, which cruise lengths actually make sense, what prices look like in 2026, and how to avoid the classic mistakes that waste an entire day.</p>
+                <div class="mt-8 flex flex-wrap gap-4">
+                    <a href="#video" class="px-6 py-3 bg-yellow-500 text-black rounded-full font-semibold hover:bg-yellow-400 transition">Watch the Video</a>
+                    <a href="#plan" class="px-6 py-3 border border-yellow-500 text-yellow-500 rounded-full font-semibold hover:bg-yellow-500 hover:text-black transition">Plan the Trip</a>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Video Section -->
+    <section id="video" class="py-16 bg-secondary">
+        <div class="container mx-auto px-6">
+            <div class="text-center mb-12">
+                <span class="text-yellow-500 font-medium tracking-widest uppercase text-sm">Featured Episode</span>
+                <h2 class="heading-font text-3xl md:text-5xl text-white mt-4">Ha Long Bay From the Water</h2>
+                <p class="text-gray-300 max-w-3xl mx-auto mt-4">If you want a sense of what the karst islands, caves, and cruise pace feel like, this video gives you the view from the deck.</p>
+            </div>
+            <div class="relative aspect-video rounded-3xl overflow-hidden shadow-2xl">
+                <iframe class="absolute inset-0 w-full h-full" src="https://www.youtube.com/embed/gWw7ygXH_Eo" title="Ha Long Bay Travel Guide" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+            </div>
+        </div>
+    </section>
+
+    <!-- Overview Section -->
+    <section class="py-16 bg-dark">
+        <div class="container mx-auto px-6 grid lg:grid-cols-3 gap-12 items-start">
+            <div class="lg:col-span-2 space-y-6">
+                <h3 class="heading-font text-3xl md:text-4xl text-white">Overview</h3>
+                <p class="text-gray-300 leading-relaxed">Ha Long Bay sits in the Gulf of Tonkin in northern Vietnam and covers a huge area of karst islands and coves. It is a UNESCO World Heritage Site for a reason: the limestone towers rise straight out of emerald water and the scale is impossible to understand until you are moving through it.</p>
+                <p class="text-gray-300 leading-relaxed">Nearby bays often appear in itineraries because they feel quieter. Lan Ha Bay is calmer with protected lagoons, while Bai Tu Long Bay is more remote and used by longer cruises to avoid the busiest zones.</p>
+                            </div>
+            <div class="glass-card rounded-3xl p-8 shadow-xl">
+                <h4 class="heading-font text-2xl text-white mb-4">Quick Facts</h4>
+                <ul class="space-y-4 text-gray-300">
+                    <li><i class="fas fa-location-dot text-yellow-500 mr-3"></i>Location: 160 km east of Hanoi in northern Vietnam.</li>
+                    <li><i class="fas fa-ship text-yellow-500 mr-3"></i>Main departures: Tuan Chau or Ha Long Harbor.</li>
+                    <li><i class="fas fa-clock text-yellow-500 mr-3"></i>Suggested stay: 2 to 3 days.</li>
+                    <li><i class="fas fa-water text-yellow-500 mr-3"></i>Nearby bays: Lan Ha Bay and Bai Tu Long Bay.</li>
+                </ul>
+            </div>
+        </div>
+    </section>
+
+    <!-- Who It Is For Section -->
+    <section class="py-16 bg-secondary">
+        <div class="container mx-auto px-6 grid lg:grid-cols-2 gap-12 items-start">
+            <div class="space-y-6">
+                <h3 class="heading-font text-3xl md:text-4xl text-white">Who Ha Long Bay is for — and who should skip it</h3>
+                <p class="text-gray-300 leading-relaxed">Ha Long Bay works best if you like slow scenery days, photography, and water activities like kayaking or bamboo boats. If you are on a tight schedule or hate crowds, the logistics and busy boats can make it feel like more hassle than reward.</p>
+            </div>
+            <div class="glass-card rounded-3xl p-8 shadow-xl space-y-6">
+                <h4 class="heading-font text-2xl text-white">Quick Check</h4>
+                <ul class="space-y-4 text-gray-300">
+                    <li><i class="fas fa-check text-yellow-500 mr-3"></i>Yes if you want dramatic scenery and time on the water.</li>
+                    <li><i class="fas fa-check text-yellow-500 mr-3"></i>Yes if you can handle early departures and long travel days.</li>
+                    <li><i class="fas fa-xmark text-yellow-500 mr-3"></i>No if you only have one spare day in Hanoi.</li>
+                    <li><i class="fas fa-xmark text-yellow-500 mr-3"></i>No if boats, crowds, or motion bother you.</li>
+                </ul>
+            </div>
+        </div>
+    </section>
+
+    <!-- Getting There Section -->
+    <section id="plan" class="py-16 bg-dark">
+        <div class="container mx-auto px-6 grid lg:grid-cols-2 gap-12 items-start">
+            <div class="space-y-6">
+                <h3 class="heading-font text-3xl md:text-4xl text-white">How to get there (from Hanoi & northern Vietnam)</h3>
+                <p class="text-gray-300 leading-relaxed">Most travelers reach Ha Long Bay from Hanoi. The drive is roughly 160 km and takes around 2.5 to 3 hours depending on traffic and the shuttle route.</p>
+                <p class="text-gray-300 leading-relaxed">The standard option is an express shuttle or limousine van. Expect to pay about $10 to $20 USD one way if you book separately, or it may be bundled into your cruise. Private cars are quicker and more flexible for groups but cost more.</p>
+                <p class="text-gray-300 leading-relaxed">From Sapa or other northern provinces, overnight buses run directly to Ha Long City (about $20 USD, 9 to 10 hours). Train routes require a transfer via Hai Phong and usually take longer.</p>
+            </div>
+            <div class="glass-card rounded-3xl p-8 shadow-xl space-y-6">
+                <h4 class="heading-font text-2xl text-white">Transport Pricing Snapshot</h4>
+                <ul class="space-y-4 text-gray-300">
+                    <li><i class="fas fa-bus text-yellow-500 mr-3"></i>Shuttle or limousine: about $10–$20 one way.</li>
+                    <li><i class="fas fa-car text-yellow-500 mr-3"></i>Private car: higher cost, fastest option for families.</li>
+                    <li><i class="fas fa-train text-yellow-500 mr-3"></i>Train + bus via Hai Phong: longer, rarely worth it.</li>
+                    <li><i class="fas fa-moon text-yellow-500 mr-3"></i>Overnight bus from Sapa: around $20, 9–10 hours.</li>
+                </ul>
+            </div>
+        </div>
+    </section>
+
+    <!-- Best Ways to Go Section -->
+    <section class="py-16 bg-secondary">
+        <div class="container mx-auto px-6">
+            <div class="text-center mb-12">
+                <span class="text-yellow-500 font-medium tracking-widest uppercase text-sm">Choosing the Cruise</span>
+                <h3 class="heading-font text-3xl md:text-5xl text-white mt-4">Best ways to experience Ha Long Bay</h3>
+                <p class="text-gray-300 max-w-3xl mx-auto mt-4">There are three main formats: a quick day cruise, a 2 day/1 night cruise, and a 3 day/2 night cruise. The right option depends on your time and tolerance for long travel days.</p>
+            </div>
+            <div class="grid lg:grid-cols-3 gap-8">
+                <div class="highlight-card rounded-3xl p-6">
+                    <h4 class="heading-font text-2xl text-white mb-3">Full day tour (6–8 hours)</h4>
+                    <p class="text-gray-300 leading-relaxed">This is the budget and time saver option. You leave Hanoi early, sail past the main karsts, visit one cave, kayak or take a bamboo boat, then return late.</p>
+                </div>
+                <div class="highlight-card rounded-3xl p-6">
+                    <h4 class="heading-font text-2xl text-white mb-3">2 days / 1 night cruise</h4>
+                    <p class="text-gray-300 leading-relaxed">This is the best balance. You get sunset and sunrise on the water, enough time for a cave or viewpoint, and one evening on board. The bay feels less like a checklist and more like a place.</p>
+                </div>
+                <div class="highlight-card rounded-3xl p-6">
+                    <h4 class="heading-font text-2xl text-white mb-3">3 days / 2 nights cruise</h4>
+                    <p class="text-gray-300 leading-relaxed">The extra day lets you reach quieter zones such as Lan Ha Bay or Bai Tu Long Bay. If you want a slower pace with more kayaking and village stops, this is the itinerary that delivers.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Pricing Section -->
+    <section class="py-16 bg-dark">
+        <div class="container mx-auto px-6 grid lg:grid-cols-2 gap-12 items-start">
+            <div class="space-y-6">
+                <h3 class="heading-font text-3xl md:text-4xl text-white">Current pricing examples (2025–2026)</h3>
+                <p class="text-gray-300 leading-relaxed">Ha Long Bay is more expensive than many other Vietnam highlights, especially compared with Ninh Binh. Budget day cruises can be good value, but quality varies, so read recent reviews or stick with a mid-range operator.</p>
+                <p class="text-gray-300 leading-relaxed">Typical day tours range from $30 to $80 USD. Mid-range 2 day cruises often sit between $130 and $190 per person for a shared cabin, while higher end cruises push $200 to $400+ per person. Three day cruises usually start in the mid-$200s and climb past $500 for premium cabins.</p>
+                <p class="text-gray-300 leading-relaxed">Prices often include meals, kayaking, and entry fees, but transfers from Hanoi are sometimes optional. Always confirm what is included.</p>
+            </div>
+            <div class="glass-card rounded-3xl p-8 shadow-xl space-y-6">
+                <h4 class="heading-font text-2xl text-white">Pricing Snapshot</h4>
+                <ul class="space-y-4 text-gray-300">
+                    <li><i class="fas fa-ship text-yellow-500 mr-3"></i>Day cruise: about $30–$80 USD.</li>
+                    <li><i class="fas fa-bed text-yellow-500 mr-3"></i>2D1N cruise: around $130–$190+ per person.</li>
+                    <li><i class="fas fa-anchor text-yellow-500 mr-3"></i>Luxury 2D1N: roughly $200–$400+ per person.</li>
+                    <li><i class="fas fa-sun text-yellow-500 mr-3"></i>3D2N cruise: mid-$200s to $500+ per person.</li>
+                </ul>
+            </div>
+        </div>
+    </section>
+
+    <!-- Cruise Experience Section -->
+    <section class="py-16 bg-secondary">
+        <div class="container mx-auto px-6 grid lg:grid-cols-2 gap-12 items-start">
+            <div class="space-y-6">
+                <h3 class="heading-font text-3xl md:text-4xl text-white">What the cruises are like</h3>
+                <p class="text-gray-300 leading-relaxed">Most cruises follow a similar rhythm. You board late morning at Tuan Chau or Ha Long Harbor, have lunch while the boat glides through the karsts, and then head out for a mix of caves, viewpoints, and kayaking. Overnight cruises add sunset time, dinner on board, and a quiet morning watching the bay wake up.</p>
+                <p class="text-gray-300 leading-relaxed">Day cruises are more group oriented and compact. Overnight boats have private cabins, multi-course meals, and extras like Tai Chi sessions or squid fishing. The big difference between budget and mid-range cruises is usually cabin size, noise levels, and the pace of the itinerary.</p>
+            </div>
+            <div class="glass-card rounded-3xl p-8 shadow-xl">
+                <h4 class="heading-font text-2xl text-white mb-4">Typical Day on the Water</h4>
+                <ul class="space-y-4 text-gray-300">
+                    <li><i class="fas fa-check text-yellow-500 mr-3"></i>Mid-morning boarding and welcome briefing.</li>
+                    <li><i class="fas fa-check text-yellow-500 mr-3"></i>Lunch served while cruising through karsts.</li>
+                    <li><i class="fas fa-check text-yellow-500 mr-3"></i>Cave visit or island viewpoint in the afternoon.</li>
+                    <li><i class="fas fa-check text-yellow-500 mr-3"></i>Kayaking or bamboo boat through lagoons.</li>
+                    <li><i class="fas fa-check text-yellow-500 mr-3"></i>Sunset on deck, dinner, and overnight stay.</li>
+                </ul>
+            </div>
+        </div>
+    </section>
+
+    <!-- Itineraries Section -->
+    <section class="py-16 bg-dark">
+        <div class="container mx-auto px-6">
+            <div class="text-center mb-12">
+                <span class="text-yellow-500 font-medium tracking-widest uppercase text-sm">Sample Itineraries</span>
+                <h3 class="heading-font text-3xl md:text-5xl text-white mt-4">1 day, 2 day, and 3 day itineraries</h3>
+                <p class="text-gray-300 max-w-3xl mx-auto mt-4">Use these as rough planning templates. Cruise operators vary, but the structure is consistent enough that you can compare options without overthinking it.</p>
+            </div>
+            <div class="grid lg:grid-cols-3 gap-8">
+                <div class="highlight-card rounded-3xl p-6">
+                    <h4 class="heading-font text-2xl text-white mb-3">1 Day – Quick Overview</h4>
+                    <p class="text-gray-300 leading-relaxed">07:00 pickup in Hanoi, arrive around 11:00, lunch on board, then a cave and kayaking stop before returning to the harbor. Expect to be back in Hanoi around 20:00. It works if you are time poor, but it is a long day with little downtime.</p>
+                </div>
+                <div class="highlight-card rounded-3xl p-6">
+                    <h4 class="heading-font text-2xl text-white mb-3">2 Days – Balanced</h4>
+                    <p class="text-gray-300 leading-relaxed">Day 1 includes transfer, boarding, lunch, a cave or viewpoint, and sunset on deck. Day 2 starts with sunrise and Tai Chi, then one more excursion before lunch and the return drive. This is the sweet spot for most travelers.</p>
+                </div>
+                <div class="highlight-card rounded-3xl p-6">
+                    <h4 class="heading-font text-2xl text-white mb-3">3 Days – Deep Dive</h4>
+                    <p class="text-gray-300 leading-relaxed">The extra day pushes into Lan Ha Bay or Bai Tu Long Bay with quieter water, more kayaking, and possible village stops.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Best Time Section -->
+    <section class="py-16 bg-secondary">
+        <div class="container mx-auto px-6 grid lg:grid-cols-2 gap-12 items-start">
+            <div class="space-y-6">
+                <h3 class="heading-font text-3xl md:text-4xl text-white">Best time to visit & weather</h3>
+                <p class="text-gray-300 leading-relaxed">Spring (March to May) and autumn (September to November) are the most comfortable windows. You get warm days, lower humidity, and clearer skies for photos. Summer is hotter with more rain and occasional storms that can cancel cruises. Winter can be cool and misty, which looks dramatic but cuts visibility.</p>
+                <p class="text-gray-300 leading-relaxed">For the best mix of weather and visibility, aim for late March to early May or late September to early November.</p>
+            </div>
+            <div class="glass-card rounded-3xl p-8 shadow-xl">
+                <h4 class="heading-font text-2xl text-white mb-4">Weather At a Glance</h4>
+                <ul class="space-y-4 text-gray-300">
+                    <li><i class="fas fa-sun text-yellow-500 mr-3"></i>Spring: warm, clear, best visibility.</li>
+                    <li><i class="fas fa-cloud-rain text-yellow-500 mr-3"></i>Summer: hot, humid, more storms.</li>
+                    <li><i class="fas fa-wind text-yellow-500 mr-3"></i>Autumn: mild, clear, stable seas.</li>
+                    <li><i class="fas fa-cloud text-yellow-500 mr-3"></i>Winter: cool, misty, fewer crowds.</li>
+                </ul>
+            </div>
+        </div>
+    </section>
+
+    <!-- Safety Section -->
+    <section class="py-16 bg-dark">
+        <div class="container mx-auto px-6 grid lg:grid-cols-2 gap-12 items-start">
+            <div class="space-y-6">
+                <h3 class="heading-font text-3xl md:text-4xl text-white">Safety & expectations</h3>
+                <p class="text-gray-300 leading-relaxed">Ha Long Bay is generally safe, but remember you are on a boat for long stretches. Wear the life jacket when you kayak, watch the steps when boarding, and keep electronics dry. Weather changes quickly, so listen to the crew if activities are canceled due to wind or storms.</p>
+                <p class="text-gray-300 leading-relaxed">Expect some crowds on popular routes and in famous caves like Sung Sot. If you are sensitive to motion, consider taking medication before boarding and choose a larger, more stable boat.</p>
+            </div>
+            <div class="glass-card rounded-3xl p-8 shadow-xl">
+                <h4 class="heading-font text-2xl text-white mb-4">Keep in mind</h4>
+                <ul class="space-y-4 text-gray-300">
+                    <li><i class="fas fa-life-ring text-yellow-500 mr-3"></i>Wear life jackets during kayaking.</li>
+                    <li><i class="fas fa-cloud-bolt text-yellow-500 mr-3"></i>Storms can cancel activities in summer.</li>
+                    <li><i class="fas fa-person-walking text-yellow-500 mr-3"></i>Boat steps can be slippery.</li>
+                    <li><i class="fas fa-people-group text-yellow-500 mr-3"></i>Expect crowds at headline caves.</li>
+                </ul>
+            </div>
+        </div>
+    </section>
+
+    <!-- Budget Breakdown Section -->
+    <section class="py-16 bg-secondary">
+        <div class="container mx-auto px-6 grid lg:grid-cols-2 gap-12 items-start">
+            <div class="space-y-6">
+                <h3 class="heading-font text-3xl md:text-4xl text-white">Budget breakdown (realistic)</h3>
+                <p class="text-gray-300 leading-relaxed">A basic day trip from Hanoi can be done for around $40–$90 USD including transport and lunch. A mid-range 2D1N cruise typically lands around $160–$230 USD per person once you add transfers and tips. A 3D2N cruise often ends up between $260–$550 depending on cabin class.</p>
+                <p class="text-gray-300 leading-relaxed">Factor in drinks, optional activities, and transfer costs so you do not get surprised onboard.</p>
+            </div>
+            <div class="glass-card rounded-3xl p-8 shadow-xl">
+                <h4 class="heading-font text-2xl text-white mb-4">Sample Daily Costs</h4>
+                <ul class="space-y-4 text-gray-300">
+                    <li><i class="fas fa-wallet text-yellow-500 mr-3"></i>Day tour total: $40–$90 per person.</li>
+                    <li><i class="fas fa-hotel text-yellow-500 mr-3"></i>2D1N cruise total: $160–$230 per person.</li>
+                    <li><i class="fas fa-ship text-yellow-500 mr-3"></i>3D2N cruise total: $260–$550 per person.</li>
+                    <li><i class="fas fa-utensils text-yellow-500 mr-3"></i>Most meals included on overnight cruises.</li>
+                </ul>
+            </div>
+        </div>
+    </section>
+
+    <!-- Mistakes Section -->
+    <section class="py-16 bg-dark">
+        <div class="container mx-auto px-6">
+            <div class="text-center mb-12">
+                <span class="text-yellow-500 font-medium tracking-widest uppercase text-sm">Common Mistakes</span>
+                <h3 class="heading-font text-3xl md:text-5xl text-white mt-4">Mistakes to avoid</h3>
+                <p class="text-gray-300 max-w-3xl mx-auto mt-4">Most bad experiences come from rushing the trip or chasing the cheapest ticket without checking the operator’s reputation.</p>
+            </div>
+            <div class="grid lg:grid-cols-3 gap-8">
+                <div class="highlight-card rounded-3xl p-6">
+                    <h4 class="heading-font text-2xl text-white mb-3">Trying to cram it into one day</h4>
+                    <p class="text-gray-300 leading-relaxed">A single day from Hanoi means 5–6 hours of driving plus a packed schedule. You will see the bay, but you will barely feel it.</p>
+                </div>
+                <div class="highlight-card rounded-3xl p-6">
+                    <h4 class="heading-font text-2xl text-white mb-3">Booking the cheapest cruise</h4>
+                    <p class="text-gray-300 leading-relaxed">Ultra cheap tours can be crowded and rushed. A slightly higher price often means a calmer itinerary and better cabins.</p>
+                </div>
+                <div class="highlight-card rounded-3xl p-6">
+                    <h4 class="heading-font text-2xl text-white mb-3">Not confirming pickup times</h4>
+                    <p class="text-gray-300 leading-relaxed">Transfers from Hanoi are early and sometimes change last minute. Confirm the exact pickup point the day before.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- FAQ Section -->
+    <section class="py-16 bg-secondary">
+        <div class="container mx-auto px-6 grid lg:grid-cols-2 gap-12 items-start">
+            <div class="space-y-6">
+                <h3 class="heading-font text-3xl md:text-4xl text-white">FAQ</h3>
+                <p class="text-gray-300 leading-relaxed"><strong>Is Ha Long Bay worth it?</strong> Yes, if you love nature and scenery. It is one of the most iconic landscapes in Vietnam. It is even better when you take at least one night on the water.</p>
+                <p class="text-gray-300 leading-relaxed"><strong>How long should I plan?</strong> Two days is ideal for most travelers. Three days is best if you want quieter water and a slower pace.</p>
+                <p class="text-gray-300 leading-relaxed"><strong>Can I do it on a budget?</strong> Yes. There are affordable day tours and mid-range cruises, but quality varies. Read reviews and avoid tours that are dramatically cheaper than the rest.</p>
+                <p class="text-gray-300 leading-relaxed"><strong>Do I need to book in advance?</strong> In high season, yes. Boats can sell out, and the best cabins go first. Shoulder season is more flexible.</p>
+            </div>
+            <div class="glass-card rounded-3xl p-8 shadow-xl">
+                <h4 class="heading-font text-2xl text-white mb-4">Quick Answers</h4>
+                <ul class="space-y-4 text-gray-300">
+                    <li><i class="fas fa-circle-check text-yellow-500 mr-3"></i>Best stay: 2–3 days.</li>
+                    <li><i class="fas fa-circle-check text-yellow-500 mr-3"></i>Best value: 2D1N cruise.</li>
+                    <li><i class="fas fa-circle-check text-yellow-500 mr-3"></i>Best scenery: Lan Ha or Bai Tu Long Bay.</li>
+                    <li><i class="fas fa-circle-check text-yellow-500 mr-3"></i>Best season: March–May or Sept–Nov.</li>
+                </ul>
+            </div>
+        </div>
+    </section>
+
+    <!-- Internal Links Section -->
+    <section class="py-16 bg-dark">
+        <div class="container mx-auto px-6">
+            <div class="text-center mb-12">
+                <span class="text-yellow-500 font-medium tracking-widest uppercase text-sm">Related Guides</span>
+                <h3 class="heading-font text-3xl md:text-5xl text-white mt-4">Internal links & related pages</h3>
+                <p class="text-gray-300 max-w-3xl mx-auto mt-4">If you are building a Vietnam itinerary, these guides help you connect Hanoi, Ninh Binh, and other northern highlights.</p>
+            </div>
+            <div class="grid md:grid-cols-3 gap-8">
+                <a href="../hanoitravelguide.html" class="highlight-card rounded-3xl p-6 block">
+                    <h4 class="heading-font text-2xl text-white mb-3">Hanoi Travel Guide</h4>
+                    <p class="text-gray-300 leading-relaxed">Where to stay, how to eat well, and a realistic pace for the capital.</p>
+                </a>
+                <a href="../ninhbinhtravelguide.html" class="highlight-card rounded-3xl p-6 block">
+                    <h4 class="heading-font text-2xl text-white mb-3">Ninh Binh Travel Guide</h4>
+                    <p class="text-gray-300 leading-relaxed">Karst landscapes on land, river cave rides, and an easy Hanoi escape.</p>
+                </a>
+                <a href="../top-10-things-to-do-in-hanoi.html" class="highlight-card rounded-3xl p-6 block">
+                    <h4 class="heading-font text-2xl text-white mb-3">Top Things to Do in Hanoi</h4>
+                    <p class="text-gray-300 leading-relaxed">A simple shortlist to add between Ha Long Bay and your next destination.</p>
+                </a>
+            </div>
+        </div>
+    </section>
+
+    <!-- Footer -->
+    <footer class="py-12 bg-black">
+        <div class="container mx-auto px-6 text-center text-gray-500">
+            <p>&copy; 2026 Carl Travels. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <script>
+        const navbar = document.getElementById('navbar');
+        const mobileMenuButton = document.getElementById('mobile-menu-button');
+        const mobileMenu = document.getElementById('mobile-menu');
+
+        window.addEventListener('scroll', () => {
+            if (window.scrollY > 50) {
+                navbar.classList.add('scrolled');
+            } else {
+                navbar.classList.remove('scrolled');
+            }
+        });
+
+        mobileMenuButton.addEventListener('click', () => {
+            mobileMenu.classList.toggle('open');
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Add a new destination guide for Ha Long Bay using the same template/layout/components as existing guides so the site has up-to-date 2026 travel info and an embedded video.
- Provide a practical, first-person travel guide covering transport, cruises, pricing, itineraries and tips to help readers plan without fluff.
- Surface the new guide in the site’s destinations grid and interactive map so it is discoverable from the main Destinations page.

### Description
- Added a new page at `ha-long-bay-travel-guide/index.html` containing the full Ha Long Bay travel guide (structured sections, SEO/meta tags, Open Graph, and `TravelArticle` structured data) and an embedded YouTube video (`https://www.youtube.com/embed/gWw7ygXH_Eo`).
- Reused the existing site components and styles (navigation, hero, glass/highlight cards, responsive video layout) so the new page matches other destination posts.
- Updated `destinations.html` to insert a new destination card, a map list entry button, and a `destinations` data object for `halongbay` (coords, `url: 'ha-long-bay-travel-guide/'`, and `video`), wired to the existing interactive Leaflet map and popup template.
- Minor copy/styling tweaks to ensure the guide fits the site pattern and internal links to related pages (`hanoitravelguide.html`, `ninhbinhtravelguide.html`, `top-10-things-to-do-in-hanoi.html`) were added.

### Testing
- Performed an automated word-count check on `ha-long-bay-travel-guide/index.html` to confirm content length (~2,000 words) and it succeeded.
- Launched a local HTTP server and used an automated Playwright script to load the new page and capture a full-page screenshot, and the script completed successfully.
- Verified the `destinations.html` interactive map data array includes the new `halongbay` entry and the page renders locally without JavaScript errors during the screenshot run.
- No unit/test-suite was applicable since this is a static content addition; changes were committed to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948aca0738883238e6e8d9c5c55853e)