### PR TITLE
Add title variants, natural descriptions, and CTAs to articles

### DIFF
--- a/7 ways to find cheap accomodation while traveling.html
+++ b/7 ways to find cheap accomodation while traveling.html
@@ -1,5 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
+<!--
+Title variants:
+Safe SEO: 7 Ways to Find Cheap Accommodation While Traveling
+Honest/blunt: How I actually keep accommodation costs down when I travel
+Curiosity-driven: The cheapest stays I found weren’t on booking sites
+-->
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -15,7 +21,7 @@
       gtag('config', 'G-G72KT5ZW2J');
     </script>
     <!-- Meta Tags -->
-    <meta name="description" content="Seven proven ways to find cheap accommodation while traveling, from hostels and Workaway to house sitting, points, and rural stays." />
+    <meta name="description" content="A practical rundown of seven ways to keep accommodation costs down, from hostels and work exchanges to house sitting, points, and rural stays." />
     <meta name="keywords" content="cheap accommodation, budget travel, hostels, Workaway, house sitting, Couchsurfing, WWOOF, Carl Travels" />
     <meta name="author" content="Carl Ostomich" />
     <meta name="tags" content="budget travel, accommodation, digital nomad, Workaway, house sitting, hostels" />
@@ -220,6 +226,8 @@
                             </p>
                         </div>
 
+                        <p class="text-gray-400 italic">If this saved you time or money, there’s a coffee link below.</p>
+
                         <div class="glass-card p-8 rounded-2xl">
                             <h3 class="text-xl font-semibold text-white mb-3">5. Volunteer for accommodation (beyond Workaway)</h3>
                             <p class="text-gray-300 leading-relaxed">
@@ -280,6 +288,7 @@
                             sustainable.
                         </p>
                     </div>
+                    <p class="text-gray-400 italic">I don’t sell courses or hype. If this helped, you know where the button is.</p>
                 </article>
 
                 <aside class="space-y-8">

--- a/Hifuinhanoi.html
+++ b/Hifuinhanoi.html
@@ -1,5 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
+<!--
+Title variants:
+Safe SEO: Why I Tried HIFU in Vietnam at 40
+Honest/blunt: What it was like getting HIFU in Hanoi at 40
+Curiosity-driven: The moment I decided HIFU was worth trying
+-->
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -7,7 +13,7 @@
     <!-- Cookiebot for GDPR Compliance -->
     <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="e44b7cd2-126b-4f49-8aee-22495afe3ece" type="text/javascript" async></script>
     <!-- Meta Tags -->
-    <meta name="description" content="Inside my HIFU experience at Oceania Spa & Clinic in Hanoi, why beauty tourism in Vietnam makes sense, and how to choose a safe clinic while traveling." />
+    <meta name="description" content="A personal recap of trying HIFU in Hanoi, how I chose a clinic, and what to expect from Vietnam’s beauty tourism scene." />
     <meta name="keywords" content="HIFU in Vietnam, beauty tourism Hanoi, Oceania Spa & Clinic, non-surgical facelift, digital nomad wellness" />
     <meta name="author" content="Carl Ostomich">
     <!-- Open Graph Meta Tags -->
@@ -286,6 +292,8 @@
                     </p>
                 </div>
 
+                <p class="text-gray-300 italic">If this saved you time or money, there’s a coffee link below.</p>
+
                 <div class="content-card space-y-4">
                     <h3 class="text-xl font-semibold text-white">My Experience at Oceania Spa & Clinic</h3>
                     <p class="lead">
@@ -371,6 +379,7 @@
                         I didn’t try HIFU because I’m afraid of aging. I did it to feel like my best self heading into my 40s—on camera, in life, and in relationships. Getting older is inevitable; letting yourself go completely is optional. Vietnam made preventative care accessible, safe, and normal.
                     </p>
                 </div>
+                <p class="text-gray-300 italic">I don’t sell courses or hype. If this helped, you know where the button is.</p>
             </div>
 
             <aside class="space-y-6">

--- a/balitravelguide.html
+++ b/balitravelguide.html
@@ -1,5 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
+<!--
+Title variants:
+Safe SEO: Bali, Indonesia Travel Guide
+Honest/blunt: What Bali is really like once the hype wears off
+Curiosity-driven: The Bali spot that still feels calm
+-->
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -15,7 +21,7 @@
       gtag('config', 'G-G72KT5ZW2J');
     </script>
     <!-- Meta Tags -->
-    <meta name="description" content="Explore Bali, Indonesia with Carl Travels’ 2025 guide. A brutally honest look at the island’s highs and lows, from serene Sanur to the chaotic Canggu, with tips for budget travelers.">
+    <meta name="description" content="An opinionated 2025 Bali guide covering where to stay, getting around, costs, and what still feels worth it." />
     <meta name="keywords" content="Bali travel guide 2025, Indonesia budget travel, Nusa Lembongan, Sanur, Carl Travels">
     <meta name="author" content="Carl Ostomich">
     <!-- Open Graph Meta Tags -->
@@ -338,6 +344,8 @@
                                 <p class="text-gray-600"><strong>Tip:</strong> Never trust “just 10 minutes” in Bali—it could mean eternity in traffic.</p>
                             </div>
                         </div>
+
+                        <p class="text-gray-600 italic mb-8">If this saved you time or money, there’s a coffee link below.</p>
                         
                         <div class="bg-gray-50 rounded-xl p-6 shadow-lg mb-8">
                             <h2 class="text-2xl font-bold text-gray-800 mb-4"><i class="fas fa-bus mr-2 text-yellow-500"></i> Getting to Bali</h2>
