### PR TITLE
Fix internal links, add Donate nav links, and restyle Donate page

### DIFF
--- a/DJI-Flip-review.html
+++ b/DJI-Flip-review.html
@@ -166,6 +166,7 @@
                     <a href="blog.html" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">Blog</a>
                     <a href="gear.html" class="text-yellow-500 font-medium transition-colors">Gear</a>
                     <a href="index.html#about" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">About</a>
+                    <a href="donate.html" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">Donate</a>
                     <a href="index.html#contact" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">Contact</a>
                 </div>
                 <button id="mobile-menu-button" class="md:hidden text-gray-700 focus:outline-none">
@@ -179,6 +180,7 @@
                 <a href="blog.html" class="block py-2 text-gray-700 hover:text-yellow-500">Blog</a>
                 <a href="gear.html" class="block py-2 text-yellow-500">Gear</a>
                 <a href="index.html#about" class="block py-2 text-gray-700 hover:text-yellow-500">About</a>
+                <a href="donate.html" class="block py-2 text-gray-700 hover:text-yellow-500">Donate</a>
                 <a href="index.html#contact" class="block py-2 text-gray-700 hover:text-yellow-500">Contact</a>
             </div>
         </div>

--- a/aiarty-video-enhancer-review.html
+++ b/aiarty-video-enhancer-review.html
@@ -202,6 +202,7 @@
                     <li><a href="index.html#tech" class="hover:text-yellow-400 transition">Tech Reviews</a></li>
                     <li><a href="index.html#portfolio" class="hover:text-yellow-400 transition">Portfolio</a></li>
                     <li><a href="blog.html" class="hover:text-yellow-400 transition">Blog</a></li>
+                    <li><a href="donate.html" class="hover:text-yellow-400 transition">Donate</a></li>
                     <li><a href="contact.html" class="hover:text-yellow-400 transition">Contact</a></li>
                 </ul>
             </div>
@@ -212,6 +213,7 @@
                     <li><a href="index.html#tech" class="block hover:text-yellow-400 transition">Tech Reviews</a></li>
                     <li><a href="index.html#portfolio" class="block hover:text-yellow-400 transition">Portfolio</a></li>
                     <li><a href="blog.html" class="block hover:text-yellow-400 transition">Blog</a></li>
+                    <li><a href="donate.html" class="block hover:text-yellow-400 transition">Donate</a></li>
                     <li><a href="contact.html" class="block hover:text-yellow-400 transition">Contact</a></li>
                 </ul>
             </div>

--- a/balitravelguide.html
+++ b/balitravelguide.html
@@ -266,6 +266,7 @@ Curiosity-driven: The Bali spot that still feels calm
                     <a href="blog.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Blog</a>
                     <a href="gear.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Gear</a>
                     <a href="index.html#about" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">About</a>
+                    <a href="donate.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Donate</a>
                     <a href="index.html#contact" class="px-4 py-2 bg-gradient-to-r from-yellow-500 to-amber-600 text-black rounded-full hover:shadow-lg transition-all">Contact</a>
                 </div>
 
@@ -283,6 +284,7 @@ Curiosity-driven: The Bali spot that still feels calm
                     <a href="blog.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Blog</a>
                     <a href="gear.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Gear</a>
                     <a href="index.html#about" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">About</a>
+                    <a href="donate.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Donate</a>
                     <a href="index.html#contact" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Contact</a>
                 </div>
             </div>

--- a/becomingadigitalnomad.html
+++ b/becomingadigitalnomad.html
@@ -614,9 +614,9 @@ Curiosity-driven: The one country I didn’t expect to be so affordable
                         <li><a href="melbournetravelguide.html" class="text-gray-400 hover:text-white transition-colors">Melbourne</a></li>
                         <li><a href="cairnstravelguide.html" class="text-gray-400 hover:text-white transition-colors">Cairns</a></li>
                         <li><a href="phuketravelguide.html" class="text-gray-400 hover:text-white transition-colors">Phuket</a></li>
-                        <li><a href="hanoiguide.html" class="text-gray-400 hover:text-white transition-colors">Hanoi</a></li>
+                        <li><a href="hanoitravelguide.html" class="text-gray-400 hover:text-white transition-colors">Hanoi</a></li>
                         <li><a href="osakatravelguide.html" class="text-gray-400 hover:text-white transition-colors">Osaka</a></li>
-                        <li><a href="korculaguide.html" class="text-gray-400 hover:text-white transition-colors">Korčula</a></li>
+                        <li><a href="korcula.html" class="text-gray-400 hover:text-white transition-colors">Korčula</a></li>
                     </ul>
                 </div>
                 

--- a/bose-s1pro-plus-vs-everse8-the-best-portable-speaker.html
+++ b/bose-s1pro-plus-vs-everse8-the-best-portable-speaker.html
@@ -539,9 +539,9 @@
                         <li><a href="melbournetravelguide.html" class="text-gray-400 hover:text-white transition-colors">Melbourne</a></li>
                         <li><a href="cairnstravelguide.html" class="text-gray-400 hover:text-white transition-colors">Cairns</a></li>
                         <li><a href="phuketravelguide.html" class="text-gray-400 hover:text-white transition-colors">Phuket</a></li>
-                        <li><a href="hanoiguide.html" class="text-gray-400 hover:text-white transition-colors">Hanoi</a></li>
+                        <li><a href="hanoitravelguide.html" class="text-gray-400 hover:text-white transition-colors">Hanoi</a></li>
                         <li><a href="osakatravelguide.html" class="text-gray-400 hover:text-white transition-colors">Osaka</a></li>
-                        <li><a href="korculaguide.html" class="text-gray-400 hover:text-white transition-colors">Korčula</a></li>
+                        <li><a href="korcula.html" class="text-gray-400 hover:text-white transition-colors">Korčula</a></li>
                         <li><a href="kyototravelguide.html" class="text-gray-400 hover:text-white transition-colors">Kyoto</a></li>
                         <li><a href="balitravelguide.html" class="text-gray-400 hover:text-white transition-colors">Bali</a></li>
                     </ul>

--- a/budvatravelguide.html
+++ b/budvatravelguide.html
@@ -23,7 +23,7 @@
     <meta property="og:title" content="Budva, Montenegro Travel Guide - Carl Travels">
     <meta property="og:description" content="Explore Budva, Montenegro with Carl Travels’ 2025 guide. Discover budget stays, historic Old Town, clear Adriatic beaches, and vibrant nightlife.">
     <meta property="og:image" content="https://www.carltravels.com/images/budvalogo.jpg">
-    <meta property="og:url" content="https://www.carltravels.com/budavatravelguide.html">
+    <meta property="og:url" content="https://www.carltravels.com/budvatravelguide.html">
     <meta property="og:type" content="article">
     <!-- Twitter Card Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
@@ -415,7 +415,7 @@
                             <h2 class="text-2xl font-bold text-gray-800 mb-4"><i class="fas fa-flag-checkered mr-2 text-yellow-500"></i> Final Thoughts</h2>
                             <p class="text-gray-600 mb-4">Budva surprised me—affordable, scenic, historic, and just the right mix of chill and cultural depth. Don’t skip it on a Balkan trip. Stay a few nights, get lost in the Old Town, eat too much pork, buy a magic hat, and swim in clear waters.</p>
                             <p class="text-gray-600 mb-4">You might come for a cheap beach but leave with a little more. Share your Budva stories in the comments on <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="text-yellow-500 hover:text-yellow-500">my YouTube channel</a> or via <a href="index.html#contact" class="text-yellow-500 hover:text-yellow-500">my contact form</a>!</p>
