### PR TITLE
Update Zhiyun Weebill 2 review with travel-focused copy

### DIFF
--- a/tech-review-zhiyun-weebill2.html
+++ b/tech-review-zhiyun-weebill2.html
@@ -195,20 +195,89 @@
             <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
                 <div class="lg:col-span-2">
                     <div class="prose max-w-none text-gray-800">
-                        <p>The Weebill 2 is a compact 3-axis gimbal that handles mirrorless cameras with ease.</p>
-                        <p>I’ve hauled it through crowded markets and rocky trails with reliable results.</p>
-                        <h3 class="text-xl font-bold text-gray-800">Mid-Review Check-in</h3>
-                        <p>Time marker: day 9 of the trip. Money marker: $18 for balancing tools and hex keys. Trade-off/regret: I skipped a counterweight and felt it with heavier glass.</p>
-                        <h2>Why It Works</h2>
+                        <h1 class="text-3xl font-bold text-gray-800">Zhiyun Weebill 2 Review: A Travel Gimbal That Actually Makes Sense</h1>
+                        <p>When you travel with a mirrorless camera, every piece of gear becomes a negotiation between weight, reliability, and sanity. You want cinematic footage, but you also want to get through airports, crowded markets, and uneven trails without feeling like a walking production crew.</p>
+                        <p>That’s where the Zhiyun Weebill 2 fits in. It’s a compact 3-axis gimbal built for mirrorless cameras, and after hauling it through busy cities and rough terrain, I’d describe it as quietly dependable — not flashy, but consistently doing its job.</p>
+                        <p>This isn’t a studio review. This is a real-world travel test.</p>
+
+                        <h2 class="text-2xl font-bold text-gray-800 mt-8">Real-World Use: On the Road, Not on a Desk</h2>
+                        <p>I’ve carried the Weebill 2 through crowded markets, long walking days, and rocky trails, often pairing it with heavier lenses than I probably should. Once balanced properly, it handled those conditions with confidence.</p>
+
+                        <h3 class="text-xl font-bold text-gray-800 mt-6">Mid-Review Check-In (Real Numbers)</h3>
                         <ul>
-                            <li>Responsive touchscreen for quick settings</li>
-                            <li>Strong motors keep footage steady with heavier lenses</li>
-                            <li>Underslung mode for low-angle shots</li>
+                            <li><strong>Time marker:</strong> Day 9 of the trip</li>
+                            <li><strong>Unexpected spend:</strong> ~$18 on balancing tools and hex keys</li>
+                            <li><strong>Regret:</strong> Skipped a counterweight</li>
+                            <li><strong>Result:</strong> With heavier glass, you feel it — not unusable, but less forgiving</li>
                         </ul>