@@ -457,6 +465,7 @@
                             <p class="text-gray-600 mb-4">Bali’s not the paradise it’s cracked up to be, but it’s worth a look if you know where to go. Skip Canggu’s chaos, head to Sanur or the Nusa islands, and embrace the irony of it all. Share your Bali stories in the comments on <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="text-yellow-500 hover:text-yellow-500">my YouTube channel</a> or via <a href="index.html#contact" class="text-yellow-500 hover:text-yellow-500">my contact form</a>!</p>
                             <p class="text-gray-600 mb-4">Want more honest travel takes? Check out my <a href="kyototravelguide.html" class="text-yellow-500 hover:text-yellow-500">Kyoto travel guide</a>!</p>
                         </div>
+                        <p class="text-gray-600 italic mb-8">I don’t sell courses or hype. If this helped, you know where the button is.</p>
                     </div>
                 </div>
                 

--- a/becomingadigitalnomad.html
+++ b/becomingadigitalnomad.html
@@ -1,5 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
+<!--
+Title variants:
+Safe SEO: The 3 Cheapest Countries to Be a Digital Nomad in 2025
+Honest/blunt: Where I found the cheapest, livable nomad bases in 2025
+Curiosity-driven: The one country I didn’t expect to be so affordable
+-->
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -16,7 +22,7 @@
   gtag('config', 'G-G72KT5ZW2J');
 </script>
     <!-- Meta Tags -->
-    <meta name="description" content="Discover the 3 cheapest countries for digital nomads in 2025 with Carl Travels: Vietnam, Bulgaria, and Bali. Learn about visas, costs, and smart visa run tips.">
+    <meta name="description" content="A guide to three budget-friendly digital nomad bases with visa notes, costs, and visa-run options." />
     <meta name="keywords" content="digital nomad 2024, cheapest countries, Vietnam digital nomad, Bulgaria digital nomad, Bali digital nomad, visa run tips, Carl Travels">
     <meta name="author" content="Carl Ostomich">
     <!-- Open Graph Meta Tags -->
@@ -200,6 +206,8 @@
                         <p class="text-gray-600 mb-8">
                             Choosing the right country as a digital nomad isn’t just about finding cheap rent. You need fast internet, welcoming communities, and visa rules that don’t break the bank. I’ve lived the digital nomad life—coding in Bali’s cafes, editing videos in Sofia’s co-working spaces, and sipping coffee in Hanoi’s bustling streets. After years of traveling, here are my top 3 cheapest countries for digital nomads in 2024, plus smart visa run strategies to keep your adventure going. Carl Travels uses Cookiebot to manage cookie consent, ensuring GDPR compliance.
                         </p>
+
+                        <p class="text-gray-600 italic mb-8">If this saved you time or money, there’s a coffee link below.</p>
                         
                         <div class="bg-gray-50 rounded-xl p-6 shadow-lg mb-8">
                             <h2 class="text-2xl font-bold text-gray-800 mb-4"><i class="fas fa-laptop mr-2 text-yellow-500"></i> 🇻🇳 Vietnam</h2>
@@ -478,6 +486,7 @@
                             <h2 class="text-2xl font-bold text-gray- sixties mb-4"><i class="fas fa-star mr-2 text-yellow-500"></i> 🎤 Final Thoughts</h2>
                             <p class="text-gray-600 mb-4">If you’re serious about building your remote lifestyle while keeping costs low, Vietnam, Bulgaria, and Bali are the smartest choices in 2024 and beyond. Each offers affordable rent, great food, fast internet, thriving nomad communities, and easy visa options with a little planning.</p>
                             <p class="text-gray-600 mb-4">Visa runs aren’t just chores—they’re mini-adventures built into your journey. So pick a country, pack your bags, and build the life everyone else is dreaming about.</p>
+                            <p class="text-gray-600 italic mb-4">I don’t sell courses or hype. If this helped, you know where the button is.</p>
                             <p class="text-gray-600 mb-4">Want to see the digital nomad life in action? Check out my YouTube channel for vlogs from these destinations!</p>
                             <div class="flex items-center justify-between">
                                 <div class="flex items-center">

--- a/buskingguide.html
+++ b/buskingguide.html
@@ -1,5 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
+<!--
+Title variants:
+Safe SEO: The Ultimate Guide to Busking
+Honest/blunt: What busking is really like after years on the street
+Curiosity-driven: The busking tip that doubled my earnings
+-->
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -7,7 +13,7 @@
     <!-- Cookiebot for GDPR Compliance -->
     <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="e44b7cd2-126b-4f49-8aee-22495afe3ece" type="text/javascript" async></script>
     <!-- Meta Tags -->
-    <meta name="description" content="Discover the ultimate guide to busking with Carl Travels. Learn tips, rules, earnings, and favorite spots from a seasoned street performer. Watch documentaries on Berlin's busking scene.">
+    <meta name="description" content="A practical guide to busking based on years on the street, covering rules, gear, earnings, and survival tips." />
     <meta name="keywords" content="busking guide, street performance, Carl Travels, busking tips, Berlin busking, street music, Neigh Kid Horse">
     <meta name="author" content="Carl Ostomich">
     <!-- Open Graph Meta Tags -->
