### PR TITLE
Add contextual internal links and internal link matrix

### DIFF
--- a/finedininginhanoi.html
+++ b/finedininginhanoi.html
@@ -144,6 +144,7 @@
             <div class="space-y-6 text-lg text-gray-600">
                 <p>At Khuê, food is more than flavour—it’s a narrative. Every dish is crafted with inspiration drawn from emotion, memory, and connection. The menu moves from humble street food roots to meticulously plated fine dining creations, capturing the warmth of home cooking with the imagination of modern cuisine.</p>
                 <p>This film explores the heart behind Khuê’s culinary philosophy. We stepped into the kitchen, spoke with the passionate minds who bring each dish to life, and captured the intimate dining atmosphere that has made Khuê one of Hanoi’s most talked-about restaurants.</p>
+                <p>If your dinner plans lead into a full evening out, the <a href="hanoi-by-night.html" class="text-yellow-500 hover:text-yellow-600 underline">Hanoi by night</a> story is a perfect next stop.</p>
                 <p>Whether you’re a traveller chasing the city’s best dining experiences or a local searching for something special, Khuê offers a journey that touches the heart as much as the palate.</p>
             </div>
         </div>

--- a/hanoi-by-night.html
+++ b/hanoi-by-night.html
@@ -174,6 +174,7 @@
                 <h3 class="heading-font text-3xl md:text-4xl text-white">The Midnight Spirit of Hanoi</h3>
                 <p class="text-gray-300 leading-relaxed">This is one of the projects I’m most proud of so far. Filmed around midnight in Hanoi’s Old Quarter, Hoàn Kiếm Lake, and Beer Street, it captures the city in all its contrasts.</p>
                 <p class="text-gray-300 leading-relaxed">Think chaos in the crowds, silence at Ngọc Sơn Temple, and neon glow that makes the sidewalks shimmer.</p>
+                <p class="text-gray-300 leading-relaxed">For the daylight version of this energy, start with my <a href="top-10-things-to-do-in-hanoi.html" class="text-yellow-400 hover:text-yellow-300 underline">top 10 things to do in Hanoi</a> checklist.</p>
                 <h4 class="text-yellow-400 font-semibold uppercase tracking-wide text-xs">Mid-Article Check-in</h4>
                 <p class="text-gray-300 leading-relaxed">Time marker: 1:15 AM halfway point at Hoàn Kiếm Lake. Money marker: $4 for hot trà đá and a late-night snack. Trade-off/regret: I skipped a second pass through Train Street and felt it later.</p>
                 <p class="text-yellow-400 text-sm font-semibold">Mini-hook: the next paragraph explains why the trade-off still worked.</p>

--- a/hanoitravelguide.html
+++ b/hanoitravelguide.html
@@ -326,6 +326,7 @@
                 <h1 class="heading-font text-4xl md:text-6xl text-white leading-tight mb-6">7 Days in Hanoi with Carl Travels</h1>
                 <p class="text-lg md:text-xl text-gray-300 leading-relaxed mb-8">From Tay Ho’s lakeside calm and caffeine-fuelled mornings to Train Street’s rush and Ha Long Bay’s limestone giants, this Hanoi itinerary blends street eats, neighborhood discoveries, and cinematic escapes.</p>
                 <p class="text-sm text-gray-400 mb-8">Time marker: 7-day Hanoi loop. Money marker: $35–$60 per day for food, transport, and stays. Trade-off/regret: I skipped a second café crawl and wished I’d slowed down.</p>
+                <p class="text-sm text-gray-400 mb-8">For a deeper budget breakdown, see the <a href="pros-and-cons-and-cost-of-living-in-hanoi.html" class="text-yellow-400 hover:text-yellow-300 underline">Hanoi cost of living guide</a>.</p>
                 <div class="flex flex-wrap gap-4">
                     <a href="#itinerary" class="px-6 py-3 bg-yellow-500 text-black rounded-full font-semibold hover:bg-yellow-400 transition">See the Itinerary</a>
                     <a href="#hanoi-watch" class="px-6 py-3 border border-yellow-500 text-yellow-500 rounded-full font-semibold hover:bg-yellow-500 hover:text-black transition">Watch Hanoi Episodes</a>

