### PR TITLE
Add 'Horse Riding Near Hanoi' blog article and link from blog listing

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -271,6 +271,33 @@
                         </a>
                     </div>
                 </div>
+                <!-- Blog Post: Horse Riding Near Hanoi -->
+                <div class="blog-card rounded-xl overflow-hidden shadow-lg">
+                    <div class="relative overflow-hidden h-64">
+                        <img src="https://img.youtube.com/vi/7AYuPAYa3XQ/maxresdefault.jpg" alt="Horse riding near Hanoi countryside experience" class="w-full h-full object-cover transform hover:scale-110 transition-transform duration-500">
+                        <div class="absolute inset-0 card-overlay"></div>
+                        <div class="absolute bottom-0 left-0 p-6 text-white">
+                            <h3 class="text-xl font-bold">Horse Riding Near Hanoi</h3>
+                            <p class="text-sm">A Quiet Countryside Experience</p>
+                        </div>
+                        <span class="absolute top-4 right-4 bg-yellow-9000 text-white text-xs px-3 py-1 rounded-full">New</span>
+                    </div>
+                    <div class="p-6 bg-white">
+                        <div class="flex justify-between items-center mb-3">
+                            <span class="text-gray-500 text-sm"><i class="fas fa-leaf mr-1 text-yellow-500"></i> Vietnam</span>
+                            <div class="flex items-center">
+                                <i class="fas fa-star text-yellow-400 mr-1"></i>
+                                <span class="font-medium">5.0</span>
+                            </div>
+                        </div>
+                        <p class="text-gray-600 mb-4">
+                            A reflective ride outside Hanoi where calm paths, careful instruction, and still gardens set the pace.
+                        </p>
+                        <a href="/blog/horse-riding-near-hanoi-countryside-experience.html" class="text-yellow-500 font-medium hover:text-yellow-500 inline-flex items-center">
+                            Read the story <i class="fas fa-arrow-right ml-2"></i>
+                        </a>
+                    </div>
+                </div>
                 <!-- Blog Post: Vietnam E-Visa 2026 Guide -->
                 <div class="blog-card rounded-xl overflow-hidden shadow-lg">
                     <div class="relative overflow-hidden h-64">