@@ -188,6 +194,8 @@
                 <p class="text-gray-600 mb-8">
                     Busking is more than just standing on a street corner with a guitar. It’s freedom. It’s survival. It’s hustle. It’s community. It’s putting your heart out there for the world—and sometimes the world throws coins, sometimes insults, and sometimes... magic. I’ve busked across Berlin, London, Italy, Spain, Prague, Budapest, Australia—even along the rugged coastline between France and Spain. This guide is everything I’ve learned from years on the street, with the good, the bad, and the hilarious. If you’re dreaming about it, curious, or about to head off with a guitar and a suitcase, this is for you. Carl Travels uses Cookiebot to manage cookie consent, ensuring GDPR compliance.
                 </p>
+
+                <p class="text-gray-600 italic mb-8">If this saved you time or money, there’s a coffee link below.</p>
                 
                 <div class="bg-gray-50 rounded-xl p-6 shadow-lg mb-8">
                     <h2 class="text-2xl font-bold text-gray-800 mb-4"><i class="fas fa-guitar mr-2 text-yellow-500"></i> 🎭 What is Busking?</h2>
@@ -383,6 +391,8 @@
                         <li>Rotate spots—don’t overstay your welcome.</li>
                     </ul>
                 </div>
+
+                <p class="text-gray-600 italic mb-8">I don’t sell courses or hype. If this helped, you know where the button is.</p>
                 
                 <div class="bg-gray-50 rounded-xl p-6 shadow-lg mb-8">
                     <h2 class="text-2xl font-bold text-gray-800 mb-4"><i class="fas fa-star mr-2 text-yellow-500"></i> 🎤 Final Thoughts</h2>

--- a/getyourwisecard.html
+++ b/getyourwisecard.html
@@ -1,5 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
+<!--
+Title variants:
+Safe SEO: Why Every Traveller Should Get a Wise Card
+Honest/blunt: Why I rely on a Wise card for travel spending
+Curiosity-driven: The fee that disappeared once I switched to Wise
+-->
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -7,7 +13,7 @@
     <!-- Cookiebot for GDPR Compliance -->
     <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="e44b7cd2-126b-4f49-8aee-22495afe3ece" type="text/javascript" async></script>
     <!-- Meta Tags -->
-    <meta name="description" content="Discover why every traveller needs a Wise card to save money, skip hidden bank fees, and spend like a local with real exchange rates. Carl Travels shares real-world tips.">
+    <meta name="description" content="A practical breakdown of how Wise works for travel spending, the fees it avoids, and how I use it on the road." />
     <meta name="keywords" content="Wise card, travel money, avoid bank fees, multi-currency account, budget travel, Carl Travels, travel finance">
     <meta name="author" content="Carl Ostomich">
     <!-- Open Graph Meta Tags -->
@@ -262,6 +268,8 @@
                             <li><strong>Prepaid Top-Up:</strong> You can only spend what you have. No surprises, no debt.</li>
                             <li><strong>Virtual Card Available:</strong> For even more secure online purchases while travelling.</li>
                         </ul>
+
+                        <p class="text-gray-600 italic mb-8">If this saved you time or money, there’s a coffee link below.</p>
                         
                         <h2 class="text-2xl font-bold text-gray-800 mb-4"><i class="fas fa-globe mr-2 text-yellow-500"></i> Real-World Example</h2>
                         <p class="text-gray-600 mb-4">When I spent months travelling across Vietnam, Japan, Germany, France, and Albania, I used my Wise card everywhere:</p>
@@ -281,6 +289,7 @@
                             <li>Start loading money and travelling smarter.</li>
                         </ol>
                         <p class="text-gray-600 mb-4"><span class="text-yellow-500 font-medium">💡 Note:</span> Delivery times and free ATM withdrawal limits may vary by country. Check Wise’s website for details.</p>
+                        <p class="text-gray-600 italic mb-4">I don’t sell courses or hype. If this helped, you know where the button is.</p>
                         <p class="text-gray-600 mb-4">👉 <a href="https://wise.com/invite/irhc/carlt62" target="_blank" class="text-yellow-500 hover:text-yellow-500 font-medium">Get your Wise card using my link here</a>. You'll support me a little (thanks!) — and honestly, you'll be supporting your own wallet even more.</p>
                         <a href="https://wise.com/invite/irhc/carlt62" target="_blank" class="inline-flex items-center px-6 py-3 bg-gradient-to-r from-yellow-500 to-amber-600 text-white rounded-full font-medium hover:shadow-lg transition-all">
                             Get Your Wise Card Now <i class="fas fa-credit-card ml-2"></i>

--- a/how-to-get-croatian-citizenship-by-descent.html
+++ b/how-to-get-croatian-citizenship-by-descent.html
@@ -1,5 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
+<!--
+Title variants:
+Safe SEO: How to Get Croatian Citizenship by Descent (The Real 2025 Guide)
+Honest/blunt: What the Croatian citizenship by descent process really takes
+Curiosity-driven: The document that slowed my Croatia application
+-->
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -15,7 +21,7 @@
       gtag('config', 'G-G72KT5ZW2J');
     </script>
     <!-- Meta Tags -->
-    <meta name="description" content="Learn how to get Croatian citizenship in 2025 with Carl Travels’ step-by-step guide. Discover eligibility, documents, costs, and insider tips from personal experience.">
+    <meta name="description" content="A step-by-step look at Croatian citizenship by descent, including eligibility, documents, costs, and what the process felt like." />
     <meta name="keywords" content="Croatian citizenship 2025, EU passport, citizenship by descent, Croatia visa, Carl Travels, croatian citizenship by descent">
     <meta name="author" content="Carl Ostomich">
     <!-- Open Graph Meta Tags -->