-                        <h2>Limitations</h2>
-                        <p>Battery life is average and balancing can be fiddly at first. Once dialed in, it performs beautifully.</p>
-                        <h2>Overall</h2>
-                        <p>For travellers who want silky smooth footage without a huge rig, the Weebill 2 is a solid choice.</p>
+                        <p>This is important: the Weebill 2 can handle heavier lenses, but it rewards proper setup. Rush the balance and you’ll drain battery faster or stress the motors more than necessary.</p>
+
+                        <h2 class="text-2xl font-bold text-gray-800 mt-8">Why the Weebill 2 Works So Well for Travel</h2>
+                        <h3 class="text-xl font-bold text-gray-800 mt-6">1. Built-In Touchscreen (Actually Useful)</h3>
+                        <p>The standout feature is the integrated touchscreen. Unlike older gimbals that force you to memorize button combos or use a phone app mid-shoot, the Weebill 2 lets you:</p>
+                        <ul>
+                            <li>Switch modes quickly</li>
+                            <li>Adjust motor strength</li>
+                            <li>Re-center and recalibrate on the fly</li>
+                        </ul>
+                        <p>When you’re moving fast — crossing streets, chasing light, or filming solo — this saves time and frustration.</p>
+
+                        <h3 class="text-xl font-bold text-gray-800 mt-6">2. Strong Motors for Real Lenses</h3>
+                        <p>This isn’t a “kit-lens-only” gimbal. The motors are strong enough to keep footage stable even with:</p>
+                        <ul>
+                            <li>Fast zooms</li>
+                            <li>Slightly front-heavy setups</li>
+                            <li>Small follow-focus or mic accessories</li>
+                        </ul>
+                        <p>Compared to lighter gimbals, the Weebill 2 feels confident, not on the edge of its limits.</p>
+
+                        <h3 class="text-xl font-bold text-gray-800 mt-6">3. Underslung Mode for Cinematic Movement</h3>
+                        <p>Low-angle walking shots, ground-level reveals, and glide-throughs are easy thanks to underslung mode. For travel filmmakers, this is where your footage starts to look intentional instead of accidental.</p>
+
+                        <h2 class="text-2xl font-bold text-gray-800 mt-8">Where the Weebill 2 Falls Short</h2>
+                        <h3 class="text-xl font-bold text-gray-800 mt-6">Battery Life: Fine, Not Amazing</h3>
+                        <p>Battery life is average. Expect a solid shooting day if you’re efficient, but heavy lenses, poor balancing, and cold environments will shorten runtime. This isn’t a dealbreaker, but it’s not a “forget your charger” gimbal either.</p>
+
+                        <h3 class="text-xl font-bold text-gray-800 mt-6">Balancing Has a Learning Curve</h3>
+                        <p>If you’re new to gimbals, the Weebill 2 can feel fiddly at first: tight tolerances, sensitive balance points, and less forgiving with front-heavy lenses. Once dialed in, it performs beautifully — but the first few setups may test your patience.</p>
+
+                        <h2 class="text-2xl font-bold text-gray-800 mt-8">Weebill 2 vs Popular Alternatives</h2>
+                        <h3 class="text-xl font-bold text-gray-800 mt-6">Weebill 2 vs DJI RS 3 Mini</h3>
+                        <div>
+                            <p><strong>Weebill 2:</strong> Better onboard screen, more cinematic control, slightly bulkier</p>
+                            <p><strong>RS 3 Mini:</strong> Faster setup, lighter, less control without phone</p>
+                            <p><strong>Verdict:</strong> Weebill 2 wins for filmmakers, RS 3 Mini wins for vlog-and-go creators.</p>
+                        </div>
+
+                        <h3 class="text-xl font-bold text-gray-800 mt-6">Weebill 2 vs Zhiyun Crane M3</h3>
+                        <div>
+                            <p><strong>Weebill 2:</strong> Handles heavier setups, better for interchangeable lenses</p>
+                            <p><strong>Crane M3:</strong> Ultra-compact, great for small primes</p>
+                            <p><strong>Verdict:</strong> If you shoot zooms or heavier glass, the Weebill 2 is the safer choice.</p>
+                        </div>
+
+                        <h2 class="text-2xl font-bold text-gray-800 mt-8">Price &amp; Value</h2>
+                        <p>Pricing typically sits in the mid-range gimbal category, making it more expensive than entry-level stabilizers and cheaper than full-size cinema gimbals. For what you get — touchscreen, motor strength, portability — it offers strong value for serious travel shooters.</p>
+
+                        <h2 class="text-2xl font-bold text-gray-800 mt-8">Who the Weebill 2 Is For (and Who It Isn’t)</h2>
+                        <h3 class="text-xl font-bold text-gray-800 mt-6">Ideal For:</h3>
+                        <ul>
+                            <li>Travel filmmakers</li>
+                            <li>Solo creators</li>
+                            <li>Mirrorless shooters who value control and stability</li>
+                            <li>People who don’t want a massive rig</li>
+                        </ul>
+                        <h3 class="text-xl font-bold text-gray-800 mt-6">Not Ideal For:</h3>
+                        <ul>
+                            <li>Ultra-light vloggers who want zero setup</li>
+                            <li>Creators allergic to balancing</li>
+                            <li>Heavy cinema camera users</li>
+                        </ul>
+
+                        <h2 class="text-2xl font-bold text-gray-800 mt-8">Final Verdict</h2>
+                        <p>The Zhiyun Weebill 2 isn’t the lightest or the simplest gimbal — but it’s one of the most capable travel-friendly options available.</p>
+                        <p>If you want silky smooth footage, strong motors, and real control without carrying a huge rig, this gimbal earns its place in your bag. Treat it properly, balance it well, and it will quietly deliver shot after shot.</p>
+                        <p>For travellers who care about how their footage feels, not just how easy it is to shoot, the Weebill 2 is a solid, no-nonsense choice.</p>
                         <p><a href="https://amzn.to/3-example" target="_blank" class="text-yellow-500 hover:underline">Check Price</a></p>
                     </div>
                 </div>


### PR DESCRIPTION
### Motivation

- Replace the short, generic review with a real-world, travel-focused writeup that reflects on usability in the field.
- Provide clearer structure and headings for readability and SEO by adding an H1 and sectional content.
- Capture practical details (balance, battery, accessories, cost) and direct comparisons to popular alternatives.
- Preserve the existing page layout, CTAs, and sidebar while improving the main article content.

### Description

- Replaced the review block in `tech-review-zhiyun-weebill2.html` with a full travel-focused article including an H1, `Real-World Use`, `Mid-Review Check-In`, pros/cons, comparisons, and a `Final Verdict` section.
- Added lists and subheadings that cover `Built-In Touchscreen`, motor performance, `Underslung Mode`, battery/balancing notes, and comparisons vs the `DJI RS 3 Mini` and `Zhiyun Crane M3`.
- Kept existing layout, sidebar signup CTA, and affiliate `https://amzn.to/3-example` link intact, with no CSS or JS changes.
- File modified: `tech-review-zhiyun-weebill2.html`.

### Testing

- Launched a local server with `python -m http.server 8000` and used a Playwright script to load `http://localhost:8000/tech-review-zhiyun-weebill2.html` and capture a full-page screenshot, which succeeded.
- The change was staged and committed and the rendered page screenshot was produced as an automated artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694abd388e7483238b475ddce984a85c)