-                            <p class="text-gray-600 mb-4">Craving more budget adventures? Check out my <a href="hanoiguide.html" class="text-yellow-500 hover:text-yellow-500">Hanoi travel guide</a>!</p>
+                            <p class="text-gray-600 mb-4">Craving more budget adventures? Check out my <a href="hanoitravelguide.html" class="text-yellow-500 hover:text-yellow-500">Hanoi travel guide</a>!</p>
                         </div>
                     </div>
                 </div>
@@ -450,7 +450,7 @@
                     </div>
                     
                     <div class="text-center">
-                        <a href="hanoiguide.html" class="inline-flex items-center px-6 py-3 border border-yellow-500 text-yellow-500 rounded-full font-medium hover:bg-yellow-900 transition-all">
+                        <a href="hanoitravelguide.html" class="inline-flex items-center px-6 py-3 border border-yellow-500 text-yellow-500 rounded-full font-medium hover:bg-yellow-900 transition-all">
                             More Budget Adventures <i class="fas fa-arrow-right ml-2"></i>
                         </a>
                     </div>
@@ -698,7 +698,7 @@
                     });
                 }
             } catch (error) {
-                console.error('JavaScript Error in budavatravelguide.html:', error);
+                console.error('JavaScript Error in budvatravelguide.html:', error);
             }
         });
     </script>

--- a/buskingguide.html
+++ b/buskingguide.html
@@ -494,7 +494,7 @@ Curiosity-driven: The busking tip that doubled my earnings
                         <li><a href="melbournetravelguide.html" class="text-gray-400 hover:text-white transition-colors">Melbourne</a></li>
                         <li><a href="cairnstravelguide.html" class="text-gray-400 hover:text-white transition-colors">Cairns</a></li>
                         <li><a href="phuketravelguide.html" class="text-gray-400 hover:text-white transition-colors">Phuket</a></li>
-                        <li><a href="hanoiguide.html" class="text-gray-400 hover:text-white transition-colors">Hanoi</a></li>
+                        <li><a href="hanoitravelguide.html" class="text-gray-400 hover:text-white transition-colors">Hanoi</a></li>
                         <li><a href="osakatravelguide.html" class="text-gray-400 hover:text-white transition-colors">Osaka</a></li>
                         <li><a href="korcula.html" class="text-gray-400 hover:text-white transition-colors">Korčula</a></li>
                     </ul>

--- a/danangtravelguide.html
+++ b/danangtravelguide.html
@@ -446,7 +446,7 @@
                             <h2 class="text-2xl font-bold text-gray-800 mb-4"><i class="fas fa-flag-checkered mr-2 text-yellow-500"></i> Final Thoughts</h2>
                             <p class="text-gray-600 mb-4">Da Nang is a budget traveler’s dream—stunning beaches, rich culture, and quirky attractions like Ba Na Hills. Don’t miss Marble Mountains or a day trip to Hoi An. Stay a few days, eat phở, and soak up the coastal charm.</p>
                             <p class="text-gray-600 mb-4">Share your Da Nang stories in the comments on <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="text-yellow-500 hover:text-yellow-500">my YouTube channel</a> or via <a href="index.html#contact" class="text-yellow-500 hover:text-yellow-500">my contact form</a>!</p>
-                            <p class="text-gray-600 mb-4">Craving more budget adventures? Check out my <a href="hanoiguide.html" class="text-yellow-500 hover:text-yellow-500">Hanoi travel guide</a>!</p>
+                            <p class="text-gray-600 mb-4">Craving more budget adventures? Check out my <a href="hanoitravelguide.html" class="text-yellow-500 hover:text-yellow-500">Hanoi travel guide</a>!</p>
                         </div>
                     </div>
                 </div>
@@ -481,7 +481,7 @@
                     </div>
                     
                     <div class="text-center">
-                        <a href="hanoiguide.html" class="inline-flex items-center px-6 py-3 border border-yellow-500 text-yellow-500 rounded-full font-medium hover:bg-yellow-900 transition-all">
+                        <a href="hanoitravelguide.html" class="inline-flex items-center px-6 py-3 border border-yellow-500 text-yellow-500 rounded-full font-medium hover:bg-yellow-900 transition-all">
                             More Budget Adventures <i class="fas fa-arrow-right ml-2"></i>
                         </a>
                     </div>

--- a/dji-mini-3-pro-review.html
+++ b/dji-mini-3-pro-review.html
@@ -493,9 +493,9 @@
                         <li><a href="melbournetravelguide.html" class="text-gray-400 hover:text-white transition-colors">Melbourne</a></li>
                         <li><a href="cairnstravelguide.html" class="text-gray-400 hover:text-white transition-colors">Cairns</a></li>
                         <li><a href="phuketravelguide.html" class="text-gray-400 hover:text-white transition-colors">Phuket</a></li>
-                        <li><a href="hanoiguide.html" class="text-gray-400 hover:text-white transition-colors">Hanoi</a></li>
+                        <li><a href="hanoitravelguide.html" class="text-gray-400 hover:text-white transition-colors">Hanoi</a></li>
                         <li><a href="osakatravelguide.html" class="text-gray-400 hover:text-white transition-colors">Osaka</a></li>
-                        <li><a href="korculaguide.html" class="text-gray-400 hover:text-white transition-colors">Korčula</a></li>
+                        <li><a href="korcula.html" class="text-gray-400 hover:text-white transition-colors">Korčula</a></li>
                         <li><a href="kyototravelguide.html" class="text-gray-400 hover:text-white transition-colors">Kyoto</a></li>
                         <li><a href="balitravelguide.html" class="text-gray-400 hover:text-white transition-colors">Bali</a></li>
                     </ul>

--- a/donate.html
+++ b/donate.html
@@ -60,13 +60,13 @@
         
         .navbar {
             backdrop-filter: blur(10px);
-            background-color: rgba(255, 255, 255, 0.9);
+            background-color: rgba(26, 26, 26, 0.9);
             transition: all 0.3s ease;
         }
         
         .navbar.scrolled {
-            background-color: rgba(255, 255, 255, 0.98);
-            box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+            background-color: rgba(26, 26, 26, 0.98);
+            box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.3);
         }
         
         .wave-shape {
@@ -100,7 +100,7 @@
         }
     </style>
 </head>
-<body class="text-gray-800">
+<body class="text-gray-200">
     <!-- Navigation -->
     <nav id="navbar" class="navbar fixed w-full z-50 shadow-sm transition-all duration-300">
         <div class="container mx-auto px-6 py-3">
@@ -113,17 +113,17 @@
                 </a>
                 
                 <div class="hidden md:flex items-center space-x-8">
-                    <a href="index.html" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">Home</a>
-                    <a href="destinations.html" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">Destinations</a>
-                    <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">Videos</a>
-                    <a href="blog.html" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">Blog</a>
-                    <a href="gear.html" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">Gear</a>
-                    <a href="index.html#about" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">About</a>
+                    <a href="index.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Home</a>
+                    <a href="destinations.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Destinations</a>
+                    <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Videos</a>
+                    <a href="blog.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Blog</a>
+                    <a href="gear.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Gear</a>
+                    <a href="index.html#about" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">About</a>
                     <a href="donate.html" class="text-yellow-500 font-medium transition-colors">Donate</a>
-                    <a href="index.html#contact" class="px-4 py-2 bg-gradient-to-r from-yellow-500 to-amber-600 text-white rounded-full hover:shadow-lg transition-all">Contact</a>
+                    <a href="index.html#contact" class="px-4 py-2 bg-gradient-to-r from-yellow-500 to-amber-600 text-black rounded-full hover:shadow-lg transition-all">Contact</a>
                 </div>
                 