@@ -199,6 +205,8 @@
                         <p class="text-gray-600 mb-8">
                             Croatian citizenship is your ticket to the EU, a rich cultural heritage, and the stunning Adriatic lifestyle. I went through the process myself—digging through family records, chasing apostilles, and navigating Croatian bureaucracy. It wasn’t easy, but it was worth it. This step-by-step guide covers who qualifies, what documents you need, and insider tips from my experience to help you succeed. Carl Travels uses Cookiebot to manage cookie consent, ensuring GDPR compliance.
                         </p>
+
+                        <p class="text-gray-600 italic mb-8">If this saved you time or money, there’s a coffee link below.</p>
                         
                         <div class="bg-gray-50 rounded-xl p-6 shadow-lg mb-8">
                             <h2 class="text-2xl font-bold text-gray-800 mb-4"><i class="fas fa-passport mr-2 text-yellow-500"></i> 🏛️ Who Can Apply for Croatian Citizenship?</h2>
@@ -406,6 +414,7 @@
                                 <iframe class="w-full h-full rounded-xl shadow-lg" src="https://www.youtube.com/embed/feBJCpoA_LA" title="In-Depth Guide to Croatian Citizenship by Carl Travels" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
                             </div>
                             <p class="text-gray-600 mb-4">For a deeper dive into the process, this video covers additional details and tips to help you navigate your application.</p>
+                            <p class="text-gray-600 italic mb-4">I don’t sell courses or hype. If this helped, you know where the button is.</p>
                             <p class="text-gray-600 mb-4">Good luck! Or as we say in Croatia, <strong>Sretno!</strong> Hello Awin 🇭🇷 Explore more on <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="text-yellow-500 hover:text-yellow-500">my YouTube channel</a>!</p>
                         </div>
                     </div>

--- a/how-to-make-your-videos-look-cinematic.html
+++ b/how-to-make-your-videos-look-cinematic.html
@@ -1,5 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
+<!--
+Title variants:
+Safe SEO: Why I Use Dehancer to Make My Videos Look Cinematic (And How You Can Too)
+Honest/blunt: How I actually grade footage with Dehancer and why it stays in my workflow
+Curiosity-driven: The one tweak that made my footage feel less digital
+-->
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -15,7 +21,7 @@
       gtag('config', 'G-G72KT5ZW2J');
     </script>
     <!-- Meta Tags -->
-    <meta name="description" content="Discover how Carl uses Dehancer to give digital footage a cinematic, film-like look with grain, halation, and more."/>
+    <meta name="description" content="A personal walkthrough of how I use Dehancer to get a filmic look, including my setup and practical grading tips." />
     <meta name="keywords" content="Dehancer, cinematic video, film emulation, color grading, Carl Travels"/>
     <meta name="author" content="Carl Ostomich"/>
     <!-- Open Graph Meta Tags -->
@@ -179,6 +185,7 @@
                     <h2 class="heading-font text-3xl font-bold mt-10 mb-4">📽 What Is Dehancer?</h2>
                     <p>Dehancer is a film emulation plugin that recreates the look and feel of real analog film stocks. It works inside apps like DaVinci Resolve, Premiere Pro, and Final Cut Pro, and they’ve recently added support for Photoshop and Lightroom too.</p>
                     <p>But it’s more than just a LUT or a filter—it simulates all the little imperfections that make film beautiful: the grain, halation, bloom, color cast, even the film compression and print characteristics. You can push it hard for a dreamy 16mm vibe, or dial it back for subtle Kodak Portra tones.</p>
+                    <p class="text-gray-600 italic">If this saved you time or money, there’s a coffee link below.</p>
                     <h2 class="heading-font text-3xl font-bold mt-10 mb-4">🎬 My Setup</h2>
                     <p>Right now I shoot with a Sony A7CII, filming in S-Log3 for maximum flexibility in post. I grade my videos in DaVinci Resolve, and Dehancer has become a permanent part of my workflow. It's helped me unify my look across all the different travel projects I shoot—whether I'm filming a foggy morning in Hanoi or golden hour in Bali (yes, even Bali has good lighting if you get up early enough).</p>
                     <h2 class="heading-font text-3xl font-bold mt-10 mb-4">💡 Why It Matters</h2>
@@ -197,6 +204,7 @@
                         <li>Don’t go overboard with the grain or halation—start subtle, build from there.</li>
                         <li>Use the print film emulations at the end of your grade—they add the final magic.</li>
                     </ul>
+                    <p class="text-gray-600 italic">I don’t sell courses or hype. If this helped, you know where the button is.</p>
                     <p>Got questions? DM me on Instagram or leave a comment on YouTube. Always happy to share my workflow.</p>
                     <p>Stay cinematic,<br>– Carl</p>
                 </div>

--- a/howtofoldapopuptent.html
+++ b/howtofoldapopuptent.html
@@ -1,5 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
+<!--
+Title variants:
+Safe SEO: Why Do Pop-Up Tents Pop Up… But Never Pop Down?
+Honest/blunt: How to actually fold a pop-up tent without the struggle
+Curiosity-driven: The folding move that finally made the tent behave
+-->
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -7,7 +13,7 @@
     <!-- Cookiebot for GDPR Compliance -->
     <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="e44b7cd2-126b-4f49-8aee-22495afe3ece" type="text/javascript" async></script>
     <!-- Meta Tags -->