--- a/blog/horse-riding-near-hanoi-countryside-experience.html
+++ b/blog/horse-riding-near-hanoi-countryside-experience.html
@@ -1,0 +1,251 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Horse Riding Near Hanoi: A Quiet Countryside Experience | Carl Travels</title>
+    <!-- Cookiebot for GDPR Compliance -->
+    <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="e44b7cd2-126b-4f49-8aee-22495afe3ece" type="text/javascript" async></script>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-G72KT5ZW2J"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-G72KT5ZW2J');
+    </script>
+    <!-- Meta Tags -->
+    <meta name="description" content="A reflective look at horse riding near Hanoi, where calm countryside paths and thoughtful instruction create a grounded, unhurried experience." />
+    <meta name="keywords" content="horse riding near Hanoi, Hanoi countryside experience, Mây Villa Horse Club, Vietnam slow travel" />
+    <meta name="author" content="Carl Tomich" />
+    <!-- Open Graph Meta Tags -->
+    <meta property="og:title" content="Horse Riding Near Hanoi: A Quiet Countryside Experience" />
+    <meta property="og:description" content="A calm, reflective ride outside Hanoi that trades pressure for space, and speed for stillness." />
+    <meta property="og:image" content="https://img.youtube.com/vi/7AYuPAYa3XQ/maxresdefault.jpg" />
+    <meta property="og:url" content="https://www.carltravels.com/blog/horse-riding-near-hanoi-countryside-experience.html" />
+    <meta property="og:type" content="article" />
+    <!-- Twitter Card Meta Tags -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Horse Riding Near Hanoi: A Quiet Countryside Experience" />
+    <meta name="twitter:description" content="Cinematic, unhurried horse riding near Hanoi in a countryside setting that slows everything down." />
+    <meta name="twitter:image" content="https://img.youtube.com/vi/7AYuPAYa3XQ/maxresdefault.jpg" />
+    <!-- External Resources -->
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700&family=Bebas+Neue&display=swap');
+
+        :root {
+            --primary: #f5c518;
+            --secondary: #2a2a2a;
+            --dark: #0d0d0d;
+            --light: #e5e5e5;
+        }
+
+        body {
+            font-family: 'Montserrat', sans-serif;
+            background-color: var(--dark);
+            color: var(--light);
+            scroll-behavior: smooth;
+        }
+
+        .hero-gradient {
+            background: linear-gradient(135deg, rgba(0, 0, 0, 0.65), rgba(0, 0, 0, 0.75)),
+                        url('https://img.youtube.com/vi/7AYuPAYa3XQ/maxresdefault.jpg') center/cover no-repeat;
+        }
+
+        .heading-font {
+            font-family: 'Bebas Neue', sans-serif;
+            letter-spacing: 1px;
+        }
+
+        .navbar {
+            backdrop-filter: blur(10px);
+            background-color: rgba(26, 26, 26, 0.9);
+            transition: all 0.3s ease;
+        }
+
+        .navbar.scrolled {
+            background-color: rgba(26, 26, 26, 0.98);
+            box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.3);
+        }
+
+        .wave-shape {
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            width: 100%;
+            overflow: hidden;
+            line-height: 0;
+        }
+
+        .wave-shape svg {
+            position: relative;
+            display: block;
+            width: calc(100% + 1.3px);
+            height: 150px;
+        }
+
+        .wave-shape .shape-fill {
+            fill: #0b0b0b;
+        }
+
+        .content-card {
+            background: rgba(15, 15, 15, 0.9);
+            border: 1px solid rgba(255, 255, 255, 0.06);
+            border-radius: 1.25rem;
+            box-shadow: 0 20px 45px -20px rgba(0, 0, 0, 0.6);
+        }
+
+        .video-frame {
+            position: relative;
+            width: 100%;
+            padding-top: 56.25%;
+            border-radius: 1rem;
+            overflow: hidden;
+            box-shadow: 0 20px 40px -20px rgba(0, 0, 0, 0.55);
+        }
+
+        .video-frame iframe {
+            position: absolute;
+            inset: 0;
+            width: 100%;
+            height: 100%;
+            border: 0;
+        }
+
+        a { color: #f5c518; }
+    </style>
+    <link rel="stylesheet" href="/assets/css/styles.css">
+</head>
+<body class="text-gray-200">
+    <!-- Navigation -->
+    <nav id="navbar" class="navbar fixed w-full z-50 shadow-sm transition-all duration-300">
+        <div class="container mx-auto px-6 py-3">
+            <div class="flex justify-between items-center">
+                <a href="/index.html" class="text-2xl font-bold flex items-center">
+                    <div class="w-10 h-10 rounded-full bg-gradient-to-r from-yellow-500 to-amber-600 flex items-center justify-center mr-2">
+                        <i class="fas fa-camera text-black text-lg"></i>
+                    </div>
+                    <span class="heading-font bg-gradient-to-r from-yellow-500 to-amber-600 bg-clip-text text-transparent">Carl Tomich</span>
+                </a>
+
+                <div class="hidden md:flex items-center space-x-8">
+                    <a href="/index.html" class="nav-link font-medium transition-colors">Home</a>
+                    <a href="/destinations.html" class="nav-link font-medium transition-colors">Destinations</a>
+                    <a href="/portfolio.html" class="nav-link font-medium transition-colors">Portfolio</a>
+                    <a href="/videos/index.html" class="nav-link font-medium transition-colors">Watch</a>
+                    <a href="/blog.html" class="nav-link font-medium transition-colors">Blog</a>
+                    <a href="/gear.html" class="nav-link font-medium transition-colors">Gear</a>
+                    <a href="/index.html#about" class="nav-link font-medium transition-colors">About</a>
+                    <a href="/donate.html" class="nav-link font-medium transition-colors">Donate</a>
+                    <a href="/index.html#contact" class="contact-button px-4 py-2 bg-gradient-to-r from-yellow-500 to-amber-600 rounded-full hover:shadow-lg transition-all">Contact</a>
+                </div>
+
+                <button id="mobile-menu-button" class="md:hidden text-gray-300 focus:outline-none">
+                    <i class="fas fa-bars text-2xl"></i>
+                </button>
+            </div>
+
+            <div id="mobile-menu" class="mobile-menu md:hidden">
+                <div class="pt-4 pb-2 space-y-2">
+                    <a href="/index.html" class="mobile-link block px-3 py-2 rounded-md font-medium">Home</a>
+                    <a href="/destinations.html" class="mobile-link block px-3 py-2 rounded-md">Destinations</a>
+                    <a href="/portfolio.html" class="mobile-link block px-3 py-2 rounded-md">Portfolio</a>
+                    <a href="/videos/index.html" class="mobile-link block px-3 py-2 rounded-md">Watch</a>
+                    <a href="/blog.html" class="mobile-link block px-3 py-2 rounded-md">Blog</a>
+                    <a href="/gear.html" class="mobile-link block px-3 py-2 rounded-md">Gear</a>
+                    <a href="/index.html#about" class="mobile-link block px-3 py-2 rounded-md">About</a>
+                    <a href="/donate.html" class="mobile-link block px-3 py-2 rounded-md">Donate</a>
+                    <a href="/index.html#contact" class="mobile-link block px-3 py-2 rounded-md">Contact</a>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <!-- Hero Section -->
+    <section class="hero-gradient relative overflow-hidden min-h-[65vh] flex items-center pt-24">
+        <div class="wave-shape">
+            <svg data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 120" preserveAspectRatio="none">
+                <path d="M321.39,56.44c58-10.79,114.16-30.13,172-41.86,82.39-16.72,168.19-17.73,250.45-.39C823.78,31,906.67,72,985.66,92.83c70.05,18.48,146.53,26.09,214.34,3V0H0V27.35A600.21,600.21,0,0,0,321.39,56.44Z" class="shape-fill"></path>
+            </svg>
+        </div>
+
+        <div class="container mx-auto px-6 py-20 relative z-10">
+            <div class="max-w-3xl">
+                <span class="text-yellow-300 uppercase tracking-[0.35em] text-xs">Vietnam • Hanoi • Experiences</span>
+                <h1 class="heading-font text-4xl md:text-5xl lg:text-6xl font-bold text-white leading-tight mt-4 mb-6">
+                    Horse Riding Near Hanoi: A Quiet Countryside Experience
+                </h1>
+                <p class="text-lg text-yellow-100 max-w-2xl">
+                    A slow afternoon of riding beyond the city, where still gardens and soft paths make space for breath, balance, and a gentler pace.
+                </p>
+            </div>
+        </div>
+    </section>
+
+    <main class="bg-[#0b0b0b] py-16">
+        <div class="container mx-auto px-6">
+            <article class="content-card p-8 md:p-12 space-y-8 leading-relaxed">
+                <p>Most riding schools near Hanoi are shaped around routine: a track, a schedule, a focus on technique. This countryside setting invites a different rhythm, where horse riding near Hanoi feels less like a lesson and more like a quiet reset in the landscape itself.</p>
+                <p>The calm begins before you ride. Gardens open around the arena, water reflects the light, and the pace of the place settles your shoulders before you even reach the stable.</p>
+
+                <div class="flex justify-center">
+                    <figure class="w-full max-w-4xl text-center">
+                        <div class="video-frame">
+                            <iframe src="https://www.youtube.com/embed/7AYuPAYa3XQ" title="Horse Riding Near Hanoi Countryside Experience" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+                        </div>
+                        <figcaption class="text-sm text-gray-400 mt-3">A quiet countryside horse riding experience near Hanoi</figcaption>
+                    </figure>
+                </div>
+
+                <h2 class="text-2xl md:text-3xl font-semibold text-white">A setting that slows everything down</h2>
+                <p>The first thing you notice is the silence. Paths meander through small bridges and green corners, and the riding areas feel woven into the landscape rather than placed on top of it.</p>
+                <p>That atmosphere shapes how you learn. There is room to breathe, to settle into the saddle, and to move across gentle slopes and narrow tracks with a steady, grounded focus.</p>
+
+                <h2 class="text-2xl md:text-3xl font-semibold text-white">Learning that feels calm, not intimidating</h2>
+                <p>Lessons are guided by trainers who focus on clarity and safety without pressure. If you are new to riding, time is built in for the basics. If you have experience, the pace adjusts naturally to your confidence.</p>
+                <p>The structure is there, but it never feels rushed. It is a quiet kind of instruction that makes you feel present rather than observed.</p>
+
+                <h2 class="text-2xl md:text-3xl font-semibold text-white">Horses chosen for the rider</h2>
+                <p>The horses are calm, well trained, and matched carefully to each rider. That pairing creates trust quickly, especially for first-timers who need a steady rhythm and a gentle response.</p>
+                <p>It becomes easier to focus on posture, balance, and movement when the horse beneath you feels settled and attentive.</p>
+
+                <h2 class="text-2xl md:text-3xl font-semibold text-white">Less than an hour from Hanoi</h2>
+                <p>Despite the countryside atmosphere, the club sits under an hour from central Hanoi. It is close enough for a half-day escape, yet far enough to feel like a true shift in pace.</p>
+                <p>For anyone looking for horse riding near Hanoi that feels unhurried and scenic, this distance creates the perfect balance between access and quiet.</p>
+
+                <h2 class="text-2xl md:text-3xl font-semibold text-white">Riding that feels natural from the first moment</h2>
+                <p>This experience is less about ticking off an activity and more about slowing down. It is the kind of afternoon that stays with you because of its mood, its pace, and the way the landscape supports the lesson.</p>
+                <p>In the end, the ride feels quiet and complete, shaped by the countryside and by a sense that the moment was allowed to unfold in its own time.</p>
+
+                <h2 class="text-2xl md:text-3xl font-semibold text-white">Related Vietnam Articles</h2>
+                <p class="text-gray-300">Keep exploring Vietnam with these quieter, place-first reads:</p>
+                <ul class="space-y-2 text-gray-300">
+                    <li><a href="/destinations/hanoi" class="hover:text-yellow-400">Hanoi guides and city notes</a></li>
+                    <li><a href="/blog/vietnam" class="hover:text-yellow-400">Vietnam travel stories</a></li>
+                    <li><a href="/blog/living-in-vietnam" class="hover:text-yellow-400">Living in Vietnam reflections</a></li>
+                </ul>
+            </article>
+        </div>
+    </main>
+
+    <script>
+        const mobileMenuButton = document.getElementById('mobile-menu-button');
+        const mobileMenu = document.getElementById('mobile-menu');
+        const navbar = document.getElementById('navbar');
+
+        mobileMenuButton.addEventListener('click', () => {
+            mobileMenu.classList.toggle('open');
+        });
+
+        window.addEventListener('scroll', () => {
+            if (window.scrollY > 50) {
+                navbar.classList.add('scrolled');
+            } else {
+                navbar.classList.remove('scrolled');
+            }
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a new Vietnam-focused blog article in the same cinematic, reflective tone as other Hanoi posts and surface it from the main blog listing. 

### Description
- Add a new blog page at `blog/horse-riding-near-hanoi-countryside-experience.html` with H1, short intro, centered YouTube embed (video `7AYuPAYa3XQ`) using the video thumbnail as the hero, captioned “A quiet countryside horse riding experience near Hanoi”, and H2-structured body content. 
- Include a “Related Vietnam Articles” H2 section with internal placeholder links to `/destinations/hanoi`, `/blog/vietnam`, and `/blog/living-in-vietnam`. 
- Update `blog.html` to add a new article card linking to the new page and showing the YouTube thumbnail in the listing.

### Testing
- Served the site locally with `python -m http.server 8000` and captured a full-page screenshot using a Playwright script to verify the new article renders and the video embed appears; the screenshot run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967c2a6bb8c8323b5876b79d7e58ee2)