-                <button id="mobile-menu-button" class="md:hidden text-gray-700 focus:outline-none">
+                <button id="mobile-menu-button" class="md:hidden text-gray-300 focus:outline-none">
                     <i class="fas fa-bars text-2xl"></i>
                 </button>
             </div>
@@ -131,14 +131,14 @@
             <!-- Mobile Menu -->
             <div id="mobile-menu" class="mobile-menu md:hidden">
                 <div class="pt-4 pb-2 space-y-2">
-                    <a href="index.html" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">Home</a>
-                    <a href="destinations.html" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">Destinations</a>
-                    <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">Videos</a>
-                    <a href="blog.html" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">Blog</a>
-                    <a href="gear.html" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">Gear</a>
-                    <a href="index.html#about" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">About</a>
+                    <a href="index.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Home</a>
+                    <a href="destinations.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Destinations</a>
+                    <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Videos</a>
+                    <a href="blog.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Blog</a>
+                    <a href="gear.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Gear</a>
+                    <a href="index.html#about" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">About</a>
                     <a href="donate.html" class="block px-3 py-2 rounded-md bg-yellow-900 text-yellow-500 font-medium">Donate</a>
-                    <a href="index.html#contact" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">Contact</a>
+                    <a href="index.html#contact" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Contact</a>
                 </div>
             </div>
         </div>
@@ -155,12 +155,12 @@
         <div class="container mx-auto px-6 py-20 relative z-10">
             <div class="text-center">
                 <h1 class="heading-font text-4xl md:text-5xl lg:text-6xl font-bold text-white leading-tight mb-6">
-                    Support My Journey <br>With <span class="text-yellow-300">Carl Travels</span>
+                    Support My Journey <br>With <span class="text-yellow-500">Carl Travels</span>
                 </h1>
-                <p class="text-lg text-yellow-300 mb-8 max-w-2xl mx-auto">
+                <p class="text-lg text-gray-300 mb-8 max-w-2xl mx-auto">
                     Your donations help me create inspiring travel documentaries and share captivating stories from around the world. Every contribution makes a difference!
                 </p>
-                <a href="#donate" class="px-8 py-3 bg-white text-yellow-500 rounded-full font-medium hover:bg-gray-100 transition-all shadow-lg">
+                <a href="#donate" class="px-8 py-3 bg-yellow-500 text-black rounded-full font-medium hover:bg-yellow-600 transition-all shadow-lg">
                     Donate Now
                 </a>
             </div>
@@ -168,12 +168,12 @@
     </section>
 
     <!-- Donation Content Section -->
-    <section id="donate" class="py-20 bg-white">
+    <section id="donate" class="py-20 bg-[#111827]">
         <div class="container mx-auto px-6">
             <!-- Motivational Story -->
-            <div class="donation-card bg-white rounded-xl shadow-lg p-8 mb-12">
-                <h2 class="heading-font text-3xl font-bold text-gray-800 mb-6 text-center">Why Your Support Matters</h2>
-                <div class="text-gray-600 leading-relaxed space-y-4">
+            <div class="donation-card bg-[#1f2937] rounded-xl shadow-lg p-8 mb-12">
+                <h2 class="heading-font text-3xl font-bold text-white mb-6 text-center">Why Your Support Matters</h2>
+                <div class="text-gray-300 leading-relaxed space-y-4">
                     <p>Hi there! I'm passionate about capturing the world through my lens, telling stories that resonate and inspire. Over the years, I've been fortunate to travel to over 40 countries and explore more than 300 cities, immersing myself in diverse cultures and experiences. Living in four different countries has broadened my perspective and fueled my desire to share these incredible moments with you.</p>
                     <p>Creating content isn't just a hobby—it's my way of connecting with people, preserving memories, and showcasing the beauty and complexity of our world. However, producing high-quality travel videos and documentaries requires resources, from travel expenses and equipment upgrades to time and dedication. This is where your support makes a significant difference.</p>
                     <p>Every donation, no matter how small, helps me continue my mission to create meaningful content. Whether it's funding a new camera, covering travel costs to a remote destination, or simply allowing me to dedicate more time to storytelling, your generosity empowers me to bring more authentic and impactful stories to life.</p>
@@ -183,8 +183,8 @@
             </div>
 
             <!-- Donation Button -->
-            <div class="donation-card bg-white rounded-xl shadow-lg p-8 mb-12 text-center">
-                <h2 class="heading-font text-3xl font-bold text-gray-800 mb-6">Make a Donation</h2>
+            <div class="donation-card bg-[#1f2937] rounded-xl shadow-lg p-8 mb-12 text-center">
+                <h2 class="heading-font text-3xl font-bold text-white mb-6">Make a Donation</h2>
                 <form action="https://www.paypal.com/donate" method="post" target="_top" class="inline-block">
                     <input type="hidden" name="hosted_button_id" value="48D6VPE8NSCWU" />
                     <input type="image" src="https://www.paypalobjects.com/en_AU/i/btn/btn_donateCC_LG.gif" border="0" name="submit" title="Donate with PayPal" alt="Donate with PayPal button" />
@@ -193,9 +193,9 @@
             </div>
 
             <!-- How Donations Help -->
-            <div class="donation-card bg-white rounded-xl shadow-lg p-8 mb-12">
-                <h2 class="heading-font text-3xl font-bold text-gray-800 mb-6 text-center">How Your Donations Help</h2>
-                <ul class="space-y-4 text-gray-600">
+            <div class="donation-card bg-[#1f2937] rounded-xl shadow-lg p-8 mb-12">
+                <h2 class="heading-font text-3xl font-bold text-white mb-6 text-center">How Your Donations Help</h2>
+                <ul class="space-y-4 text-gray-300">
                     <li class="flex items-start">
                         <i class="fas fa-plane text-yellow-500 mr-3 mt-1"></i>
                         <div>
@@ -224,25 +224,25 @@
             </div>
 
             <!-- Additional Support Options -->
-            <div class="donation-card bg-white rounded-xl shadow-lg p-8 mb-12">
-                <h2 class="heading-font text-3xl font-bold text-gray-800 mb-6 text-center">Other Ways to Support</h2>
+            <div class="donation-card bg-[#1f2937] rounded-xl shadow-lg p-8 mb-12">
+                <h2 class="heading-font text-3xl font-bold text-white mb-6 text-center">Other Ways to Support</h2>
                 <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-                    <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="block px-4 py-3 bg-yellow-9000 text-white rounded-lg text-center hover:bg-yellow-600 transition-all">
+                    <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="block px-4 py-3 bg-gradient-to-r from-yellow-500 to-amber-600 text-black rounded-lg text-center hover:bg-yellow-600 transition-all">
                         <i class="fab fa-youtube mr-2"></i> Subscribe on YouTube
                     </a>
-                    <a href="https://www.instagram.com/carlostomich" target="_blank" class="block px-4 py-3 bg-yellow-9000 text-white rounded-lg text-center hover:bg-yellow-600 transition-all">
+                    <a href="https://www.instagram.com/carlostomich" target="_blank" class="block px-4 py-3 bg-gradient-to-r from-yellow-500 to-amber-600 text-black rounded-lg text-center hover:bg-yellow-600 transition-all">
                         <i class="fab fa-instagram mr-2"></i> Follow on Instagram
                     </a>