-    <meta name="description" content="Master the art of folding a pop-up tent with Carl Travels’ 60-second Circle-Fold method. Learn tips, troubleshooting, and storage hacks for stress-free camping.">
+    <meta name="description" content="A straightforward guide to folding a pop-up tent with the Circle-Fold method, plus troubleshooting and storage tips." />
     <meta name="keywords" content="pop-up tent, folding pop-up tent, Circle-Fold method, camping tips, Carl Travels, tent storage, travel hacks">
     <meta name="author" content="Carl Ostomich">
     <!-- Open Graph Meta Tags -->
@@ -206,6 +212,8 @@
                     </div>
                     <p class="text-gray-600 mb-4">This video breaks down the Circle-Fold method step-by-step to make your next camping trip a breeze.</p>
                 </div>
+
+                <p class="text-gray-600 italic mb-8">If this saved you time or money, there’s a coffee link below.</p>
                 
                 <div class="bg-gray-50 rounded-xl p-6 shadow-lg mb-8">
                     <h2 class="text-2xl font-bold text-gray-800 mb-4"><i class="fas fa-tools mr-2 text-yellow-500"></i> 🔧 Troubleshooting Corner</h2>
@@ -250,6 +258,8 @@
                         <li><a href="https://amzn.to/4kGH71w" target="_blank" class="text-yellow-500 hover:text-yellow-500">Compact Microfiber Towels</a> (wipe down & pack away fast).</li>
                     </ul>
                 </div>
+
+                <p class="text-gray-600 italic mb-8">I don’t sell courses or hype. If this helped, you know where the button is.</p>
                 
                 <div class="bg-gray-50 rounded-xl p-6 shadow-lg mb-8">
                     <h2 class="text-2xl font-bold text-gray-800 mb-4"><i class="fas fa-map mr-2 text-yellow-500"></i> 🗺️ Keep the Adventure Rolling</h2>

--- a/howtomakemoneyonlinesellingstockfootage.html
+++ b/howtomakemoneyonlinesellingstockfootage.html
@@ -1,5 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
+<!--
+Title variants:
+Safe SEO: How to Earn Money on Adobe Stock and Shutterstock
+Honest/blunt: What selling stock footage actually pays for me
+Curiosity-driven: The stock footage clip that keeps selling
+-->
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -15,7 +21,7 @@
       gtag('config', 'G-G72KT5ZW2J');
     </script>
     <!-- Meta Tags -->
-    <meta name="description" content="Learn how traveling filmmaker Carl Tomich earns passive income selling stock footage on Adobe Stock and Shutterstock, including workflow tips, keyword strategy, and real earnings numbers.">
+    <meta name="description" content="A step-by-step look at how I earn from stock footage on Adobe Stock and Shutterstock, including workflow, keywords, and real earnings." />
     <meta name="keywords" content="stock footage income, Adobe Stock earnings, Shutterstock contributor tips, sell stock videos, passive income travel, drone footage, video licensing, stock video workflow, digital nomad side hustle, stock footage keywords">
     <meta name="author" content="Carl Ostomich">
     <meta name="tags" content="Adobe Stock, Shutterstock, stock footage, passive income, traveling filmmaker, video licensing, drone footage, stock keywords, digital nomad finances, side hustle">
@@ -240,6 +246,7 @@
                         <p class="text-gray-600 mb-8">
                             Both platforms pay royalties ranging from 15% to 40%, depending on exclusivity and your lifetime sales volume. Video payouts are typically higher than photos, making moving images the best use of your travel filmmaking skills.
                         </p>
+                        <p class="text-gray-500 italic mb-8">If this saved you time or money, there’s a coffee link below.</p>
 
                         <div class="bg-yellow-50 border border-yellow-200 rounded-xl p-6 shadow-inner mb-10">
                             <h3 class="text-xl font-semibold text-yellow-700 mb-2"><i class="fas fa-coins mr-2"></i>Royalty Snapshot</h3>
@@ -358,6 +365,7 @@
                                 <span class="px-4 py-2 bg-white rounded-full text-sm text-gray-700 shadow">stock keywords strategy</span>
                             </div>
                         </div>
+                        <p class="text-gray-500 italic">I don’t sell courses or hype. If this helped, you know where the button is.</p>
                     </div>
                 </div>
 

--- a/make-money-online-while-traveling.html
+++ b/make-money-online-while-traveling.html
@@ -1,5 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
+<!--
+Title variants:
+Safe SEO: How I Make Money Online While Traveling (2025 Breakdown)
+Honest/blunt: What actually pays me online while traveling and what didn’t
+Curiosity-driven: The income stream I expected to work that didn’t
+-->
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -15,7 +21,7 @@
       gtag('config', 'G-G72KT5ZW2J');
     </script>
     <!-- Meta Tags -->
-    <meta name="description" content="See exactly how I earn money online while traveling—AdSense, affiliates, stock footage, client work, and what flopped—in a transparent 2025 breakdown." />
+    <meta name="description" content="A 2025 breakdown of the income streams I use to fund travel, including what works, what flopped, and how I approach growth." />
     <meta name="keywords" content="make money online while traveling, digital nomad income, YouTube AdSense 2025, stock footage earnings, affiliate marketing travel, Carl Travels" />
     <meta name="author" content="Carl Ostomich" />
     <meta name="tags" content="digital nomad, make money online, YouTube income, affiliate marketing, stock footage, travel creator, passive income, side hustle" />