--- a/internal-link-matrix.json
+++ b/internal-link-matrix.json
@@ -1,0 +1,47 @@
+{
+  "pros-and-cons-and-cost-of-living-in-hanoi.html": [
+    "hanoi-by-night.html",
+    "top-10-things-to-do-in-hanoi.html",
+    "hanoitravelguide.html"
+  ],
+  "hanoi-by-night.html": [
+    "top-10-things-to-do-in-hanoi.html",
+    "finedininginhanoi.html",
+    "hanoitravelguide.html"
+  ],
+  "top-10-things-to-do-in-hanoi.html": [
+    "lotte-world-aquarium-hanoi.html",
+    "thebesttemplesinhanoi.html",
+    "hanoitravelguide.html"
+  ],
+  "thebesttemplesinhanoi.html": [
+    "top-10-things-to-do-in-hanoi.html",
+    "hanoitravelguide.html",
+    "hanoi-by-night.html"
+  ],
+  "lotte-world-aquarium-hanoi.html": [
+    "top-10-things-to-do-in-hanoi.html",
+    "hanoitravelguide.html",
+    "finedininginhanoi.html"
+  ],
+  "finedininginhanoi.html": [
+    "hanoi-by-night.html",
+    "top-10-things-to-do-in-hanoi.html",
+    "hanoitravelguide.html"
+  ],
+  "hanoitravelguide.html": [
+    "pros-and-cons-and-cost-of-living-in-hanoi.html",
+    "top-10-things-to-do-in-hanoi.html",
+    "hanoi-by-night.html"
+  ],
+  "sony-a7cii-review.html": [
+    "tech-review-sony-a7siii.html",
+    "tech-review-dji-mavic3.html",
+    "travel-gear-2025.html"
+  ],
+  "tech-review-sony-a7siii.html": [
+    "sony-a7cii-review.html",
+    "tech-review-zhiyun-weebill2.html",
+    "travel-gear-2025.html"
+  ]
+}

--- a/lotte-world-aquarium-hanoi.html
+++ b/lotte-world-aquarium-hanoi.html
@@ -204,7 +204,7 @@
                     <li><i class="fas fa-clock text-yellow-500 mr-3"></i> Shows and feedings run hourly — check the digital boards as you enter.</li>
                     <li><i class="fas fa-child text-yellow-500 mr-3"></i> Kids can stamp an explorer passport at different zones — it’s a fun way to keep them engaged.</li>
                 </ul>
-                <p class="text-gray-300 leading-relaxed">Whether you’re pairing it with a date night, keeping the kids entertained, or just cooling off after a morning of Hanoi street food, the Lotte World Aquarium is a refreshing addition to the city’s must-do list.</p>
+                <p class="text-gray-300 leading-relaxed">Whether you’re pairing it with a date night, keeping the kids entertained, or just cooling off after a morning of Hanoi street food, the Lotte World Aquarium is a refreshing addition to the city’s must-do list. It also fits neatly into the <a href="top-10-things-to-do-in-hanoi.html" class="text-yellow-400 hover:text-yellow-300 underline">top 10 things to do in Hanoi</a> loop.</p>
             </div>
             <div class="info-card rounded-3xl p-8 shadow-xl">
                 <h4 class="heading-font text-2xl text-yellow-400 mb-4">Stay Connected</h4>

--- a/pros-and-cons-and-cost-of-living-in-hanoi.html
+++ b/pros-and-cons-and-cost-of-living-in-hanoi.html
@@ -213,6 +213,9 @@
                             can you stay long term, will the city ground you or wear you down, and can you build routines here instead of just memories?
                         </p>
                         <p class="text-lg text-gray-200 leading-relaxed mt-4">
+                            If you’re wondering what the city feels like after dark, the <a href="hanoi-by-night.html" class="text-yellow-400 hover:text-yellow-300 underline">Hanoi by night</a> story captures the mood when the crowds thin out.
+                        </p>
+                        <p class="text-lg text-gray-200 leading-relaxed mt-4">
                             This is for anyone past the honeymoon phase (or heading toward it with open eyes).
                         </p>
                     </div>

--- a/sony-a7cii-review.html
+++ b/sony-a7cii-review.html
@@ -326,6 +326,9 @@
                             <p class="text-gray-600 mb-4">
                                 For run-and-gun shoots, documentary work, or low-light environments—the A7CII’s full-frame sensor and stabilization just win. It gives me DSLR-level performance in a mirrorless body, and when fully rigged, it holds its own on any set.
                             </p>
+                            <p class="text-gray-600 mb-4">
+                                If you’re weighing it against a low-light specialist, the <a href="tech-review-sony-a7siii.html" class="text-yellow-500 hover:text-yellow-600 underline">Sony A7S III review</a> breaks down the differences.
+                            </p>
                         </div>
                         
                         <div class="bg-gray-50 rounded-xl p-6 shadow-lg mb-8">

--- a/tech-review-sony-a7siii.html
+++ b/tech-review-sony-a7siii.html
@@ -405,6 +405,7 @@
             <div class="max-w-3xl mx-auto text-center space-y-6">
                 <h2 class="heading-font text-3xl text-white">Final Thoughts</h2>
                 <p class="text-gray-300 leading-relaxed">The Sony A7III is that trusted friend: not the flashiest, but always ready. In a market obsessed with what’s new, it quietly keeps delivering — producing professional results for thousands of creators at a fraction of the price of newer bodies.</p>