-                    <a href="https://www.facebook.com/thecarlostomich/" target="_blank" class="block px-4 py-3 bg-yellow-9000 text-white rounded-lg text-center hover:bg-yellow-600 transition-all">
+                    <a href="https://www.facebook.com/thecarlostomich/" target="_blank" class="block px-4 py-3 bg-gradient-to-r from-yellow-500 to-amber-600 text-black rounded-lg text-center hover:bg-yellow-600 transition-all">
                         <i class="fab fa-facebook-f mr-2"></i> Like on Facebook
                     </a>
                 </div>
             </div>
 
             <!-- Thank You Note -->
-            <div class="donation-card bg-yellow-900 rounded-xl p-8 text-center">
-                <h2 class="heading-font text-3xl font-bold text-gray-800 mb-4">Thank You!</h2>
-                <p class="text-gray-600">
+            <div class="donation-card bg-[#1f2937] rounded-xl p-8 text-center">
+                <h2 class="heading-font text-3xl font-bold text-white mb-4">Thank You!</h2>
+                <p class="text-gray-300">
                     Thank you for your support! Your contributions help me turn dreams into reality and continue sharing incredible stories from around the globe.
                 </p>
             </div>

--- a/farnorthqueenslandtravelguide.html
+++ b/farnorthqueenslandtravelguide.html
@@ -498,7 +498,7 @@
                         <li><a href="melbournetravelguide.html" class="text-gray-400 hover:text-white transition-colors">Melbourne</a></li>
                         <li><a href="cairnstravelguide.html" class="text-gray-400 hover:text-white transition-colors">Cairns</a></li>
                         <li><a href="phuketravelguide.html" class="text-gray-400 hover:text-white transition-colors">Phuket</a></li>
-                        <li><a href="hanoiguide.html" class="text-gray-400 hover:text-white transition-colors">Hanoi</a></li>
+                        <li><a href="hanoitravelguide.html" class="text-gray-400 hover:text-white transition-colors">Hanoi</a></li>
                         <li><a href="osakatravelguide.html" class="text-gray-400 hover:text-white transition-colors">Osaka</a></li>
                     </ul>
                 </div>

--- a/getyourwisecard.html
+++ b/getyourwisecard.html
@@ -412,7 +412,7 @@ Curiosity-driven: The fee that disappeared once I switched to Wise
                         <li><a href="melbournetravelguide.html" class="text-gray-400 hover:text-white transition-colors">Melbourne</a></li>
                         <li><a href="cairnstravelguide.html" class="text-gray-400 hover:text-white transition-colors">Cairns</a></li>
                         <li><a href="phuketravelguide.html" class="text-gray-400 hover:text-white transition-colors">Phuket</a></li>
-                        <li><a href="hanoiguide.html" class="text-gray-400 hover:text-white transition-colors">Hanoi</a></li>
+                        <li><a href="hanoitravelguide.html" class="text-gray-400 hover:text-white transition-colors">Hanoi</a></li>
                         <li><a href="osakatravelguide.html" class="text-gray-400 hover:text-white transition-colors">Osaka</a></li>
                     </ul>
                 </div>

--- a/hanoi-by-night.html
+++ b/hanoi-by-night.html
@@ -85,6 +85,7 @@
                     <a href="videos/index.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Watch</a>
                     <a href="blog.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Blog</a>
                     <a href="gear.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Gear</a>
+                    <a href="donate.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Donate</a>
                     <a href="#film" class="px-4 py-2 bg-gradient-to-r from-yellow-500 to-amber-600 text-black rounded-full hover:shadow-lg transition-all">Watch the Film</a>
                 </div>
                 <button id="mobile-menu-button" class="md:hidden text-gray-300 focus:outline-none">
@@ -99,6 +100,7 @@
                     <a href="videos/index.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Watch</a>
                     <a href="blog.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Blog</a>
                     <a href="gear.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Gear</a>
+                    <a href="donate.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Donate</a>
                     <a href="#film" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Watch the Film</a>
                 </div>
             </div>

--- a/hanoitravelguide.html
+++ b/hanoitravelguide.html
@@ -296,6 +296,7 @@
                     <a href="blog.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Blog</a>
                     <a href="gear.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Gear</a>
                     <a href="index.html#about" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">About</a>
+                    <a href="donate.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Donate</a>
                     <a href="index.html#contact" class="px-4 py-2 bg-gradient-to-r from-yellow-500 to-amber-600 text-black rounded-full hover:shadow-lg transition-all">Contact</a>
                 </div>
                 <button id="mobile-menu-button" class="md:hidden text-gray-300 focus:outline-none">
@@ -311,6 +312,7 @@
                     <a href="blog.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Blog</a>
                     <a href="gear.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Gear</a>
                     <a href="index.html#about" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">About</a>
+                    <a href="donate.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Donate</a>
                     <a href="index.html#contact" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Contact</a>
                 </div>
             </div>

--- a/hiroshima-travel-guide.html
+++ b/hiroshima-travel-guide.html
@@ -123,6 +123,7 @@
                     <a href="blog.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Blog</a>
                     <a href="gear.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Gear</a>
                     <a href="index.html#about" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">About</a>
+                    <a href="donate.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Donate</a>
                     <a href="index.html#contact" class="px-4 py-2 bg-gradient-to-r from-yellow-500 to-amber-600 text-black rounded-full hover:shadow-lg transition-all">Contact</a>
                 </div>
                 <button id="mobile-menu-button" class="md:hidden text-gray-300 focus:outline-none">
@@ -137,6 +138,7 @@
                     <a href="blog.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Blog</a>
                     <a href="gear.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Gear</a>
                     <a href="index.html#about" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">About</a>
+                    <a href="donate.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Donate</a>
                     <a href="index.html#contact" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Contact</a>
                 </div>
             </div>

--- a/hon-chong-rocks-nha-trang.html
+++ b/hon-chong-rocks-nha-trang.html
@@ -90,6 +90,7 @@
                     <a href="blog.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Blog</a>
                     <a href="gear.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Gear</a>
                     <a href="index.html#about" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">About</a>
+                    <a href="donate.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Donate</a>
                     <a href="index.html#contact" class="px-4 py-2 bg-gradient-to-r from-yellow-500 to-amber-600 text-black rounded-full hover:shadow-lg transition-all">Contact</a>
                 </div>
                 <button id="mobile-menu-button" class="md:hidden text-gray-300 focus:outline-none">
@@ -104,6 +105,7 @@
                     <a href="blog.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Blog</a>
                     <a href="gear.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Gear</a>
                     <a href="index.html#about" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">About</a>
+                    <a href="donate.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Donate</a>
                     <a href="index.html#contact" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Contact</a>
                 </div>
             </div>

--- a/how-to-get-croatian-citizenship-by-descent.html
+++ b/how-to-get-croatian-citizenship-by-descent.html
@@ -450,7 +450,7 @@ Curiosity-driven: The document that slowed my Croatia application
                     </div>
                     
                     <div class="text-center">
-                        <a href="korculaguide.html" class="inline-flex items-center px-6 py-3 border border-yellow-500 text-yellow-500 rounded-full font-medium hover:bg-yellow-900 transition-all">
+                        <a href="korcula.html" class="inline-flex items-center px-6 py-3 border border-yellow-500 text-yellow-500 rounded-full font-medium hover:bg-yellow-900 transition-all">
                             Explore Korčula <i class="fas fa-arrow-right ml-2"></i>
                         </a>
                     </div>
@@ -533,7 +533,7 @@ Curiosity-driven: The document that slowed my Croatia application
                         <li><a href="melbournetravelguide.html" class="text-gray-400 hover:text-white transition-colors">Melbourne</a></li>
                         <li><a href="cairnstravelguide.html" class="text-gray-400 hover:text-white transition-colors">Cairns</a></li>
                         <li><a href="phuketravelguide.html" class="text-gray-400 hover:text-white transition-colors">Phuket</a></li>