@@ -225,6 +231,8 @@
                     </div>
                 </section>
 
+                <p class="text-gray-500 italic">If this saved you time or money, there’s a coffee link below.</p>
+
                 <!-- What Failed -->
                 <section class="bg-gray-50 border border-gray-200 rounded-2xl p-8 shadow-sm">
                     <div class="flex items-center gap-3 mb-4">
@@ -285,6 +293,7 @@
                         <a href="https://youtu.be/WA06gan4Xy8" target="_blank" class="inline-flex items-center px-5 py-3 bg-yellow-500 text-gray-900 font-semibold rounded-full shadow hover:bg-yellow-400 transition-colors">Watch &amp; comment <i class="fas fa-arrow-right ml-2"></i></a>
                     </div>
                 </section>
+                <p class="text-gray-500 italic">I don’t sell courses or hype. If this helped, you know where the button is.</p>
             </div>
 
             <!-- Sidebar -->

--- a/mytop10travelhacks.html
+++ b/mytop10travelhacks.html
@@ -1,5 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
+<!--
+Title variants:
+Safe SEO: 10 Powerful Budget Travel Hacks
+Honest/blunt: The budget travel tricks that actually save me money
+Curiosity-driven: The travel hack that saved me the most last year
+-->
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -16,7 +22,7 @@
   gtag('config', 'G-G72KT5ZW2J');
 </script>
     <!-- Meta Tags -->
-    <meta name="description" content="Discover 10 powerful budget travel hacks from Carl Travels to save money on flights, accommodation, food, and more. Travel smarter and cheaper with real-world tips.">
+    <meta name="description" content="Ten practical budget travel tactics for flights, accommodation, food, and transport based on what I use." />
     <meta name="keywords" content="budget travel, cheap travel tips, travel hacks, save money traveling, Carl Travels, affordable travel, travel on a budget">
     <meta name="author" content="Carl Ostomich">
     <!-- Open Graph Meta Tags -->
@@ -287,6 +293,8 @@
                             <li>Activate as soon as you hit the ground—no local paperwork, no stress.</li>
                         </ul>
                         <p class="text-gray-600 mb-4">I’ve used Saily seamlessly across Germany, Vietnam, Japan, Croatia, Albania, and France. Use my Saily referral code: <strong>CARLRI5370</strong> to save $5 USD! It’s one of the easiest modern travel upgrades.</p>
+
+                        <p class="text-gray-600 italic mb-8">If this saved you time or money, there’s a coffee link below.</p>
                         
                         <h2 class="text-2xl font-bold text-gray-800 mb-4"><i class="fas fa-bed mr-2 text-yellow-500"></i> 5. Stay Smart (and Sometimes Stay Free!)</h2>
                         <p class="text-gray-600 mb-4">Accommodation can drain your budget if you're not strategic. Here’s how to win:</p>
@@ -391,6 +399,7 @@
             <div class="mt-12 bg-white rounded-xl shadow-lg p-8">
                 <h2 class="text-2xl font-bold text-gray-800 mb-4"><i class="fas fa-microphone mr-2 text-yellow-500"></i> Final Thoughts</h2>
                 <p class="text-gray-600 mb-4">You don’t need to spend $10,000 to travel the world. You just need $10 worth of strategy.</p>
+                <p class="text-gray-600 italic mb-4">I don’t sell courses or hype. If this helped, you know where the button is.</p>
                 <p class="text-gray-600 mb-4">From smarter flights and lighter packing to local apps and free places to sleep, budget travel isn’t about cutting corners—it’s about cutting waste. The less you waste, the more you can do. More sunsets, more street food, more people you never would have met otherwise.</p>
                 <p class="text-gray-600 mb-4 font-semibold">Travel smarter—and you’ll travel further.</p>
                 <div class="flex items-center justify-between">

--- a/pros-and-cons-and-cost-of-living-in-hanoi.html
+++ b/pros-and-cons-and-cost-of-living-in-hanoi.html
@@ -1,5 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
+<!--
+Title variants:
+Safe SEO: Pros and Cons of Living in Hanoi (Honest, Lived-In Perspective)
+Honest/blunt: The parts of living in Hanoi that are great and the parts that wear you down
+Curiosity-driven: The Hanoi trade-off I didn’t expect at first
+-->
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -7,7 +13,7 @@
     <!-- Cookiebot for GDPR Compliance -->
     <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="e44b7cd2-126b-4f49-8aee-22495afe3ece" type="text/javascript" async></script>
     <!-- Meta Tags -->
-    <meta name="description" content="An honest, lived-in look at Hanoi: true costs, visa reality, daily routines, and the trade-offs that make you stay or leave." />
+    <meta name="description" content="A lived-in look at Hanoi life that covers real costs, visas, routines, and the trade-offs that make it work or not." />
     <meta name="keywords" content="Pros and cons of living in Hanoi, cost of living Hanoi, Hanoi expat life, digital nomad Vietnam, Tay Ho" />
     <meta name="author" content="Carl Ostomich">
     <!-- Open Graph Meta Tags -->
@@ -235,6 +241,8 @@
                         </p>
                     </div>
 
