### PR TITLE
Add Old Quarter scams guide post and index card

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -217,6 +217,33 @@
             </div>
 
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+                <!-- Blog Post: Old Quarter Scams in Hanoi -->
+                <div class="blog-card rounded-xl overflow-hidden shadow-lg">
+                    <div class="relative overflow-hidden h-64">
+                        <img src="https://img.youtube.com/vi/IybWdSE35_0/maxresdefault.jpg" alt="Old Quarter scams in Hanoi" class="w-full h-full object-cover transform hover:scale-110 transition-transform duration-500">
+                        <div class="absolute inset-0 card-overlay"></div>
+                        <div class="absolute bottom-0 left-0 p-6 text-white">
+                            <h3 class="text-xl font-bold">Old Quarter Scams in Hanoi</h3>
+                            <p class="text-sm">What to Watch For</p>
+                        </div>
+                        <span class="absolute top-4 right-4 bg-yellow-9000 text-white text-xs px-3 py-1 rounded-full">New</span>
+                    </div>
+                    <div class="p-6 bg-white">
+                        <div class="flex justify-between items-center mb-3">
+                            <span class="text-gray-500 text-sm"><i class="fas fa-shield-halved mr-1 text-yellow-500"></i> Vietnam</span>
+                            <div class="flex items-center">
+                                <i class="fas fa-star text-yellow-400 mr-1"></i>
+                                <span class="font-medium">5.0</span>
+                            </div>
+                        </div>
+                        <p class="text-gray-600 mb-4">
+                            A 2025 guide to the Old Quarter’s biggest scams and how to avoid overpriced cyclos, shoe-shine hustles, and Beer Street traps.
+                        </p>
+                        <a href="old-quarter-scams-hanoi.html" class="text-yellow-500 font-medium hover:text-yellow-500 inline-flex items-center">
+                            Read the guide <i class="fas fa-arrow-right ml-2"></i>
+                        </a>
+                    </div>
+                </div>
                 <!-- Blog Post: Vietnam E-Visa 2026 Guide -->
                 <div class="blog-card rounded-xl overflow-hidden shadow-lg">
                     <div class="relative overflow-hidden h-64">