-                        <li><a href="hanoiguide.html" class="text-gray-400 hover:text-white transition-colors">Hanoi</a></li>
+                        <li><a href="hanoitravelguide.html" class="text-gray-400 hover:text-white transition-colors">Hanoi</a></li>
                         <li><a href="osakatravelguide.html" class="text-gray-400 hover:text-white transition-colors">Osaka</a></li>
                         <li><a href="korcula.html" class="text-gray-400 hover:text-white transition-colors">Korčula</a></li>
                     </ul>

--- a/how-to-get-croatian-citizenship-through-your-grandparent.html
+++ b/how-to-get-croatian-citizenship-through-your-grandparent.html
@@ -346,7 +346,7 @@
                     </div>
                     
                     <div class="text-center">
-                        <a href="korculaguide.html" class="inline-flex items-center px-6 py-3 border border-yellow-500 text-yellow-500 rounded-full font-medium hover:bg-yellow-900 transition-all">
+                        <a href="korcula.html" class="inline-flex items-center px-6 py-3 border border-yellow-500 text-yellow-500 rounded-full font-medium hover:bg-yellow-900 transition-all">
                             Explore Korčula <i class="fas fa-arrow-right ml-2"></i>
                         </a>
                     </div>
@@ -429,9 +429,9 @@
                         <li><a href="melbournetravelguide.html" class="text-gray-400 hover:text-white transition-colors">Melbourne</a></li>
                         <li><a href="cairnstravelguide.html" class="text-gray-400 hover:text-white transition-colors">Cairns</a></li>
                         <li><a href="phuketravelguide.html" class="text-gray-400 hover:text-white transition-colors">Phuket</a></li>
-                        <li><a href="hanoiguide.html" class="text-gray-400 hover:text-white transition-colors">Hanoi</a></li>
+                        <li><a href="hanoitravelguide.html" class="text-gray-400 hover:text-white transition-colors">Hanoi</a></li>
                         <li><a href="osakatravelguide.html" class="text-gray-400 hover:text-white transition-colors">Osaka</a></li>
-                        <li><a href="korculaguide.html" class="text-gray-400 hover:text-white transition-colors">Korčula</a></li>
+                        <li><a href="korcula.html" class="text-gray-400 hover:text-white transition-colors">Korčula</a></li>
                     </ul>
                 </div>
                 

--- a/how-to-make-your-videos-look-cinematic.html
+++ b/how-to-make-your-videos-look-cinematic.html
@@ -134,6 +134,7 @@ Curiosity-driven: The one tweak that made my footage feel less digital
                     <a href="blog.html" class="text-gray-700 hover:text-yellow-500 transition-colors">Blog</a>
                     <a href="gear.html" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">Gear</a>
                     <a href="portfolio.html" class="text-gray-700 hover:text-yellow-500 transition-colors">Portfolio</a>
+                    <a href="donate.html" class="text-gray-700 hover:text-yellow-500 transition-colors">Donate</a>
                     <a href="contact.html" class="text-gray-700 hover:text-yellow-500 transition-colors">Contact</a>
                 </div>
                 <button id="mobile-menu-button" class="md:hidden text-gray-700 focus:outline-none">
@@ -146,6 +147,7 @@ Curiosity-driven: The one tweak that made my footage feel less digital
                     <li><a href="blog.html" class="block px-4 py-2 text-gray-700 hover:bg-gray-100 rounded">Blog</a>
                     <a href="gear.html" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">Gear</a></li>
                     <li><a href="portfolio.html" class="block px-4 py-2 text-gray-700 hover:bg-gray-100 rounded">Portfolio</a></li>
+                    <li><a href="donate.html" class="block px-4 py-2 text-gray-700 hover:bg-gray-100 rounded">Donate</a></li>
                     <li><a href="contact.html" class="block px-4 py-2 text-gray-700 hover:bg-gray-100 rounded">Contact</a></li>
                 </ul>
             </div>

--- a/howtofoldapopuptent.html
+++ b/howtofoldapopuptent.html
@@ -265,9 +265,9 @@ Curiosity-driven: The folding move that finally made the tent behave
                     <h2 class="text-2xl font-bold text-gray-800 mb-4"><i class="fas fa-map mr-2 text-yellow-500"></i> 🗺️ Keep the Adventure Rolling</h2>
                     <p class="text-gray-600 mb-4">Loved this bite-sized hack? Check out these other Carl Travels posts:</p>
                     <ul class="list-disc pl-6 mb-4 text-gray-600">
-                        <li><a href="carry-on-packing.html" class="text-yellow-500 hover:text-yellow-500">How to Pack a 7 kg Carry-On Like a Tetris Master</a></li>
-                        <li><a href="travel-knots.html" class="text-yellow-500 hover:text-yellow-500">The Only Two Knots Every Traveller Actually Needs</a></li>
-                        <li><a href="bali-budget.html" class="text-yellow-500 hover:text-yellow-500">Bali on a Bogan Budget – Yes, It’s Possible</a></li>
+                        <li><a href="mytop10travelhacks.html" class="text-yellow-500 hover:text-yellow-500">My Top 10 Travel Hacks for Long-Term Adventures</a></li>
+                        <li><a href="7 ways to find cheap accomodation while traveling.html" class="text-yellow-500 hover:text-yellow-500">7 Ways to Find Cheap Accommodation While Traveling</a></li>
+                        <li><a href="make-money-online-while-traveling.html" class="text-yellow-500 hover:text-yellow-500">Make Money Online While Traveling</a></li>
                     </ul>
                     <p class="text-gray-600 mb-4">
                         And, of course, subscribe to <a href="https://www.youtube.com/@globetraveladventures" target="_blank" class="text-yellow-500 hover:text-yellow-500">Globe Travel Adventures on YouTube</a> for more no-fluff travel tips.
@@ -351,7 +351,7 @@ Curiosity-driven: The folding move that finally made the tent behave
                         <li><a href="melbournetravelguide.html" class="text-gray-400 hover:text-white transition-colors">Melbourne</a></li>
                         <li><a href="cairnstravelguide.html" class="text-gray-400 hover:text-white transition-colors">Cairns</a></li>
                         <li><a href="phuketravelguide.html" class="text-gray-400 hover:text-white transition-colors">Phuket</a></li>
-                        <li><a href="hanoiguide.html" class="text-gray-400 hover:text-white transition-colors">Hanoi</a></li>
+                        <li><a href="hanoitravelguide.html" class="text-gray-400 hover:text-white transition-colors">Hanoi</a></li>
                         <li><a href="osakatravelguide.html" class="text-gray-400 hover:text-white transition-colors">Osaka</a></li>
                         <li><a href="korcula.html" class="text-gray-400 hover:text-white transition-colors">Korčula</a></li>
                     </ul>

--- a/index.html
+++ b/index.html
@@ -181,6 +181,7 @@
                     <a href="blog.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Blog</a>
                     <a href="gear.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Gear</a>
                     <a href="#about" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">About</a>
+                    <a href="donate.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Donate</a>
                     <a href="#contact" class="px-4 py-2 bg-gradient-to-r from-yellow-500 to-amber-600 text-black rounded-full hover:shadow-lg transition-all">Contact</a>
                 </div>
                 
@@ -199,6 +200,7 @@
                     <a href="blog.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Blog</a>
                     <a href="gear.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Gear</a>
                     <a href="#about" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">About</a>
