### PR TITLE
Add transparent hero image to gear page

### DIFF
--- a/gear.html
+++ b/gear.html
@@ -65,6 +65,7 @@
             <div class="text-center">
                 <h1 class="heading-font text-4xl md:text-5xl font-bold text-white mb-6">Gear Reviews &amp; Recommendations</h1>
                 <p class="text-lg text-yellow-300 mb-8">Practical insights on the tech I use on the road.</p>
+                <img src="flatlaytech.jpg" alt="Flat lay of travel tech gear" class="mx-auto mt-8 w-full max-w-4xl rounded-2xl shadow-2xl opacity-80">
             </div>
         </div>
     </section>


### PR DESCRIPTION
### Motivation
- Improve the hero section by adding a subtle, transparent photo beneath the main headline to better showcase travel tech gear.
- Use the existing image file `flatlaytech.jpg` in the project root so no new assets are required.

### Description
- Inserted an `<img>` element into `gear.html` directly below the main heading with `src="flatlaytech.jpg"` and an appropriate `alt` attribute.
- Applied layout and style utility classes `mx-auto mt-8 w-full max-w-4xl rounded-2xl shadow-2xl opacity-80` to center the image and give it a translucent, rounded hero appearance.
- The only modified file is `gear.html` with a single image insertion.

### Testing
- Started a local server using `python -m http.server 8000` and the page served successfully.
- Captured a screenshot with Playwright which produced the artifact `artifacts/gear-hero.png` confirming the image renders as intended.
- No automated unit tests were required for this static HTML change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949ed224e888323a6732937bd1e880d)