+                    <p class="text-gray-600 italic">If this saved you time or money, there’s a coffee link below.</p>
+
                     <div class="grid md:grid-cols-2 gap-8">
                         <div class="content-card bg-neutral-900 text-gray-100">
                             <h3 class="heading-font text-2xl text-yellow-400 mb-3">Video: Cost of Living in Hanoi</h3>
@@ -411,6 +419,8 @@
                             If you are thinking about moving here, the real question is not whether Hanoi is good or bad. It is whether its trade-offs match the season of life you are in.
                         </p>
                     </div>
+
+                    <p class="text-gray-600 italic">I don’t sell courses or hype. If this helped, you know where the button is.</p>
 
                     <div class="content-card bg-neutral-900 text-gray-100">
                         <h3 class="heading-font text-2xl text-yellow-400 mb-3">Comments &amp; Questions</h3>

--- a/travel-gear-2025.html
+++ b/travel-gear-2025.html
@@ -1,5 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
+<!--
+Title variants:
+Safe SEO: My Essential Travel Filmmaking Kit (2025)
+Honest/blunt: The travel filmmaking kit I actually carry in 2025
+Curiosity-driven: The small piece of gear that saves my shoots
+-->
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -7,7 +13,7 @@
     <!-- Cookiebot for GDPR Compliance -->
     <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="e44b7cd2-126b-4f49-8aee-22495afe3ece" type="text/javascript" async></script>
     <!-- SEO Meta Tags -->
-    <meta name="description" content="Discover Carl’s 2025 travel filmmaking kit, including the Sony A7C II, DJI Osmo Pocket 3, and Ray-Ban Meta Glasses. Learn how I pack and use this gear to film cinematic travel vlogs.">
+    <meta name="description" content="A breakdown of the travel filmmaking kit I carry in 2025 and how each piece earns its spot in the bag." />
     <meta name="keywords" content="travel filmmaking gear 2025, Sony A7C II travel, DJI Osmo Pocket 3 vlogging, Ray-Ban Meta Glasses, travel vlog gear, Carl Travels">
     <!-- Open Graph -->
     <meta property="og:title" content="My Essential Travel Filmmaking Kit (2025) – Carl Travels">
@@ -199,6 +205,8 @@
                     <p>Lighting can make or break a shot. The <a href="https://amzn.to/421eJjs" target="_blank" class="text-yellow-500 hover:text-yellow-500">Aputure MC Pro and MT Pro</a> are pocket-sized RGB lights that pack a punch. They’re USB-C rechargeable, have magnetic mounts, and let me add colorful backlights or soft key lights anywhere.</p>
                     <p><strong>Story Time</strong>: In Melbourne, I used the MC Pro to light a nighttime café interview. Its RGB mode added a warm glow that made the shot pop. In Budva, I stuck the MT Pro to a metal railing for a sunset beach vlog—compact and clutch.</p>
 
+                    <p class="text-gray-600 italic">If this saved you time or money, there’s a coffee link below.</p>
+
                     <h3 class="heading-font text-2xl font-semibold mt-8 mb-4">🎬 B-Cam & Gimbal Cam: DJI Osmo Pocket 3 Creator Combo</h3>
                     <p>The <a href="https://amzn.to/4hFqguz" target="_blank" class="text-yellow-500 hover:text-yellow-500">DJI Osmo Pocket 3 Creator Combo</a> is my secret weapon for quick, stabilized shots. It’s pocket-sized, has a flip screen, built-in gimbal, and comes with a wireless mic. Perfect for walk-and-talks or casual vlogs when I don’t want to lug the Sony.</p>
                     <p><strong>Story Time</strong>: In Japan, I filmed a cherry blossom vlog with the Pocket 3. Its stabilization smoothed out my shaky hands, and the mic captured clear audio despite the crowd. Check out the cinematic footage I shot:</p>
@@ -250,6 +258,7 @@
                         <li><a href="https://www.amazon.com/FEELWORLD-FW568-Field-Monitor-Camera/dp/B07V3K4Z4Z" target="_blank" class="text-yellow-500 hover:text-yellow-500">Feelworld 5.5” Monitor</a> – Precise framing</li>
                         <li><a href="https://amzn.to/4c0rCPk" target="_blank" class="text-yellow-500 hover:text-yellow-500">ThinkTank Airport Commuter</a> – My trusty backpack</li>
                     </ul>
+                    <p class="text-gray-600 italic">I don’t sell courses or hype. If this helped, you know where the button is.</p>
                     <p>Check out my <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="text-yellow-500 hover:text-yellow-500">YouTube channel (@thecarltomich)</a> for more travel vlogs and gear tips. Got questions about my setup? Drop a comment on my videos or <a href="index.html#contact" class="text-yellow-500 hover:text-yellow-500">reach out</a>!</p>
                 </div>
             </div>

--- a/whyileftaustralia.html
+++ b/whyileftaustralia.html
@@ -1,5 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
+<!--
+Title variants:
+Safe SEO: Why I Left Australia
+Honest/blunt: Leaving Australia because the life felt smaller
+Curiosity-driven: The moment I knew I had to leave Australia
+-->
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -7,7 +13,7 @@
     <!-- Cookiebot for GDPR Compliance -->
     <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="e44b7cd2-126b-4f49-8aee-22495afe3ece" type="text/javascript" async></script>
     <!-- Meta Tags -->