+                    <a href="donate.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Donate</a>
                     <a href="#contact" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Contact</a>
                 </div>
             </div>

--- a/japanonabudget.html
+++ b/japanonabudget.html
@@ -14,7 +14,7 @@
     <meta property="og:title" content="How to Visit Japan on a Budget (From Someone Who Actually Did It) - Carl Travels">
     <meta property="og:description" content="Discover how to travel Japan on a budget in 2025 with Carl Travels’ guide. Learn money-saving tips on accommodation, food, transport, and attractions from firsthand experience.">
     <meta property="og:image" content="https://www.carltravels.com/images/japanbudget.jpg">
-    <meta property="og:url" content="https://www.carltravels.com/budgetjapan.html">
+    <meta property="og:url" content="https://www.carltravels.com/japanonabudget.html">
     <meta property="og:type" content="article">
     <!-- Twitter Card Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
@@ -427,9 +427,9 @@
                         <li><a href="melbournetravelguide.html" class="text-gray-400 hover:text-white transition-colors">Melbourne</a></li>
                         <li><a href="cairnstravelguide.html" class="text-gray-400 hover:text-white transition-colors">Cairns</a></li>
                         <li><a href="phuketravelguide.html" class="text-gray-400 hover:text-white transition-colors">Phuket</a></li>
-                        <li><a href="hanoiguide.html" class="text-gray-400 hover:text-white transition-colors">Hanoi</a></li>
+                        <li><a href="hanoitravelguide.html" class="text-gray-400 hover:text-white transition-colors">Hanoi</a></li>
                         <li><a href="osakatravelguide.html" class="text-gray-400 hover:text-white transition-colors">Osaka</a></li>
-                        <li><a href="korculaguide.html" class="text-gray-400 hover:text-white transition-colors">Korčula</a></li>
+                        <li><a href="korcula.html" class="text-gray-400 hover:text-white transition-colors">Korčula</a></li>
                     </ul>
                 </div>
                 
@@ -545,7 +545,7 @@
                     });
                 }
             } catch (error) {
-                console.error('JavaScript Error in budgetjapan.html:', error);
+                console.error('JavaScript Error in japanonabudget.html:', error);
             }
         });
     </script>

--- a/korcula.html
+++ b/korcula.html
@@ -14,7 +14,7 @@
     <meta property="og:title" content="Your Ultimate Guide to Visiting Korčula, Croatia - Carl Travels">
     <meta property="og:description" content="Join Carl Travels to explore Korčula, Croatia. Watch a video tour, see stunning images, and learn about ferries, accommodation, beaches, Old Town, and wineries.">
     <meta property="og:image" content="https://www.carltravels.com/images/korculalogo.jpg">
-    <meta property="og:url" content="https://www.carltravels.com/korculaguide.html">
+    <meta property="og:url" content="https://www.carltravels.com/korcula.html">
     <meta property="og:type" content="article">
     <!-- Twitter Card Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
@@ -610,7 +610,7 @@
                     });
                 }
             } catch (error) {
-                console.error('JavaScript Error in korculaguide.html:', error);
+                console.error('JavaScript Error in korcula.html:', error);
             }
         });
     </script>

--- a/lotte-world-aquarium-hanoi.html
+++ b/lotte-world-aquarium-hanoi.html
@@ -88,6 +88,7 @@
                     <a href="https://www.youtube.com/@globetraveladventures" target="_blank" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">YouTube</a>
                     <a href="blog.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Blog</a>
                     <a href="gear.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Gear</a>
+                    <a href="donate.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Donate</a>
                     <a href="#visit" class="px-4 py-2 bg-gradient-to-r from-yellow-500 to-amber-600 text-black rounded-full hover:shadow-lg transition-all">Plan Your Visit</a>
                 </div>
                 <button id="mobile-menu-button" class="md:hidden text-gray-300 focus:outline-none">
@@ -101,6 +102,7 @@
                     <a href="https://www.youtube.com/@globetraveladventures" target="_blank" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">YouTube</a>
                     <a href="blog.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Blog</a>
                     <a href="gear.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Gear</a>
+                    <a href="donate.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Donate</a>
                     <a href="#visit" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Plan Your Visit</a>
                 </div>
             </div>

--- a/make-money-online-while-traveling.html
+++ b/make-money-online-while-traveling.html
@@ -124,6 +124,7 @@ Curiosity-driven: The income stream I expected to work that didn’t
                     <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">Videos</a>
                     <a href="blog.html" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">Blog</a>
                     <a href="gear.html" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">Gear</a>
+                    <a href="donate.html" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">Donate</a>
                     <a href="contact.html" class="text-gray-700 hover:text-yellow-500 font-medium transition-colors">Contact</a>
                 </div>
 
@@ -139,6 +140,7 @@ Curiosity-driven: The income stream I expected to work that didn’t
                     <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">Videos</a>
                     <a href="blog.html" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">Blog</a>
                     <a href="gear.html" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">Gear</a>
+                    <a href="donate.html" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">Donate</a>
                     <a href="contact.html" class="block px-3 py-2 rounded-md text-gray-700 hover:bg-yellow-900">Contact</a>
                 </div>
             </div>

--- a/mytop10travelhacks.html
+++ b/mytop10travelhacks.html
@@ -468,7 +468,7 @@ Curiosity-driven: The travel hack that saved me the most last year
                         <li><a href="melbournetravelguide.html" class="text-gray-400 hover:text-white transition-colors">Melbourne</a></li>
                         <li><a href="cairnstravelguide.html" class="text-gray-400 hover:text-white transition-colors">Cairns</a></li>
                         <li><a href="phuketravelguide.html" class="text-gray-400 hover:text-white transition-colors">Phuket</a></li>
-                        <li><a href="hanoiguide.html" class="text-gray-400 hover:text-white transition-colors">Hanoi</a></li>
+                        <li><a href="hanoitravelguide.html" class="text-gray-400 hover:text-white transition-colors">Hanoi</a></li>
                         <li><a href="osakatravelguide.html" class="text-gray-400 hover:text-white transition-colors">Osaka</a></li>
                     </ul>
                 </div>

--- a/ninhbinhtravelguide.html
+++ b/ninhbinhtravelguide.html
@@ -211,6 +211,7 @@
                 <a href="blog.html" class="hover:text-yellow-400">Blog</a>
                 <a href="gear.html" class="hover:text-yellow-400">Gear</a>
                 <a href="index.html#about" class="hover:text-yellow-400">About</a>
+                <a href="donate.html" class="hover:text-yellow-400">Donate</a>
             </div>
         </div>
     </nav>

--- a/nusalembongan.html
+++ b/nusalembongan.html
@@ -54,7 +54,7 @@
 
     <!-- Link to Stylesheets -->
     <link rel="stylesheet" href="styles.css">
-    <link rel="stylesheet" href="destination.css">
+    <link rel="stylesheet" href="city.css">
 
     <!-- Fonts -->
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&family=Dancing+Script&family=Montserrat:wght@600&display=swap" rel="stylesheet">
@@ -344,8 +344,8 @@
                     <aside class="sidebar">
                         <h2>More From My Travels</h2>
                         <ul>
-                            <li><a href="tokyo.html">Tokyo – Urban Legends & Hidden Gems</a></li>
-                            <li><a href="nadi.html">Nadi, Fiji – Tropical Adventures & Hidden Gems</a></li>
+                            <li><a href="tokyotravelguide.html">Tokyo Travel Guide</a></li>
+                            <li><a href="phuketravelguide.html">Phuket Travel Guide</a></li>
                             <li><a href="destinations.html">All Destinations</a></li>
                         </ul>
                         <h2>Quick Tips</h2>

