### PR TITLE
Make gear hero image full-width background with semi-transparent overlay

### DIFF
--- a/gear.html
+++ b/gear.html
@@ -60,12 +60,12 @@
         </div>
     </nav>
 
-    <section class="hero-gradient relative overflow-hidden min-h-[50vh] flex items-center pt-20">
+    <section class="hero-gradient relative overflow-hidden min-h-[50vh] flex items-center pt-20" style="background-image: url('flatlaytech.jpg'); background-size: cover; background-position: center;">
+        <div class="absolute inset-0 bg-black/50"></div>
         <div class="container mx-auto px-6 py-20 relative z-10">
             <div class="text-center">
                 <h1 class="heading-font text-4xl md:text-5xl font-bold text-white mb-6">Gear Reviews &amp; Recommendations</h1>
                 <p class="text-lg text-yellow-300 mb-8">Practical insights on the tech I use on the road.</p>
-                <img src="flatlaytech.jpg" alt="Flat lay of travel tech gear" class="mx-auto mt-8 w-full max-w-4xl rounded-2xl shadow-2xl opacity-80">
             </div>
         </div>
     </section>


### PR DESCRIPTION
### Motivation
- Match the visual hero treatment used on `Berlin.html` by placing the gear image behind the hero text.
- Ensure the `flatlaytech.jpg` image spans the full width of the hero area and remains centered and cover-scaled for responsive layouts.
- Improve text legibility by adding a semi-transparent overlay above the background image.
- Remove redundant inline `<img>` markup so the hero background is a single background layer.

### Description
- Set the hero `section` to use `flatlaytech.jpg` as an inline `background-image` with `background-size: cover` and `background-position: center`.
- Added an overlay element `<div class="absolute inset-0 bg-black/50"></div>` to create a semi-transparent dark layer above the image.
- Removed the previous inline `<img src="flatlaytech.jpg">` element and kept the hero content in a `relative z-10` container so text sits above the background.
- Kept existing hero sizing and utility classes to preserve responsive behaviour.

### Testing
- Served the site locally with `python -m http.server 8000` and captured a headless browser screenshot using Playwright, producing `artifacts/gear-hero.png`, which successfully rendered the new hero.
- The Playwright visual capture completed without error.
- No automated unit tests apply to this static HTML/CSS change.
- Manual visual checks were performed via the generated screenshot to verify text legibility and background coverage.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949f1378248832398a79f97626cac6c)