--- a/old-quarter-scams-hanoi.html
+++ b/old-quarter-scams-hanoi.html
@@ -1,0 +1,517 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Old Quarter Scams in Hanoi: What to Watch For (and How to Avoid Them) | Carl Travels</title>
+    <!-- Cookiebot for GDPR Compliance -->
+    <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="e44b7cd2-126b-4f49-8aee-22495afe3ece" type="text/javascript" async></script>
+    <!-- Meta Tags -->
+    <meta name="description" content="A 2025 guide to Hanoi’s Old Quarter, the most common tourist scams in Vietnam, and practical ways to avoid overpriced cyclos, shoe-shine hustles, and bar tricks." />
+    <meta name="keywords" content="Hanoi Old Quarter scams, Vietnam travel scams, cyclo scams, shoe cleaning scam, beer street scams, Hanoi safety tips" />
+    <meta name="author" content="Carl Ostomich">
+    <!-- Open Graph Meta Tags -->
+    <meta property="og:title" content="Old Quarter Scams in Hanoi: What to Watch For (and How to Avoid Them)" />
+    <meta property="og:description" content="A grounded guide to the Old Quarter and the most common scams in Vietnam, plus how to keep your trip stress-free." />
+    <meta property="og:image" content="https://img.youtube.com/vi/IybWdSE35_0/maxresdefault.jpg" />
+    <meta property="og:url" content="https://www.carltravels.com/old-quarter-scams-hanoi.html" />
+    <meta property="og:type" content="article" />
+    <!-- Twitter Card Meta Tags -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Old Quarter Scams in Hanoi: What to Watch For (and How to Avoid Them)">
+    <meta name="twitter:description" content="A 2025 guide to Hanoi’s Old Quarter, with practical tips to avoid common scams across Vietnam.">
+    <meta name="twitter:image" content="https://img.youtube.com/vi/IybWdSE35_0/maxresdefault.jpg">
+    <!-- External Resources -->
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700&family=Bebas+Neue&display=swap');
+
+        :root {
+            --primary: #f5c518; /* Muted gold for accents */
+            --secondary: #2a2a2a; /* Deep charcoal for backgrounds */
+            --dark: #0d0d0d; /* Near-black for text/body */
+            --light: #e5e5e5; /* Light gray for secondary text */
+        }
+
+        body {
+            font-family: 'Montserrat', sans-serif;
+            background-color: var(--dark);
+            color: var(--light);
+            scroll-behavior: smooth;
+        }
+
+        .hero-gradient {
+            background: linear-gradient(135deg, rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.7)),
+                        url('https://img.youtube.com/vi/IybWdSE35_0/maxresdefault.jpg') center/cover no-repeat;
+        }
+
+        .heading-font {
+            font-family: 'Bebas Neue', sans-serif;
+        }
+
+        .navbar {
+            backdrop-filter: blur(10px);
+            background-color: rgba(255, 255, 255, 0.9);
+            transition: all 0.3s ease;
+        }
+
+        .navbar.scrolled {
+            background-color: rgba(255, 255, 255, 0.98);
+            box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+        }
+
+        .wave-shape {
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            width: 100%;
+            overflow: hidden;
+            line-height: 0;
+        }
+
+        .wave-shape svg {
+            position: relative;
+            display: block;
+            width: calc(100% + 1.3px);
+            height: 150px;
+        }
+
+        .wave-shape .shape-fill {
+            fill: #FFFFFF;
+        }
+
+        .content-card {
+            background: rgba(255, 255, 255, 0.04);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            border-radius: 1.25rem;
+            padding: 2rem;
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
+        }
+
+        .content-card:hover {
+            transform: translateY(-6px);
+            box-shadow: 0 25px 40px -18px rgba(0, 0, 0, 0.45);
+        }
+
+        .photo-card {
+            position: relative;
+            overflow: hidden;
+            border-radius: 1rem;
+            border: 1px solid rgba(255, 255, 255, 0.06);
+            background: rgba(255, 255, 255, 0.04);
+        }
+
+        .photo-card img {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+            display: block;
+            transition: transform 0.6s ease;
+        }
+
+        .photo-card:hover img {
+            transform: scale(1.05);
+        }
+
+        .video-container {
+            position: relative;
+            width: 100%;
+            padding-top: 56.25%;
+            border-radius: 1rem;
+            overflow: hidden;
+        }
+
+        .video-container iframe {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            border: 0;
+        }
+    </style>
+    <link rel="stylesheet" href="/assets/css/styles.css">
+</head>
+<body class="text-gray-200">
+    <!-- Navigation -->
+    <nav id="navbar" class="navbar fixed w-full z-50 shadow-sm transition-all duration-300">
+        <div class="container mx-auto px-6 py-3">
+            <div class="flex justify-between items-center">
+                <a href="/index.html" class="text-2xl font-bold flex items-center">
+                    <div class="w-10 h-10 rounded-full bg-gradient-to-r from-yellow-500 to-amber-600 flex items-center justify-center mr-2">
+                        <i class="fas fa-camera text-black text-lg"></i>
+                    </div>
+                    <span class="heading-font bg-gradient-to-r from-yellow-500 to-amber-600 bg-clip-text text-transparent">Carl Tomich</span>
+                </a>
+
+                <div class="hidden md:flex items-center space-x-8">
+                    <a href="/index.html" class="nav-link font-medium transition-colors">Home</a>
+                    <a href="/destinations.html" class="nav-link font-medium transition-colors">Destinations</a>
+                    <a href="/portfolio.html" class="nav-link font-medium transition-colors">Portfolio</a>
+                    <a href="/videos/index.html" class="nav-link font-medium transition-colors">Watch</a>
+                    <a href="/blog.html" class="nav-link font-medium transition-colors">Blog</a>
+                    <a href="/gear.html" class="nav-link font-medium transition-colors">Gear</a>
+                    <a href="/index.html#about" class="nav-link font-medium transition-colors">About</a>
+                    <a href="/donate.html" class="nav-link font-medium transition-colors">Donate</a>
+                    <a href="/index.html#contact" class="contact-button px-4 py-2 bg-gradient-to-r from-yellow-500 to-amber-600 rounded-full hover:shadow-lg transition-all">Contact</a>
+                </div>
+
+                <button id="mobile-menu-button" class="md:hidden text-gray-300 focus:outline-none">
+                    <i class="fas fa-bars text-2xl"></i>
+                </button>
+            </div>
+
+            <div id="mobile-menu" class="mobile-menu md:hidden">
+                <div class="pt-4 pb-2 space-y-2">
+                    <a href="/index.html" class="mobile-link block px-3 py-2 rounded-md font-medium">Home</a>
+                    <a href="/destinations.html" class="mobile-link block px-3 py-2 rounded-md">Destinations</a>
+                    <a href="/portfolio.html" class="mobile-link block px-3 py-2 rounded-md">Portfolio</a>
+                    <a href="/videos/index.html" class="mobile-link block px-3 py-2 rounded-md">Watch</a>
+                    <a href="/blog.html" class="mobile-link block px-3 py-2 rounded-md">Blog</a>
+                    <a href="/gear.html" class="mobile-link block px-3 py-2 rounded-md">Gear</a>
+                    <a href="/index.html#about" class="mobile-link block px-3 py-2 rounded-md">About</a>
+                    <a href="/donate.html" class="mobile-link block px-3 py-2 rounded-md">Donate</a>
+                    <a href="/index.html#contact" class="mobile-link block px-3 py-2 rounded-md">Contact</a>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <!-- Hero Section -->
+    <section class="hero-gradient relative overflow-hidden min-h-[70vh] flex items-center pt-20">
+        <div class="wave-shape">
+            <svg data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 120" preserveAspectRatio="none">
+                <path d="M321.39,56.44c58-10.79,114.16-30.13,172-41.86,82.39-16.72,168.19-17.73,250.45-.39C823.78,31,906.67,72,985.66,92.83c70.05,18.48,146.53,26.09,214.34,3V0H0V27.35A600.21,600.21,0,0,0,321.39,56.44Z" class="shape-fill"></path>
+            </svg>
+        </div>
+
+        <div class="container mx-auto px-6 py-20 relative z-10">
+            <div class="max-w-3xl text-left">
+                <span class="text-yellow-300 uppercase tracking-[0.35em] text-xs">Hanoi • Old Quarter • Travel Safety</span>
+                <h1 class="heading-font text-4xl md:text-5xl lg:text-6xl font-bold text-white leading-tight mb-6">
+                    Old Quarter Scams in Hanoi: What to Watch For (and How to Avoid Them)
+                </h1>
+                <p class="text-lg text-yellow-100 mb-8 max-w-2xl">
+                    The Old Quarter is the heart of Hanoi, but it is also where tourists are most likely to be overcharged. Here is how to enjoy the energy, eat well, and avoid the common traps.
+                </p>
+                <div class="flex flex-wrap items-center gap-4">
+                    <span class="text-sm text-gray-200 flex items-center gap-2"><i class="fas fa-location-dot text-yellow-400"></i> Published from Hanoi</span>
+                    <span class="text-sm text-gray-200 flex items-center gap-2"><i class="fas fa-clock text-yellow-400"></i> Updated 2025</span>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Article Content -->
+    <main class="bg-white text-gray-900">
+        <div class="container mx-auto px-6 py-16 max-w-6xl">
+            <div class="grid md:grid-cols-3 gap-12 mb-12">
+                <div class="md:col-span-2 space-y-10">
+                    <div class="content-card bg-neutral-900 text-gray-100">
+                        <h2 class="heading-font text-3xl text-yellow-400 mb-4">Why the Old Quarter Feels Like a Movie Set</h2>
+                        <p class="text-lg text-gray-200 leading-relaxed">
+                            Hanoi’s Old Quarter is only a few square kilometers, yet it packs in more life than some entire cities. The streets follow a centuries-old layout built around trade guilds. That is why you still see names like Hang Bac (silver) or Hang Gai (silk). Every block is a mix of scooters, food stalls, temples, cafés, and colonial-era buildings squeezed into an environment that feels more like a living market than a tidy tourism district.
+                        </p>
+                        <p class="text-lg text-gray-200 leading-relaxed mt-4">
+                            That intensity is the reason people fall in love with it. It is also why the Old Quarter attracts the highest concentration of tourist-facing hustle in Vietnam. When everything feels fast, crowded, and unfamiliar, small overcharges are easy to slip past. The good news is that almost every scam here is low-tech and avoidable once you know the pattern.
+                        </p>
+                    </div>
+
+                    <div class="content-card bg-neutral-900 text-gray-100">
+                        <h2 class="heading-font text-3xl text-yellow-400 mb-4">Watch the Video First (It Shows the Vibe)</h2>
+                        <div class="video-container shadow-lg">
+                            <iframe src="https://www.youtube.com/embed/IybWdSE35_0" title="Old Quarter scams in Hanoi" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+                        </div>
+                        <p class="text-gray-200 leading-relaxed mt-4">
+                            If you want the visual version, the video above walks through the Old Quarter and shows how quickly the street energy ramps up at night. Use it as a reference before you head into Beer Street or take a cyclo around Hoan Kiem Lake.
+                        </p>
+                    </div>
+
+                    <div class="space-y-6">
+                        <h2 class="heading-font text-3xl text-gray-900">A Quick Primer on How the Old Quarter Works</h2>
+                        <p class="text-lg text-gray-700 leading-relaxed">
+                            Think of the Old Quarter as a maze of specialized streets wrapped around Hoan Kiem Lake. The area is walkable, but walking does not mean calm. Sidewalks often double as parking lots or extension seating for cafés. Scooters and delivery riders use any open space as a roadway. Crossing the street requires confidence and a steady pace, not sudden stops.
+                        </p>
+                        <p class="text-lg text-gray-700 leading-relaxed">
+                            Most scams in the Old Quarter are built around momentum. A vendor starts talking before you have time to ask the price. A stranger offers to help or guide you. A friendly smile and constant motion makes it feel rude to pause. The best defense is simple: stop the momentum. Ask for a price before accepting a service, confirm it again, and walk away if anything feels vague.
+                        </p>
+                        <div class="photo-card shadow-lg">
+                            <img src="https://img.youtube.com/vi/IybWdSE35_0/maxresdefault.jpg" alt="Hanoi Old Quarter streets" loading="lazy">
+                        </div>
+                    </div>
+
+                    <div class="content-card bg-neutral-900 text-gray-100">
+                        <h2 class="heading-font text-3xl text-yellow-400 mb-4">The Core Old Quarter Scams (and How They Work)</h2>
+                        <p class="text-lg text-gray-200 leading-relaxed mb-4">
+                            Most Old Quarter scams are not dangerous; they are opportunistic. The pattern is usually the same: a low-price offer shifts into a high-price demand after the service is completed. Here are the main ones to watch for and what to do instead.
+                        </p>
+                        <ul class="space-y-4 text-gray-200">
+                            <li class="flex items-start gap-3">
+                                <i class="fas fa-bicycle text-yellow-400 mt-1"></i>
+                                <span><strong>Overpriced cyclo rides:</strong> Cyclos are iconic and slow-moving, which makes them a tourist magnet. The scam happens when the driver says a low price for a short loop, then demands a higher rate per person, per hour, or for a “tip.” Always agree on a total price in Vietnamese dong before you sit down, confirm if it is per person, and have the exact cash ready. If the price feels too cheap to be real, it probably is.</span>
+                            </li>
+                            <li class="flex items-start gap-3">
+                                <i class="fas fa-shoe-prints text-yellow-400 mt-1"></i>
+                                <span><strong>Shoe cleaning or repair hustle:</strong> Someone points at your shoes, gestures that they are dirty, and starts cleaning without clear permission. Then they ask for a high payment or insist on extra repairs. The simplest response is a firm “No thanks” and keep moving. If you actually want a clean, ask for the price upfront and pay only what you agreed.</span>
+                            </li>
+                            <li class="flex items-start gap-3">
+                                <i class="fas fa-beer-mug-empty text-yellow-400 mt-1"></i>
+                                <span><strong>Beer Street price swaps:</strong> On Ta Hien (Beer Street), menus can change or drinks can be brought at a different price from what you saw. Keep the menu, take a quick photo if needed, and confirm prices before ordering. If you are in a group, nominate one person to handle the order and bill to avoid confusion.</span>
+                            </li>
+                            <li class="flex items-start gap-3">
+                                <i class="fas fa-taxi text-yellow-400 mt-1"></i>
+                                <span><strong>Taxi meter tricks:</strong> While Grab and other ride-hailing apps reduce scams, unmarked taxis sometimes use tampered meters or take scenic routes. Use Grab, Be, or Gojek instead of street hails, and always check the license plate in the app before getting in.</span>
+                            </li>
+                            <li class="flex items-start gap-3">
+                                <i class="fas fa-camera text-yellow-400 mt-1"></i>
+                                <span><strong>Photo fee surprise:</strong> Some vendors offer to place a basket on your shoulder or pose with a street setup, then demand a fee for the photo. If you want the shot, ask the price first. If not, a polite wave and step back avoids the awkwardness.</span>
+                            </li>
+                            <li class="flex items-start gap-3">
+                                <i class="fas fa-map-marked-alt text-yellow-400 mt-1"></i>
+                                <span><strong>Friendly guide detours:</strong> Someone offers to show you a temple or a shortcut, then leads you to a shop with inflated prices. Unless it is a licensed tour you booked, decline and stick to your plan. The Old Quarter is dense; you do not need a guide to find food or a lake walk.</span>
+                            </li>
+                        </ul>
+                    </div>
+
+                    <div class="content-card bg-neutral-900 text-gray-100">
+                        <h2 class="heading-font text-3xl text-yellow-400 mb-4">Common Scams Across Vietnam (Not Just Hanoi)</h2>
+                        <p class="text-lg text-gray-200 leading-relaxed">
+                            The Old Quarter gets the attention, but the broader Vietnam scam list is consistent from Hanoi to Ho Chi Minh City, Hoi An, and Nha Trang. The tricks do not change much; only the setting does. Knowing the wider patterns helps you relax on the rest of your trip.
+                        </p>
+                        <div class="grid md:grid-cols-2 gap-6 mt-6">
+                            <div class="content-card bg-neutral-800 text-gray-100">
+                                <h3 class="heading-font text-2xl text-yellow-400 mb-3">Motorbike Rental Extras</h3>
+                                <p class="text-gray-200 leading-relaxed">
+                                    Some rental shops advertise a low daily rate and then add fees for helmets, scratches, or “late return.” Take photos of the bike from every angle, confirm the return time, and keep a copy of your agreement. If a shop refuses to document the bike’s condition, choose a different one.
+                                </p>
+                            </div>
+                            <div class="content-card bg-neutral-800 text-gray-100">
+                                <h3 class="heading-font text-2xl text-yellow-400 mb-3">Overpriced Taxi to Airport</h3>
+                                <p class="text-gray-200 leading-relaxed">
+                                    Airport transfers are a classic target for inflated prices, especially if you look like you just landed. Use ride-hailing apps or pre-book a hotel transfer with a clear price in writing. If you do take a taxi, insist on the meter and follow the route on your map app.
+                                </p>
+                            </div>
+                            <div class="content-card bg-neutral-800 text-gray-100">
+                                <h3 class="heading-font text-2xl text-yellow-400 mb-3">Menu Switches and Service Fees</h3>
+                                <p class="text-gray-200 leading-relaxed">
+                                    A menu shows one price, but the bill shows another with extra charges. This happens in tourist-heavy areas. Ask if service charge or taxes are included before ordering. Keep the menu close and do not be afraid to request a correction before paying.
+                                </p>
+                            </div>
+                            <div class="content-card bg-neutral-800 text-gray-100">
+                                <h3 class="heading-font text-2xl text-yellow-400 mb-3">Currency Confusion</h3>
+                                <p class="text-gray-200 leading-relaxed">
+                                    Vietnam has large denominations, and it is easy to mix up a 20,000 note with a 200,000 note. Count your cash, keep smaller notes accessible, and pay slowly. If a vendor says you gave them the wrong amount, stay calm and recount together.
+                                </p>
+                            </div>
+                            <div class="content-card bg-neutral-800 text-gray-100">
+                                <h3 class="heading-font text-2xl text-yellow-400 mb-3">Fake Police Shakedowns</h3>
+                                <p class="text-gray-200 leading-relaxed">
+                                    Rare but reported: someone in a uniform requests a fine or ID check and suggests paying cash. If this happens, ask to go to the station and call your hotel. Real officials do not demand on-the-spot cash from tourists.
+                                </p>
+                            </div>
+                            <div class="content-card bg-neutral-800 text-gray-100">
+                                <h3 class="heading-font text-2xl text-yellow-400 mb-3">Street Drugs on Beer Street</h3>
+                                <p class="text-gray-200 leading-relaxed">
+                                    On Beer Street, you may be offered balloons or pills. It is illegal and risky. Decline immediately and keep walking. Police sometimes crack down in waves, and foreigners are easy targets for fines or worse. Avoid the situation altogether.
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="space-y-6">
+                        <h2 class="heading-font text-3xl text-gray-900">How to Move Through the Old Quarter Without Stress</h2>
+                        <p class="text-lg text-gray-700 leading-relaxed">
+                            The most effective scam prevention is not confrontation; it is quiet confidence. Walk at a steady pace, make decisions quickly, and keep your body language neutral. If someone tries to engage you with a service you did not ask for, a smile and “No thanks” is enough. The moment you stop to debate the price, you have already handed over control of the interaction.
+                        </p>
+                        <p class="text-lg text-gray-700 leading-relaxed">
+                            That said, you can still be friendly. Vietnam is warm and hospitable, and the majority of people you meet are just trying to make a living, not scam you. The trick is to separate hospitality from sales. If someone is offering a service, treat it like a business interaction: confirm the price, confirm what is included, and pay what you agreed to.
+                        </p>
+                    </div>
+
+                    <div class="content-card bg-neutral-900 text-gray-100">
+                        <h2 class="heading-font text-3xl text-yellow-400 mb-4">Practical Tips That Actually Work</h2>
+                        <ul class="space-y-3 text-gray-200">
+                            <li class="flex items-start gap-3"><i class="fas fa-check text-yellow-400 mt-1"></i>Use Grab or Be for transport. The price is locked in, and the driver details are logged.</li>
+                            <li class="flex items-start gap-3"><i class="fas fa-check text-yellow-400 mt-1"></i>Carry small notes. It avoids the “no change” trick and makes quick payments easier.</li>
+                            <li class="flex items-start gap-3"><i class="fas fa-check text-yellow-400 mt-1"></i>Ask “How much total?” instead of “How much?” to avoid per-person surprises.</li>
+                            <li class="flex items-start gap-3"><i class="fas fa-check text-yellow-400 mt-1"></i>Pay after you see the bill, not before. If someone wants money up front, walk away.</li>
+                            <li class="flex items-start gap-3"><i class="fas fa-check text-yellow-400 mt-1"></i>Use Google Translate or a price calculator app if a negotiation feels stuck.</li>
+                            <li class="flex items-start gap-3"><i class="fas fa-check text-yellow-400 mt-1"></i>Screenshot menus or storefront signs if you are unsure about pricing.</li>
+                        </ul>
+                    </div>
+
+                    <div class="content-card bg-neutral-900 text-gray-100">
+                        <h2 class="heading-font text-3xl text-yellow-400 mb-4">The Old Quarter Is Still Worth It</h2>
+                        <p class="text-lg text-gray-200 leading-relaxed">
+                            It is easy to let scam warnings turn into paranoia. Do not let that happen. The Old Quarter is one of the most photogenic, delicious, and energetic neighborhoods in Southeast Asia. If you learn a few basics, you can enjoy it without stress. Start your mornings with a slow walk around Hoan Kiem Lake, grab a coffee on a quiet side street, and save Beer Street for a short, controlled visit if you want the nightlife.
+                        </p>
+                        <p class="text-lg text-gray-200 leading-relaxed mt-4">
+                            The key is to treat the Old Quarter like a real city, not a theme park. When you order food, order with confidence. When you cross the road, commit to your path. When someone offers a service you did not ask for, say no without guilt. You do not need to be rude; you just need to be clear.
+                        </p>
+                    </div>
+
+                    <div class="content-card bg-neutral-900 text-gray-100">
+                        <h2 class="heading-font text-3xl text-yellow-400 mb-4">A Quick Walkthrough Itinerary (Scam-Safe)</h2>
+                        <p class="text-lg text-gray-200 leading-relaxed">
+                            If you want a simple route that avoids the worst pressure points, start at sunrise around Hoan Kiem Lake. Head north along Hang Be and Hang Bac when shops are opening. Grab breakfast at a small pho or bun cha spot where locals are eating. Midday, duck into a café on a quieter street such as Bao Khanh. In the late afternoon, walk west toward St. Joseph’s Cathedral for golden light and fewer crowds.
+                        </p>
+                        <p class="text-lg text-gray-200 leading-relaxed mt-4">
+                            At night, if you want to see Beer Street, go early, walk one lap, and leave when it gets crowded. That is when the price games and aggressive offers start. You can still enjoy the energy without staying long enough for it to become annoying.
+                        </p>
+                    </div>
+
+                    <div class="space-y-6">
+                        <h2 class="heading-font text-3xl text-gray-900">Final Thoughts: Respect the Hustle, Protect Your Trip</h2>
+                        <p class="text-lg text-gray-700 leading-relaxed">
+                            Vietnam is one of the most rewarding countries to travel through. The food is extraordinary, the people are resilient and curious, and the landscape shifts from misty mountains to tropical beaches in a few hours. The scams are not unique to Vietnam; they are the byproduct of dense tourism and low daily wages. Your job as a traveler is not to become suspicious of everyone. Your job is simply to move through the space with clarity.
+                        </p>
+                        <p class="text-lg text-gray-700 leading-relaxed">
+                            If you do get overcharged, treat it as an expensive lesson and move on. The worst thing you can do is let one small moment ruin your entire perception of the country. Keep your standards, keep your calm, and enjoy the Old Quarter for what it is: a crowded, unforgettable slice of Hanoi that still feels alive even after midnight.
+                        </p>
+                    </div>
+
+                    <div class="content-card bg-neutral-900 text-gray-100">
+                        <h3 class="heading-font text-2xl text-yellow-400 mb-3">Comments &amp; Questions</h3>
+                        <p class="text-gray-200 leading-relaxed mb-6">
+                            If you have questions about the Old Quarter or want to share a scam story so others can learn from it, leave a comment below. I read every message and reply when I can.
+                        </p>
+                        <form action="https://formspree.io/f/mnnnoogg" method="POST" class="space-y-4">
+                            <div class="grid md:grid-cols-2 gap-4">
+                                <input type="text" name="name" placeholder="Your name" class="w-full px-4 py-3 rounded-lg bg-gray-900 text-white border border-gray-700 focus:outline-none focus:ring-2 focus:ring-yellow-500" required>
+                                <input type="email" name="email" placeholder="Your email" class="w-full px-4 py-3 rounded-lg bg-gray-900 text-white border border-gray-700 focus:outline-none focus:ring-2 focus:ring-yellow-500" required>
+                            </div>
+                            <textarea name="message" rows="5" placeholder="Your comment" class="w-full px-4 py-3 rounded-lg bg-gray-900 text-white border border-gray-700 focus:outline-none focus:ring-2 focus:ring-yellow-500" required></textarea>
+                            <input type="hidden" name="_subject" value="New Old Quarter Blog Comment">
+                            <input type="hidden" name="_next" value="https://www.carltravels.com/thankyou.html">
+                            <input type="hidden" name="_captcha" value="false">
+                            <input type="text" name="_gotcha" style="display:none">
+                            <button type="submit" class="inline-flex items-center px-6 py-3 bg-gradient-to-r from-yellow-500 to-amber-600 text-white font-semibold rounded-full shadow-lg hover:shadow-xl transition-all">
+                                <i class="fas fa-paper-plane mr-2"></i> Post Comment
+                            </button>
+                        </form>
+                    </div>
+                </div>
+
+                <aside class="space-y-6">
+                    <div class="content-card bg-neutral-900 text-gray-100">
+                        <h3 class="heading-font text-2xl text-yellow-400 mb-2">Quick Snapshot</h3>
+                        <ul class="space-y-2 text-gray-200">
+                            <li><strong>Best time:</strong> Early morning or late afternoon.</li>
+                            <li><strong>Top scam zones:</strong> Ta Hien, lake loop, cyclo hubs.</li>
+                            <li><strong>Safest transport:</strong> Grab/Be apps.</li>
+                            <li><strong>Cash tip:</strong> Carry 20k–100k notes.</li>
+                            <li><strong>Golden rule:</strong> Agree the total price first.</li>
+                        </ul>
+                    </div>
+
+                    <div class="content-card bg-neutral-900 text-gray-100">
+                        <h3 class="heading-font text-2xl text-yellow-400 mb-3">Scam Red Flags</h3>
+                        <ul class="space-y-2 text-gray-200 list-disc list-inside">
+                            <li>Someone starts a service without asking.</li>
+                            <li>Pricing is vague or changes mid-way.</li>
+                            <li>You are rushed to decide or pay.</li>
+                            <li>The bill shows items you did not order.</li>
+                            <li>A “too good to be true” offer appears.</li>
+                        </ul>
+                    </div>
+
+                    <div class="content-card bg-neutral-900 text-gray-100">
+                        <h3 class="heading-font text-2xl text-yellow-400 mb-3">Where to Reset</h3>
+                        <p class="text-gray-200 leading-relaxed">
+                            If the Old Quarter feels intense, reset with a lake walk, a café break, or a short ride to Tay Ho. You will return calmer and clearer.
+                        </p>
+                    </div>
+                </aside>
+            </div>
+        </div>
+    </main>
+
+    <!-- Footer -->
+    <footer class="bg-dark text-white py-12">
+        <div class="container mx-auto px-6">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
+                <div>
+                    <a href="/index.html" class="text-2xl font-bold flex items-center mb-6">
+                        <div class="w-10 h-10 rounded-full bg-gradient-to-r from-yellow-500 to-amber-600 flex items-center justify-center mr-2">
+                            <i class="fas fa-camera text-black text-lg"></i>
+                        </div>
+                        <span class="heading-font">Carl Tomich</span>
+                    </a>
+                    <p class="text-gray-400 mb-4">
+                        Crafting cinematic stories through travel, tech, and filmmaking.
+                    </p>
+                    <div class="flex space-x-4">
+                        <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="text-gray-400 hover:text-yellow-500 transition-colors">
+                            <i class="fab fa-youtube"></i>
+                        </a>
+                        <a href="https://www.youtube.com/@carltomichtech" target="_blank" class="text-gray-400 hover:text-yellow-500 transition-colors">
+                            <i class="fab fa-youtube"></i>
+                        </a>
+                        <a href="https://www.youtube.com/@globetraveladventures" target="_blank" class="text-gray-400 hover:text-yellow-500 transition-colors">
+                            <i class="fab fa-youtube"></i>
+                        </a>
+                        <a href="https://www.instagram.com/carlostomich" target="_blank" class="text-gray-400 hover:text-yellow-500 transition-colors">
+                            <i class="fab fa-instagram"></i>
+                        </a>
+                        <a href="https://www.facebook.com/thecarlostomich/" target="_blank" class="text-gray-400 hover:text-yellow-500 transition-colors">
+                            <i class="fab fa-facebook-f"></i>
+                        </a>
+                    </div>
+                </div>
+
+                <div>
+                    <h3 class="text-lg font-semibold mb-6">Quick Links</h3>
+                    <ul class="space-y-3">
+                        <li><a href="/index.html" class="text-gray-400 hover:text-yellow-500 transition-colors">Home</a></li>
+                        <li><a href="/destinations.html" class="text-gray-400 hover:text-yellow-500 transition-colors">Destinations</a></li>
+                        <li><a href="/portfolio.html" class="text-gray-400 hover:text-yellow-500 transition-colors">Portfolio</a></li>
+                        <li><a href="/videos/index.html" class="text-gray-400 hover:text-yellow-500 transition-colors">Watch</a></li>
+                        <li><a href="/blog.html" class="text-gray-400 hover:text-yellow-500 transition-colors">Blog</a></li>
+                    </ul>
+                </div>
+
+                <div>
+                    <h3 class="text-lg font-semibold mb-6">Resources</h3>
+                    <ul class="space-y-3">
+                        <li><a href="/gear.html" class="text-gray-400 hover:text-yellow-500 transition-colors">Gear Reviews</a></li>
+                        <li><a href="/portfolio.html" class="text-gray-400 hover:text-yellow-500 transition-colors">Photography</a></li>
+                        <li><a href="/privacy-policy.html" class="text-gray-400 hover:text-yellow-500 transition-colors">Privacy Policy</a></li>
+                        <li><a href="/terms-and-conditions.html" class="text-gray-400 hover:text-yellow-500 transition-colors">Terms &amp; Conditions</a></li>
+                    </ul>
+                </div>
+
+                <div>
+                    <h3 class="text-lg font-semibold mb-6">Get In Touch</h3>
+                    <p class="text-gray-400 mb-4">Want to collaborate or ask a question? I reply when I can.</p>
+                    <a href="/index.html#contact" class="inline-flex items-center px-5 py-2 bg-gradient-to-r from-yellow-500 to-amber-600 rounded-full text-white font-medium hover:shadow-lg transition-all">
+                        Contact Carl
+                    </a>
+                </div>
+            </div>
+            <div class="border-t border-gray-800 mt-10 pt-6 text-sm text-gray-500 flex flex-col md:flex-row justify-between">
+                <p>&copy; 2025 Carl Travels. All rights reserved.</p>
+                <p>Built with passion for travel and storytelling.</p>
+            </div>
+        </div>
+    </footer>
+
+    <script>
+        const navbar = document.getElementById('navbar');
+        const mobileMenuButton = document.getElementById('mobile-menu-button');
+        const mobileMenu = document.getElementById('mobile-menu');
+
+        window.addEventListener('scroll', () => {
+            if (window.scrollY > 50) {
+                navbar.classList.add('scrolled');
+            } else {
+                navbar.classList.remove('scrolled');
+            }
+        });
+
+        mobileMenuButton.addEventListener('click', () => {
+            mobileMenu.classList.toggle('open');
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a long-form guide about scams in Hanoi’s Old Quarter that matches the site’s existing visual style and layout. 
- Embed the supplied YouTube video and use its thumbnail as the hero image for a richer, visual article. 
- Surface the new post on the main blog listing so visitors can discover it from `blog.html`.

### Description
- Add a new article file `old-quarter-scams-hanoi.html` containing a full-length guide with embedded video, thumbnail hero, photo cards, sidebars, and practical tips. 
- Add a new blog card to `blog.html` that links to the new post and uses the video thumbnail as the preview image. 
- Minor UI tweak: adjust the icon class in the new blog card to `fa-shield-halved` for consistent appearance. 
- The article is ~2.28k words (verified by an automated word-count script) and includes sections on cyclos, shoe-cleaning hustles, Beer Street issues, taxis, motorbike rentals, and general scam red flags.

### Testing
- Ran a word-count script on the new HTML and confirmed ~2281 words. 
- Launched a local `python -m http.server` and captured a full-page screenshot of `old-quarter-scams-hanoi.html` using Playwright to validate rendering. 
- No unit tests were applicable for these static content changes; visual and content checks above completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696028e217f083239e66168917b29726)