--- a/osakatravelguide.html
+++ b/osakatravelguide.html
@@ -531,7 +531,7 @@
                 <div>
                     <h3 class="text-lg font-semibold mb-6">Destinations</h3>
                     <ul class="space-y-3">
-                        <li><a href="berlin.html" class="text-gray-400 hover:text-white transition-colors">Berlin</a></li>
+                        <li><a href="Berlin.html" class="text-gray-400 hover:text-white transition-colors">Berlin</a></li>
                         <li><a href="melbournetravelguide.html" class="text-gray-400 hover:text-white transition-colors">Melbourne</a></li>
                         <li><a href="cairnstravelguide.html" class="text-gray-400 hover:text-white transition-colors">Cairns</a></li>
                         <li><a href="phuketravelguide.html" class="text-gray-400 hover:text-white transition-colors">Phuket</a></li>

--- a/phuketravelguide.html
+++ b/phuketravelguide.html
@@ -247,6 +247,7 @@
                     <a href="blog.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Blog</a>
                     <a href="gear.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Gear</a>
                     <a href="index.html#about" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">About</a>
+                    <a href="donate.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Donate</a>
                     <a href="index.html#contact" class="px-4 py-2 bg-gradient-to-r from-yellow-500 to-amber-600 text-black rounded-full hover:shadow-lg transition-all">Contact</a>
                 </div>
                 <button id="mobile-menu-button" class="md:hidden text-gray-300 focus:outline-none">
@@ -262,6 +263,7 @@
                     <a href="blog.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Blog</a>
                     <a href="gear.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Gear</a>
                     <a href="index.html#about" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">About</a>
+                    <a href="donate.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Donate</a>
                     <a href="index.html#contact" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Contact</a>
                 </div>
             </div>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -336,9 +336,9 @@
                         <li><a href="melbournetravelguide.html" class="text-gray-400 hover:text-white transition-colors">Melbourne</a></li>
                         <li><a href="cairnstravelguide.html" class="text-gray-400 hover:text-white transition-colors">Cairns</a></li>
                         <li><a href="phuketravelguide.html" class="text-gray-400 hover:text-white transition-colors">Phuket</a></li>
-                        <li><a href="hanoiguide.html" class="text-gray-400 hover:text-white transition-colors">Hanoi</a></li>
+                        <li><a href="hanoitravelguide.html" class="text-gray-400 hover:text-white transition-colors">Hanoi</a></li>
                         <li><a href="osakatravelguide.html" class="text-gray-400 hover:text-white transition-colors">Osaka</a></li>
-                        <li><a href="korculaguide.html" class="text-gray-400 hover:text-white transition-colors">Korčula</a></li>
+                        <li><a href="korcula.html" class="text-gray-400 hover:text-white transition-colors">Korčula</a></li>
                     </ul>
                 </div>
                 

--- a/sony-a7cii-review.html
+++ b/sony-a7cii-review.html
@@ -475,9 +475,9 @@
                         <li><a href="melbournetravelguide.html" class="text-gray-400 hover:text-white transition-colors">Melbourne</a></li>
                         <li><a href="cairnstravelguide.html" class="text-gray-400 hover:text-white transition-colors">Cairns</a></li>
                         <li><a href="phuketravelguide.html" class="text-gray-400 hover:text-white transition-colors">Phuket</a></li>
-                        <li><a href="hanoiguide.html" class="text-gray-400 hover:text-white transition-colors">Hanoi</a></li>
+                        <li><a href="hanoitravelguide.html" class="text-gray-400 hover:text-white transition-colors">Hanoi</a></li>
                         <li><a href="osakatravelguide.html" class="text-gray-400 hover:text-white transition-colors">Osaka</a></li>
-                        <li><a href="korculaguide.html" class="text-gray-400 hover:text-white transition-colors">Korčula</a></li>
+                        <li><a href="korcula.html" class="text-gray-400 hover:text-white transition-colors">Korčula</a></li>
                         <li><a href="kyototravelguide.html" class="text-gray-400 hover:text-white transition-colors">Kyoto</a></li>
                         <li><a href="balitravelguide.html" class="text-gray-400 hover:text-white transition-colors">Bali</a></li>
                     </ul>

--- a/tech-review-dji-mavic3.html
+++ b/tech-review-dji-mavic3.html
@@ -460,9 +460,9 @@
                         <li><a href="melbournetravelguide.html" class="text-gray-400 hover:text-white transition-colors">Melbourne</a></li>
                         <li><a href="cairnstravelguide.html" class="text-gray-400 hover:text-white transition-colors">Cairns</a></li>
                         <li><a href="phuketravelguide.html" class="text-gray-400 hover:text-white transition-colors">Phuket</a></li>
-                        <li><a href="hanoiguide.html" class="text-gray-400 hover:text-white transition-colors">Hanoi</a></li>
+                        <li><a href="hanoitravelguide.html" class="text-gray-400 hover:text-white transition-colors">Hanoi</a></li>
                         <li><a href="osakatravelguide.html" class="text-gray-400 hover:text-white transition-colors">Osaka</a></li>
-                        <li><a href="korculaguide.html" class="text-gray-400 hover:text-white transition-colors">Korčula</a></li>
+                        <li><a href="korcula.html" class="text-gray-400 hover:text-white transition-colors">Korčula</a></li>
                         <li><a href="kyototravelguide.html" class="text-gray-400 hover:text-white transition-colors">Kyoto</a></li>
                         <li><a href="balitravelguide.html" class="text-gray-400 hover:text-white transition-colors">Bali</a></li>
                     </ul>

--- a/terms-and-conditions.html
+++ b/terms-and-conditions.html
@@ -337,9 +337,9 @@
                         <li><a href="melbournetravelguide.html" class="text-gray-400 hover:text-white transition-colors">Melbourne</a></li>
                         <li><a href="cairnstravelguide.html" class="text-gray-400 hover:text-white transition-colors">Cairns</a></li>
                         <li><a href="phuketravelguide.html" class="text-gray-400 hover:text-white transition-colors">Phuket</a></li>
-                        <li><a href="hanoiguide.html" class="text-gray-400 hover:text-white transition-colors">Hanoi</a></li>
+                        <li><a href="hanoitravelguide.html" class="text-gray-400 hover:text-white transition-colors">Hanoi</a></li>
                         <li><a href="osakatravelguide.html" class="text-gray-400 hover:text-white transition-colors">Osaka</a></li>
-                        <li><a href="korculaguide.html" class="text-gray-400 hover:text-white transition-colors">Korčula</a></li>
+                        <li><a href="korcula.html" class="text-gray-400 hover:text-white transition-colors">Korčula</a></li>
                     </ul>
                 </div>
                 

--- a/top-10-things-to-do-in-hanoi.html
+++ b/top-10-things-to-do-in-hanoi.html
@@ -107,6 +107,7 @@
                     <a href="https://www.youtube.com/@globetraveladventures" target="_blank" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">YouTube</a>
                     <a href="blog.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Blog</a>
                     <a href="gear.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Gear</a>
+                    <a href="donate.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Donate</a>
                     <a href="#plan" class="px-4 py-2 bg-gradient-to-r from-yellow-500 to-amber-600 text-black rounded-full hover:shadow-lg transition-all">Plan Your Trip</a>
                 </div>
                 <button id="mobile-menu-button" class="md:hidden text-gray-300 focus:outline-none">
@@ -120,6 +121,7 @@
                     <a href="https://www.youtube.com/@globetraveladventures" target="_blank" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">YouTube</a>
                     <a href="blog.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Blog</a>
                     <a href="gear.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Gear</a>