+                <p class="text-gray-300 leading-relaxed">Need a smaller full-frame option for travel days? The <a href="sony-a7cii-review.html" class="text-yellow-400 hover:text-yellow-300 underline">Sony A7C II review</a> covers the compact alternative.</p>
                 <p class="text-gray-300 leading-relaxed">If you truly need bleeding-edge specs, grab the A7IV or A7S III. But if you want the most balanced full-frame camera in 2025, and a tool that will stay with you for years, the A7III is still one of the smartest buys in photography.</p>
                 <a href="https://amzn.to/3Ktc4tq" target="_blank" rel="nofollow" class="inline-flex items-center px-6 py-3 rounded-full bg-gradient-to-r from-yellow-500 to-amber-600 text-black font-semibold shadow-lg hover:shadow-xl transition-all">
                     <i class="fas fa-shopping-cart mr-2"></i> Buy the Sony A7III on Amazon

--- a/thebesttemplesinhanoi.html
+++ b/thebesttemplesinhanoi.html
@@ -184,6 +184,7 @@
                 <span class="badge"><i class="fas fa-location-dot"></i> Hanoi • West Lake</span>
                 <h1 class="heading-font text-4xl md:text-6xl text-white leading-tight">Trấn Quốc Pagoda – Hanoi’s Oldest Buddhist Temple</h1>
                 <p class="text-lg text-slate-200 leading-relaxed">Discover 1,450 years of Vietnamese spirituality at Trấn Quốc Pagoda (Chùa Trấn Quốc). Globe Travel Adventures guest host Nhi shares local insight on how this serene island temple protects the nation, honors Buddha, and welcomes mindful travelers.</p>
+                <p class="text-lg text-slate-200 leading-relaxed">If you want to pair this visit with the city’s other highlights, start with the <a href="top-10-things-to-do-in-hanoi.html" class="text-yellow-300 hover:text-yellow-200 underline">top 10 things to do in Hanoi</a> roundup.</p>
                 <div class="flex flex-wrap gap-3 text-sm text-slate-300">
                     <span class="badge"><i class="fas fa-seedling"></i> Living Heritage</span>
                     <span class="badge"><i class="fas fa-water"></i> West Lake Views</span>

--- a/top-10-things-to-do-in-hanoi.html
+++ b/top-10-things-to-do-in-hanoi.html
@@ -227,7 +227,7 @@
                 <article class="highlight-card rounded-3xl p-8">
                     <span class="badge text-yellow-400 uppercase"><i class="fas fa-building"></i> 9️⃣ Lotte Mall West Lake</span>
                     <h3 class="heading-font text-2xl text-white mt-4">Hanoi’s Modern Face</h3>
-                    <p class="text-gray-300 mt-3 leading-relaxed">Slip into sleek cafés, cinemas, and the Lotte World Aquarium before catching golden-hour views from the rooftop terrace.</p>
+                    <p class="text-gray-300 mt-3 leading-relaxed">Slip into sleek cafés, cinemas, and the <a href="lotte-world-aquarium-hanoi.html" class="text-yellow-400 hover:text-yellow-300 underline">Lotte World Aquarium</a> before catching golden-hour views from the rooftop terrace.</p>
                 </article>
                 <article class="highlight-card rounded-3xl p-8">
                     <span class="badge text-yellow-400 uppercase"><i class="fas fa-motorcycle"></i> 🔟 Trúc Bạch Lake & Hà Giang Loop</span>


### PR DESCRIPTION
### Motivation
- Create an internal linking map to improve discoverability and logical next-step navigation between Hanoi and gear articles.  
- Add a single contextual link in each article to guide readers to related content (comparison, next step, or deeper explanation).  
- Ensure links reference only existing site content and avoid promotional or forced linking.  
- Surface camera comparisons (A7C II ↔ A7S III) where readers are already considering trade-offs.

### Description
- Added an `internal-link-matrix.json` file pairing related pages for Hanoi and gear topics.  
- Inserted one contextual internal link into each updated HTML page, including `pros-and-cons-and-cost-of-living-in-hanoi.html`, `hanoi-by-night.html`, `top-10-things-to-do-in-hanoi.html`, `thebesttemplesinhanoi.html`, `lotte-world-aquarium-hanoi.html`, `finedininginhanoi.html`, `hanoitravelguide.html`, `sony-a7cii-review.html`, and `tech-review-sony-a7siii.html`.  
- Wired cross-links for logical flows such as the Hanoi after-dark story from the cost guide and camera comparison links between the A7C II and A7S III reviews.  
- All links point to existing site pages (no external promotional linking was added as part of the contextual links).

### Testing
- Served the site locally with `python -m http.server 8000` and captured a Playwright screenshot of `top-10-things-to-do-in-hanoi.html` to verify the new contextual link rendered, which succeeded.  
- No unit or integration tests were required because these are static HTML content changes.  
- Verified that the modified pages load as static HTML and that the inserted anchor tags reference existing files.  
- No automated build or CI tests were executed beyond the local static smoke check described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a47ce10bc83238942d3b1369834c9)