-    <meta name="description" content="Carl shares why he left Australia in 2025 to chase a bigger life abroad. A raw, personal reflection on leaving the 'lucky country' for meaning and freedom.">
+    <meta name="description" content="A personal reflection on why I left Australia, the costs and creative pressure that built up, and what I was looking for abroad." />
     <meta name="keywords" content="why I left Australia, expat life 2025, moving abroad from Australia, Carl Travels">
     <meta name="author" content="Carl Ostomich">
     <!-- Open Graph Meta Tags -->
@@ -191,6 +197,8 @@
                         <p class="text-gray-600 mb-8">
                             One night in Melbourne, I sat staring at a rent bill that felt like a punch in the gut—$600 a week for a tiny flat, and I was barely scraping by. That’s when it hit me: the “lucky country” wasn’t feeling so lucky anymore. This is my story of why I left Australia, not because I hated it, but because I needed a life that lit me up. Carl Travels uses Cookiebot to manage cookie consent, ensuring GDPR compliance.
                         </p>
+
+                        <p class="text-gray-600 italic mb-8">If this saved you time or money, there’s a coffee link below.</p>
                         
                         <div class="bg-gray-50 rounded-xl p-6 shadow-lg mb-8">
                             <p class="text-gray-600 mb-4">For most of my life, I believed in the idea of the <strong>“lucky country.”</strong> That’s what we’re told growing up—that Australia is the dream. A beautiful, safe, easygoing place where if you work hard, everything will fall into place. And for a long time, I believed it. I lived it. But somewhere along the way, that feeling started to crack.</p>
@@ -236,6 +244,8 @@
                                 <iframe class="w-full h-full rounded-xl shadow-lg" src="https://www.youtube.com/embed/Izha3ONStb4" title="Why I’m Leaving Australia by Carl Travels" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
                             </div>
                             <p class="text-gray-600 mb-4">This video dives deeper into my reasons for leaving and what I’m chasing abroad—hope it resonates!</p>
+
+                            <p class="text-gray-600 italic mb-4">I don’t sell courses or hype. If this helped, you know where the button is.</p>
                             
                             <p class="text-gray-600 mb-4">And if there’s even a <strong>small voice inside you</strong> asking if there might be something more out there for you too—<strong>listen to it.</strong> You don’t have to stay stuck. You don’t have to settle. Change is scary, yeah. But sometimes, it’s the best thing you’ll ever do.</p>
                             

--- a/yesim-guide.html
+++ b/yesim-guide.html
@@ -1,10 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
+<!--
+Title variants:
+Safe SEO: Stay Seamlessly Connected Abroad with Yesim eSIM
+Honest/blunt: Why I use Yesim eSIM and where it still falls short
+Curiosity-driven: The small eSIM detail that made travel days easier
+-->
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Stay Seamlessly Connected Abroad with Yesim eSIM - Carl Travels</title>
-    <meta name="description" content="Discover why Yesim eSIM is my go-to travel data solution. Stay online in 200+ countries, skip roaming fees, and use promo code carltravels for a discount.">
+    <meta name="description" content="An overview of how I use Yesim eSIM on the road, what it does well, and how I set it up before a trip.">
     <meta name="keywords" content="Yesim eSIM guide, travel eSIM, Yesim review, Carl Travels, carltravels promo code">
     <meta name="author" content="Carl Tomich">
     <meta property="og:title" content="Stay Seamlessly Connected Abroad with Yesim eSIM - Carl Travels">
@@ -240,6 +246,7 @@
                     </tbody>
                 </table>
             </div>
+            <p class="text-gray-400 italic text-center mt-8">If this saved you time or money, there’s a coffee link below.</p>
         </div>
     </section>
 
@@ -335,6 +342,7 @@
                 <a href="https://yesim.app" target="_blank" class="inline-flex items-center px-10 py-3 bg-yellow-500 text-black rounded-full font-semibold hover:bg-yellow-400 transition-all shadow-lg">
                     Get Yesim Now <i class="fas fa-arrow-right ml-3"></i>
                 </a>
+                <p class="text-gray-400 italic mt-8">I don’t sell courses or hype. If this helped, you know where the button is.</p>
             </div>
         </div>
     </section>


### PR DESCRIPTION
### Motivation
- Provide editorial and SEO-friendly title alternatives for articles via a visible top-of-file block to aid tracking and headline testing. 
- Replace marketing-style meta descriptions with plain-language summaries that better match article content and user intent. 
- Add exactly two CTAs per article to improve reader engagement while keeping tone soft, observational mid-article and grounded near the end. 
- Ensure CTAs follow the required phrasing style and explicitly avoid prohibited words like “support me” or “buy me a coffee”.

### Description
- Added a `<!-- Title variants: ... -->` HTML comment block at the top of each updated article to include Safe SEO, Honest/blunt, and Curiosity-driven options. 
- Replaced each page’s `meta name="description"` with a concise, natural-language summary reflecting the article’s content. 
- Inserted a mid-article soft CTA (example: `If this saved you time or money, there’s a coffee link below.`) and a near-end grounded CTA (example: `I don’t sell courses or hype. If this helped, you know where the button is.`) in each modified article. 
- Applied these content-only changes across 16 HTML article files (title-variant blocks, meta updates, and the two CTAs) without altering layout or scripts.

### Testing
- No automated tests were executed because these are content-only HTML changes. 
- Changes were limited to textual edits and meta tags, so no runtime behavior was expected to change. 
- Files were saved and staged as updated HTML documents for review. 
- Manual spot-checks of a few updated pages confirmed the inserted CTAs and meta descriptions appear in the intended locations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a6703a8248323a6b08a2a2589e836)