+                    <a href="donate.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Donate</a>
                     <a href="#plan" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Plan Your Trip</a>
                 </div>
             </div>

--- a/travel-gear-2025.html
+++ b/travel-gear-2025.html
@@ -316,10 +316,10 @@ Curiosity-driven: The small piece of gear that saves my shoots
                         <li><a href="melbournetravelguide.html" class="text-gray-400 hover:text-white transition-colors">Melbourne</a></li>
                         <li><a href="cairnstravelguide.html" class="text-gray-400 hover:text-white transition-colors">Cairns</a></li>
                         <li><a href="phuketravelguide.html" class="text-gray-400 hover:text-white transition-colors">Phuket</a></li>
-                        <li><a href="hanoiguide.html" class="text-gray-400 hover:text-white transition-colors">Hanoi</a></li>
+                        <li><a href="hanoitravelguide.html" class="text-gray-400 hover:text-white transition-colors">Hanoi</a></li>
                         <li><a href="osakatravelguide.html" class="text-gray-400 hover:text-white transition-colors">Osaka</a></li>
                         <li><a href="korcula.html" class="text-gray-400 hover:text-white transition-colors">Korčula</a></li>
-                        <li><a href="budavatravelguide.html" class="text-gray-400 hover:text-white transition-colors">Budva</a></li>
+                        <li><a href="budvatravelguide.html" class="text-gray-400 hover:text-white transition-colors">Budva</a></li>
                     </ul>
                 </div>
                 <div>

--- a/vinwonders-nha-trang.html
+++ b/vinwonders-nha-trang.html
@@ -99,6 +99,7 @@
                     <a href="blog.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Blog</a>
                     <a href="gear.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Gear</a>
                     <a href="index.html#about" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">About</a>
+                    <a href="donate.html" class="text-gray-300 hover:text-yellow-500 font-medium transition-colors">Donate</a>
                     <a href="index.html#contact" class="px-4 py-2 bg-gradient-to-r from-yellow-500 to-amber-600 text-black rounded-full hover:shadow-lg transition-all">Contact</a>
                 </div>
                 <button id="mobile-menu-button" class="md:hidden text-gray-300 focus:outline-none">
@@ -113,6 +114,7 @@
                     <a href="blog.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Blog</a>
                     <a href="gear.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Gear</a>
                     <a href="index.html#about" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">About</a>
+                    <a href="donate.html" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Donate</a>
                     <a href="index.html#contact" class="block px-3 py-2 rounded-md text-gray-300 hover:bg-yellow-900">Contact</a>
                 </div>
             </div>

--- a/whyileftaustralia.html
+++ b/whyileftaustralia.html
@@ -225,7 +225,7 @@ Curiosity-driven: The moment I knew I had to leave Australia
                             
                             <p class="text-gray-600 mb-4">I didn’t leave because I had everything figured out. I didn’t leave because I was sure it would be easy. I left because I knew I owed it to myself to at least try.</p>
                             
-                            <p class="text-gray-600 mb-4">Places like Vietnam gave me the reset I needed. Life felt lighter again. I could stretch my money further. I could meet new people, build new dreams, make mistakes and still get back up again. And most importantly—I got my <strong>energy back.</strong> The kind of creative, hopeful energy that you can’t fake. The kind that makes you want to wake up in the morning and actually live. Curious about how I manage life abroad? Check out my <a href="budgetjapan.html" class="text-yellow-500 hover:text-yellow-500">budget travel tips</a>!</p>
+                            <p class="text-gray-600 mb-4">Places like Vietnam gave me the reset I needed. Life felt lighter again. I could stretch my money further. I could meet new people, build new dreams, make mistakes and still get back up again. And most importantly—I got my <strong>energy back.</strong> The kind of creative, hopeful energy that you can’t fake. The kind that makes you want to wake up in the morning and actually live. Curious about how I manage life abroad? Check out my <a href="japanonabudget.html" class="text-yellow-500 hover:text-yellow-500">budget travel tips</a>!</p>
                             
                             <p class="text-gray-600 mb-4">I’ll always have love for Australia. It’s where I’m from. But sometimes loving something means being honest about when it no longer fits.</p>
                             
@@ -286,7 +286,7 @@ Curiosity-driven: The moment I knew I had to leave Australia
                     </div>
                     
                     <div class="text-center">
-                        <a href="budgetjapan.html" class="inline-flex items-center px-6 py-3 border border-yellow-500 text-yellow-500 rounded-full font-medium hover:bg-yellow-900 transition-all">
+                        <a href="japanonabudget.html" class="inline-flex items-center px-6 py-3 border border-yellow-500 text-yellow-500 rounded-full font-medium hover:bg-yellow-900 transition-all">
                             Life Abroad on a Budget <i class="fas fa-arrow-right ml-2"></i>
                         </a>
                     </div>
@@ -369,9 +369,9 @@ Curiosity-driven: The moment I knew I had to leave Australia
                         <li><a href="melbournetravelguide.html" class="text-gray-400 hover:text-white transition-colors">Melbourne</a></li>
                         <li><a href="cairnstravelguide.html" class="text-gray-400 hover:text-white transition-colors">Cairns</a></li>
                         <li><a href="phuketravelguide.html" class="text-gray-400 hover:text-white transition-colors">Phuket</a></li>
-                        <li><a href="hanoiguide.html" class="text-gray-400 hover:text-white transition-colors">Hanoi</a></li>
+                        <li><a href="hanoitravelguide.html" class="text-gray-400 hover:text-white transition-colors">Hanoi</a></li>
                         <li><a href="osakatravelguide.html" class="text-gray-400 hover:text-white transition-colors">Osaka</a></li>
-                        <li><a href="korculaguide.html" class="text-gray-400 hover:text-white transition-colors">Korčula</a></li>
+                        <li><a href="korcula.html" class="text-gray-400 hover:text-white transition-colors">Korčula</a></li>
                     </ul>
                 </div>
                 


### PR DESCRIPTION
### Motivation
- Clean up multiple broken internal links that pointed to outdated filenames or missing pages. 
- Ensure the `donate.html` page is reachable from every site header and mobile nav for consistent navigation. 
- Make the `donate.html` styling match the site’s dark theme and accent colors used on `index.html`. 
- Replace a few legacy CSS/URL references to the correct page-level assets for consistent look-and-feel.

### Description
- Corrected many internal hrefs across destination, gear, blog and policy pages (examples: `hanoiguide.html` → `hanoitravelguide.html`, `korculaguide.html` → `korcula.html`, `budgetjapan.html` → `japanonabudget.html`, and fixed `Berlin.html` capitalization). 
- Added `Donate` links to desktop headers and mobile menus across all pages so the donate page appears in every nav. 
- Restyled `donate.html` to use the site dark theme and matching accent colors (navbar background, text colors, button styles, card backgrounds, and CTA styling). 
- Minor page tweaks such as swapping `destination.css` → `city.css` in `nusalembongan.html` and updating a handful of OG/meta URLs and link targets for consistency.

### Testing
- Ran a custom Python link-scanner that inspects `href` values across local `.html` files and it reported `missing 0`, indicating no unresolved internal links. 
- Verified `donate.html` appears in every page navigation by running a nav-scan script which returned `missing donate in nav 0`. 
- Launched a local server with `python -m http.server` and captured a full-page screenshot of `donate.html` using a Playwright script which produced `artifacts/donate-page.png` to visually confirm styling. 
- All edits were staged and a commit was created successfully (`git commit` completed) after automated verification scripts passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a76f294f883239d59598325f602b3)