### PR TITLE
Add intent-based affiliate CTAs, deterministic A/B variants, and first‑party tracking

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -120,6 +120,74 @@ a:hover {
     color: var(--primary);
 }
 
+.affiliate-cta {
+    display: grid;
+    gap: 1.5rem;
+    align-items: center;
+    padding: 1.75rem;
+    margin: 2.5rem auto;
+    max-width: 980px;
+    background: var(--card);
+    border: 1px solid var(--card-border);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-lg);
+}
+
+.affiliate-cta__media img {
+    width: 100%;
+    height: auto;
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-xl);
+}
+
+.affiliate-cta__eyebrow {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.2em;
+    color: rgba(245, 197, 24, 0.8);
+    margin-bottom: 0.5rem;
+}
+
+.affiliate-cta__headline {
+    font-size: 1.75rem;
+    color: #fff;
+    margin-bottom: 0.75rem;
+}
+
+.affiliate-cta__copy {
+    color: #d1d5db;
+    margin-bottom: 1.25rem;
+}
+
+.affiliate-cta__list {
+    margin: 0 0 1rem 1.25rem;
+    color: #d1d5db;
+    list-style: disc;
+}
+
+.affiliate-cta__alt {
+    color: #cbd5e1;
+    margin-bottom: 1rem;
+}
+
+.affiliate-cta__disclosure {
+    margin-top: 0.75rem;
+    font-size: 0.75rem;
+    color: var(--muted);
+}
+
+.affiliate-disclosure-line {
+    font-size: 0.85rem;
+    color: var(--muted);
+    margin: 1rem 0 1.5rem;
+}
+
+@media (min-width: 768px) {
+    .affiliate-cta {
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1.4fr);
+    }
+}
+
 .toc {
     background: rgba(15, 15, 15, 0.85);
     border: 1px solid var(--card-border);

--- a/assets/js/site.js
+++ b/assets/js/site.js
@@ -3,6 +3,41 @@ document.addEventListener("DOMContentLoaded", () => {
     const mobileMenuButton = document.getElementById("mobile-menu-button");
     const mobileMenu = document.getElementById("mobile-menu");
 
+    const getAffiliateIntent = () => {
+        const manualIntent = document.querySelector('meta[name="affiliateIntent"]')?.content;
+        if (manualIntent && ["A", "B", "C", "D"].includes(manualIntent)) {
+            return manualIntent;
+        }
+        const path = window.location.pathname.toLowerCase();
+        const title = document.title.toLowerCase();
+        const hasKeyword = (words) => words.some((word) => title.includes(word) || path.includes(word));
+
+        if (hasKeyword(["gear", "review", "camera", "lens", "mic", "gimbal", "workflow", "setup"])) {
+            return "C";
+        }
+        if (hasKeyword(["how-to", "howto", "tutorial", "guide", "steps", "e-visa", "visa"])) {
+            return "D";
+        }
+        if (hasKeyword(["blog", "story", "rant", "learned", "left", "returned", "returning"])) {
+            return "A";
+        }
+        if (hasKeyword(["travelguide", "travel-guide", "destinations", "itinerary", "trip"])) {
+            return "B";
+        }
+        return "B";
+    };
+
+    const resolveCtaVariant = () => {
+        const storageKey = "ctaVariant";
+        const existing = window.localStorage.getItem(storageKey);
+        if (existing && ["1", "2", "3"].includes(existing)) {
+            return Number(existing);
+        }
+        const assigned = Math.floor(Math.random() * 3) + 1;
+        window.localStorage.setItem(storageKey, String(assigned));
+        return assigned;
+    };
+
     if (mobileMenuButton && mobileMenu) {
         mobileMenuButton.addEventListener("click", () => {
             mobileMenu.classList.toggle("open");
@@ -165,6 +200,169 @@ document.addEventListener("DOMContentLoaded", () => {
             }
         }
     }
+
+    const affiliateIntent = getAffiliateIntent();
+    document.body.dataset.intentType = affiliateIntent;
+
+    const ctaBlocks = document.querySelectorAll(".affiliate-cta");
+    if (ctaBlocks.length) {
+        const assignedVariant = resolveCtaVariant();
+
+        const createAffiliateCta = (cta) => {
+            const link = cta.dataset.link || "#";
+            const placement = cta.dataset.placement || "inline";
+            const label = cta.dataset.label || cta.dataset.title || "Affiliate link";
+            const thumbnail = cta.dataset.thumbnail;
+            const benefit = cta.dataset.benefit || "A quick, reliable pick to save you time.";
+            const who = cta.dataset.who || "Ideal for travelers who want a dependable setup.";
+            const reasonOne = cta.dataset.reasonOne || "I use it in my own kit for dependable results.";
+            const reasonTwo = cta.dataset.reasonTwo || "Solid value without overpaying for extras.";
+            const alternative = cta.dataset.alternative || "Alternative: compare with a budget-friendly option.";
+
+            const variants = {
+                1: {
+                    title: "Quick recommendation",
+                    copy: `${benefit} ${who}`,
+                    ctaLabel: cta.dataset.ctaLabel || "Check price",
+                    body: `<p class="affiliate-cta__copy">${benefit} ${who}</p>`,
+                },
+                2: {
+                    title: "Support the channel",
+                    copy: "If you’re buying anyway, this helps keep the guides free.",
+                    ctaLabel: cta.dataset.ctaLabel || "Grab it on Amazon",
+                    body: `<p class="affiliate-cta__copy">If you’re buying anyway, this helps keep the guides free.</p>`,
+                },
+                3: {
+                    title: "My pick (and why)",
+                    copy: "Quick comparison notes.",
+                    ctaLabel: cta.dataset.ctaLabel || "See options",
+                    body: `<ul class="affiliate-cta__list">\n<li>${reasonOne}</li>\n<li>${reasonTwo}</li>\n</ul>\n<p class="affiliate-cta__alt">${alternative}</p>`,
+                },
+            };
+
+            const variant = variants[assignedVariant];
+            const imageMarkup = thumbnail
+                ? `<div class="affiliate-cta__media"><img src="${thumbnail}" alt="${variant.title}"></div>`
+                : "";
+
+            cta.dataset.ctaVariant = String(assignedVariant);
+            cta.dataset.intentType = affiliateIntent;
+            cta.dataset.placement = placement;
+            cta.innerHTML = `
+                ${imageMarkup}
+                <div class="affiliate-cta__content">
+                    <p class="affiliate-cta__eyebrow">${variant.title}</p>
+                    <h3 class="affiliate-cta__headline">${cta.dataset.title || variant.title}</h3>
+                    ${variant.body}
+                    <a class="button-primary affiliate-link" data-affiliate-placement="${placement}" data-affiliate-label="${label}" href="${link}" target="_blank" rel="noopener">
+                        ${variant.ctaLabel}
+                    </a>
+                    <p class="affiliate-cta__disclosure">Affiliate disclosure: I may earn a commission at no extra cost to you.</p>
+                </div>
+            `;
+        };
+
+        ctaBlocks.forEach((cta) => createAffiliateCta(cta));
+    }
+
+    const shouldTrack = () => {
+        const dnt = navigator.doNotTrack || window.doNotTrack || navigator.msDoNotTrack;
+        return !(dnt === "1" || dnt === "yes");
+    };
+
+    const sendEvent = (eventName, params) => {
+        if (!shouldTrack()) return;
+        if (typeof window.gtag === "function") {
+            window.gtag("event", eventName, params);
+            return;
+        }
+        if (Array.isArray(window.dataLayer)) {
+            window.dataLayer.push({ event: eventName, ...params });
+            return;
+        }
+        const storageKey = "affiliateEventLog";
+        const existing = JSON.parse(window.localStorage.getItem(storageKey) || "[]");
+        existing.push({ event: eventName, params, ts: Date.now() });
+        window.localStorage.setItem(storageKey, JSON.stringify(existing.slice(-100)));
+        if (["localhost", "127.0.0.1"].includes(window.location.hostname)) {
+            console.info("[affiliate-event]", eventName, params);
+        }
+    };
+
+    const affiliateDomains = [
+        "amzn.to",
+        "amazon.",
+        "wise.com",
+        "dehancer.com",
+        "yesim.app",
+        "saily",
+        "getyourwisecard",
+    ];
+
+    document.addEventListener("click", (event) => {
+        const anchor = event.target.closest("a");
+        if (!anchor) return;
+        const href = anchor.getAttribute("href");
+        if (!href || href.startsWith("#")) return;
+        const isAffiliateLink =
+            anchor.classList.contains("affiliate-link") ||
+            affiliateDomains.some((domain) => href.includes(domain));
+        if (!isAffiliateLink) return;
+
+        let linkDomain = "";
+        try {
+            linkDomain = new URL(href, window.location.origin).hostname;
+        } catch (error) {
+            linkDomain = href.split("/")[0];
+        }
+        const placement =
+            anchor.dataset.affiliatePlacement ||
+            anchor.closest("[data-affiliate-placement]")?.dataset.affiliatePlacement ||
+            "inline";
+        const ctaVariant =
+            anchor.closest(".affiliate-cta")?.dataset.ctaVariant ||
+            window.localStorage.getItem("ctaVariant") ||
+            "unknown";
+        const intentType = document.body.dataset.intentType || "unknown";
+        const linkLabel = anchor.dataset.affiliateLabel || anchor.textContent.trim() || "affiliate link";
+
+        sendEvent("affiliate_click", {
+            page_path: window.location.pathname,
+            intent_type: intentType,
+            placement,
+            cta_variant: ctaVariant,
+            link_domain: linkDomain,
+            link_label: linkLabel,
+        });
+    });
+
+    const scrollDepths = [25, 50, 75, 90];
+    const firedDepths = new Set();
+    const handleScrollDepth = () => {
+        const docHeight = document.documentElement.scrollHeight - window.innerHeight;
+        if (docHeight <= 0) return;
+        const scrollPercent = Math.round((window.scrollY / docHeight) * 100);
+        scrollDepths.forEach((depth) => {
+            if (scrollPercent >= depth && !firedDepths.has(depth)) {
+                firedDepths.add(depth);
+                sendEvent("scroll_depth", {
+                    page_path: window.location.pathname,
+                    depth,
+                });
+            }
+        });
+    };
+    window.addEventListener("scroll", handleScrollDepth, { passive: true });
+    handleScrollDepth();
+
+    [30, 60, 120].forEach((seconds) => {
+        window.setTimeout(() => {
+            sendEvent("time_on_page", {
+                page_path: window.location.pathname,
+                bucket: `${seconds}s`,
+            });
+        }, seconds * 1000);
+    });
 
     const backToTop = document.getElementById("back-to-top");
     if (backToTop) {

--- a/cairnstravelguide.html
+++ b/cairnstravelguide.html
@@ -17,6 +17,7 @@
 </script>
     <!-- SEO Meta Tags -->
     <meta name="description" content="Discover Cairns with Carl Travels' ultimate 7-day guide. Explore the Great Barrier Reef, Daintree Rainforest, waterfalls, and tropical vibes from a local’s perspective.">
+    <meta name="affiliateIntent" content="B">
     <meta name="keywords" content="Cairns, Australia, Travel, Great Barrier Reef, Daintree Rainforest, Kuranda, Palm Cove, Waterfalls, Adventure, Carl Travels, Destinations, Oceania">
     <!-- Open Graph -->
     <meta property="og:title" content="Cairns Travel Guide – Carl Travels: Your Ultimate Week in Reef, Rainforest, and Adventure">
@@ -243,6 +244,8 @@
                     <h2 class="heading-font text-2xl font-semibold mb-4 text-yellow-500">Welcome to Cairns: Where Reef Meets Rainforest</h2>
                     <p class="mb-4">Cairns is Australia’s tropical fever dream—a city cradled by the Great Barrier Reef and Daintree Rainforest, where adventure is the currency and nature runs the show.</p>
                     <p class="mb-4">I lived here for two years, driving Uber, chasing waterfalls, and discovering the haunts locals keep to themselves.</p>
+                    <p class="affiliate-disclosure-line">Disclosure: This page contains affiliate links. If you buy through them, I may earn a commission at no extra cost to you.</p>
+                    <div class="affiliate-cta" data-placement="intro" data-link="https://yesim.app" data-label="Yesim eSIM" data-title="Get data before you hit the reef" data-benefit="Activate an eSIM at home so maps, rides, and reef tours are ready on arrival." data-who="Ideal for Cairns first-timers and short stays." data-thumbnail="/esim.jpg"></div>
                     <h3 class="text-sm uppercase tracking-wide text-yellow-500 font-semibold mb-2">Mid-Article Check-in</h3>
                     <p class="mb-4">Time marker: day 4 afternoon at the Esplanade. Money marker: A$26 for lagoon snacks and bus fare. Trade-off/regret: I skipped a night market wander and missed a local food stall.</p>
                     <p class="mb-4">This isn’t just a holiday spot; it’s a wild, wet, living jungle with a laid-back heart.</p>
@@ -359,6 +362,14 @@
                         <li><strong>Wildlife</strong>: Spot cassowaries in the Daintree or bats at sunset near the Esplanade. Keep distance—cassowaries are no joke.</li>
                         <li><strong>Stay Curious</strong>: Chat with locals at Salt House or market stalls. Cairns’ stories—of reef divers, rainforest guides, Uber fares—make the trip.</li>
                     </ul>
+                    <div class="bg-white p-6 rounded-lg shadow-md mb-4" data-affiliate-placement="resources">
+                        <h3 class="heading-font text-xl font-semibold mb-4 text-gray-800">Resources for this trip</h3>
+                        <ul class="list-disc list-inside space-y-2">
+                            <li>Stay connected: <a href="https://yesim.app" class="text-yellow-500 hover:text-yellow-500">Yesim eSIM</a> for instant data.</li>
+                            <li>Money on the move: <a href="https://wise.com/invite/irhc/carlt62" class="text-yellow-500 hover:text-yellow-500">Wise travel card</a> for better FX.</li>
+                            <li>Pack light: <a href="https://amzn.to/4miS3UJ" class="text-yellow-500 hover:text-yellow-500">DJI Pocket 3</a> for compact video.</li>
+                        </ul>
+                    </div>
                     <p class="mb-4">Final thought: Cairns is wild, wet, and alive. It’s not just a city—it’s a jungle gateway where reef meets rainforest. From snorkeling Fitzroy’s corals to sliding down Josephine Falls, this is nature’s playground. I’ve lived across Australia, but Cairns’ raw beauty tops them all. Dive in, get wet, and let the tropics steal your heart.</p>
                 </section>
             </div>

--- a/docs/affiliate-audit.md
+++ b/docs/affiliate-audit.md
@@ -1,0 +1,566 @@
+# Affiliate link audit
+
+Automated scan of outbound affiliate-style links (Amazon, Wise, Dehancer, Yesim, etc.) across the codebase. Placement is a heuristic based on link position and nearby headings.
+
+| Page URL / file path | Link destination domain | Anchor text / CTA text | Placement type | Disclosure present |
+| --- | --- | --- | --- | --- |
+| Berlin.html | wise.com | Sign up here | mid-article | no |
+| Berlin.html | www.dehancer.com | dehancer.com/subscribe | mid-article | no |
+| Berlin.html | amzn.to | DJI Flip | mid-article | no |
+| Berlin.html | amzn.to | Sony A7C II | mid-article | no |
+| Berlin.html | amzn.to | DJI Pocket 3 | mid-article | no |
+| Berlin.html | amzn.to | Tamron 28–200 | mid-article | no |
+| Berlin.html | amzn.to | RØDE Wireless PRO | mid-article | no |
+| Berlin.html | amzn.to | Think Tank Backpack | mid-article | no |
+| Berlin.html | amzn.to | DJI Flip | mid-article | no |
+| Berlin.html | amzn.to | Sony A7C II | mid-article | no |
+| Berlin.html | amzn.to | DJI Osmo Pocket 3 | mid-article | no |
+| Berlin.html | amzn.to | Tamron 24–200 | mid-article | no |
+| Berlin.html | amzn.to | RØDE Wireless PRO | mid-article | no |
+| Berlin.html | amzn.to | Think Tank Backpack | mid-article | no |
+| DJI-Flip-review.html | amzn.to | DJI Flip – USA | mid-article | no |
+| DJI-Flip-review.html | amzn.to | DJI Flip – Australia | mid-article | no |
+| Hagiangloop.html | wise.com | https://wise.com/invite/irhc/carlt62 | mid-article | yes |
+| Hagiangloop.html | www.dehancer.com | dehancer.com/subscribe | mid-article | yes |
+| Hagiangloop.html | amzn.to | DJI Flip | mid-article | yes |
+| Hagiangloop.html | amzn.to | AU | mid-article | yes |
+| Hagiangloop.html | amzn.to | Sony A7C II | mid-article | yes |
+| Hagiangloop.html | amzn.to | AU | mid-article | yes |
+| Hagiangloop.html | amzn.to | DJI Pocket 3 | mid-article | yes |
+| Hagiangloop.html | amzn.to | AU | mid-article | yes |
+| Hagiangloop.html | amzn.to | Tamron 28–200 | mid-article | yes |
+| Hagiangloop.html | amzn.to | AU | mid-article | yes |
+| Hagiangloop.html | amzn.to | RØDE Wireless PRO | mid-article | yes |
+| Hagiangloop.html | amzn.to | AU | mid-article | yes |
+| Hagiangloop.html | amzn.to | Think Tank Backpack | mid-article | yes |
+| Hagiangloop.html | amzn.to | AU | mid-article | yes |
+| Hagiangloop.html | wise.com | Sign up here | mid-article | yes |
+| Hagiangloop.html | www.dehancer.com | dehancer.com/subscribe | mid-article | yes |
+| Hagiangloop.html | amzn.to | DJI Flip | mid-article | yes |
+| Hagiangloop.html | amzn.to | Sony A7C II | mid-article | yes |
+| Hagiangloop.html | amzn.to | DJI Pocket 3 | mid-article | yes |
+| Hagiangloop.html | amzn.to | Tamron 28–200 | mid-article | yes |
+| Hagiangloop.html | amzn.to | RØDE Wireless PRO | mid-article | yes |
+| Hagiangloop.html | amzn.to | Think Tank Backpack | mid-article | yes |
+| Hagiangloop.html | amzn.to | DJI Flip | mid-article | yes |
+| Hagiangloop.html | amzn.to | Sony A7C II | mid-article | yes |
+| Hagiangloop.html | amzn.to | DJI Osmo Pocket 3 | mid-article | yes |
+| Hagiangloop.html | amzn.to | Tamron 24–200 | mid-article | yes |
+| Hagiangloop.html | amzn.to | RØDE Wireless PRO | mid-article | yes |
+| Hagiangloop.html | amzn.to | Think Tank Backpack | mid-article | yes |
+| balitravelguide.html | wise.com | Sign up here | mid-article | yes |
+| balitravelguide.html | www.dehancer.com | dehancer.com/subscribe | mid-article | yes |
+| balitravelguide.html | amzn.to | DJI Flip | mid-article | yes |
+| balitravelguide.html | amzn.to | Sony A7C II | mid-article | yes |
+| balitravelguide.html | amzn.to | DJI Pocket 3 | mid-article | yes |
+| balitravelguide.html | amzn.to | Tamron 28–200 | mid-article | yes |
+| balitravelguide.html | amzn.to | RØDE Wireless PRO | mid-article | yes |
+| balitravelguide.html | amzn.to | Think Tank Backpack | mid-article | yes |
+| balitravelguide.html | amzn.to | DJI Flip | mid-article | yes |
+| balitravelguide.html | amzn.to | Sony A7C II | mid-article | yes |
+| balitravelguide.html | amzn.to | DJI Osmo Pocket 3 | mid-article | yes |
+| balitravelguide.html | amzn.to | Tamron 24–200 | mid-article | yes |
+| balitravelguide.html | amzn.to | RØDE Wireless PRO | mid-article | yes |
+| balitravelguide.html | amzn.to | Think Tank Backpack | mid-article | yes |
+| beginners-guide-davinci-resolve-2025.html | amzn.to | DJI Flip | mid-article | yes |
+| beginners-guide-davinci-resolve-2025.html | amzn.to | Sony A7C II | mid-article | yes |
+| beginners-guide-davinci-resolve-2025.html | amzn.to | DJI Pocket 3 (Creator Combo) | mid-article | yes |
+| beginners-guide-davinci-resolve-2025.html | amzn.to | Tamron 28–200mm | mid-article | yes |
+| beginners-guide-davinci-resolve-2025.html | amzn.to | RØDE Wireless PRO | mid-article | yes |
+| beginners-guide-davinci-resolve-2025.html | amzn.to | Thinktank Travel Commuter backpack | mid-article | yes |
+| beginners-guide-davinci-resolve-2025.html | amzn.to | DJI Flip | mid-article | yes |
+| beginners-guide-davinci-resolve-2025.html | amzn.to | Sony A7C II | mid-article | yes |
+| beginners-guide-davinci-resolve-2025.html | amzn.to | DJI Osmo Pocket 3 | mid-article | yes |
+| beginners-guide-davinci-resolve-2025.html | amzn.to | Tamron 24–200mm (Sony) | mid-article | yes |
+| beginners-guide-davinci-resolve-2025.html | amzn.to | RØDE Wireless PRO | mid-article | yes |
+| beginners-guide-davinci-resolve-2025.html | amzn.to | Thinktank Travel Commuter backpack | mid-article | yes |
+| blog.html | getyourwisecard.html | Click here to find out more | mid-article | yes |
+| blog.html | wise.com | Sign up here | end/recap | yes |
+| blog.html | www.dehancer.com | dehancer.com/subscribe | end/recap | yes |
+| blog.html | amzn.to | DJI Flip | end/recap | yes |
+| blog.html | amzn.to | Sony A7C II | end/recap | yes |
+| blog.html | amzn.to | DJI Pocket 3 | end/recap | yes |
+| blog.html | amzn.to | Tamron 28–200 | end/recap | yes |
+| blog.html | amzn.to | RØDE Wireless PRO | end/recap | yes |
+| blog.html | amzn.to | Think Tank Backpack | end/recap | yes |
+| blog.html | amzn.to | DJI Flip | end/recap | yes |
+| blog.html | amzn.to | Sony A7C II | end/recap | yes |
+| blog.html | amzn.to | DJI Osmo Pocket 3 | end/recap | yes |
+| blog.html | amzn.to | Tamron 24–200 | end/recap | yes |
+| blog.html | amzn.to | RØDE Wireless PRO | end/recap | yes |
+| blog.html | amzn.to | Think Tank Backpack | end/recap | yes |
+| bose-s1pro-plus-vs-everse8-the-best-portable-speaker.html | amzn.to | Bose S1 Pro Plus | mid-article | yes |
+| bose-s1pro-plus-vs-everse8-the-best-portable-speaker.html | amzn.to | Electro-Voice Everse 8 | mid-article | yes |
+| bose-s1pro-plus-vs-everse8-the-best-portable-speaker.html | amzn.to | Main Camera (Sony A7CII) | mid-article | yes |
+| bose-s1pro-plus-vs-everse8-the-best-portable-speaker.html | amzn.to | DJI Pocket 3 | mid-article | yes |
+| bose-s1pro-plus-vs-everse8-the-best-portable-speaker.html | amzn.to | Camera Backpack | mid-article | yes |
+| budvatravelguide.html | wise.com | Sign up here | mid-article | no |
+| budvatravelguide.html | www.dehancer.com | dehancer.com/subscribe | mid-article | no |
+| budvatravelguide.html | amzn.to | DJI Flip | mid-article | no |
+| budvatravelguide.html | amzn.to | Sony A7C II | mid-article | no |
+| budvatravelguide.html | amzn.to | DJI Pocket 3 | mid-article | no |
+| budvatravelguide.html | amzn.to | Tamron 28–200 | mid-article | no |
+| budvatravelguide.html | amzn.to | RØDE Wireless PRO | mid-article | no |
+| budvatravelguide.html | amzn.to | Think Tank Backpack | mid-article | no |
+| budvatravelguide.html | amzn.to | DJI Flip | mid-article | no |
+| budvatravelguide.html | amzn.to | Sony A7C II | mid-article | no |
+| budvatravelguide.html | amzn.to | DJI Osmo Pocket 3 | mid-article | no |
+| budvatravelguide.html | amzn.to | Tamron 24–200 | mid-article | no |
+| budvatravelguide.html | amzn.to | RØDE Wireless PRO | mid-article | no |
+| budvatravelguide.html | amzn.to | Think Tank Backpack | mid-article | no |
+| cairnstravelguide.html | wise.com | Sign up here | mid-article | no |
+| cairnstravelguide.html | www.dehancer.com | dehancer.com/subscribe | mid-article | no |
+| cairnstravelguide.html | amzn.to | DJI Flip | mid-article | no |
+| cairnstravelguide.html | amzn.to | Sony A7C II | mid-article | no |
+| cairnstravelguide.html | amzn.to | DJI Pocket 3 | mid-article | no |
+| cairnstravelguide.html | amzn.to | Tamron 28–200 | mid-article | no |
+| cairnstravelguide.html | amzn.to | RØDE Wireless PRO | mid-article | no |
+| cairnstravelguide.html | amzn.to | Think Tank Backpack | mid-article | no |
+| cairnstravelguide.html | amzn.to | DJI Flip | mid-article | no |
+| cairnstravelguide.html | amzn.to | Sony A7C II | mid-article | no |
+| cairnstravelguide.html | amzn.to | DJI Osmo Pocket 3 | mid-article | no |
+| cairnstravelguide.html | amzn.to | Tamron 24–200 | mid-article | no |
+| cairnstravelguide.html | amzn.to | RØDE Wireless PRO | mid-article | no |
+| cairnstravelguide.html | amzn.to | Think Tank Backpack | mid-article | no |
+| danangtravelguide.html | wise.com | Sign up here | mid-article | no |
+| danangtravelguide.html | www.dehancer.com | dehancer.com/subscribe | mid-article | no |
+| danangtravelguide.html | amzn.to | DJI Flip | mid-article | no |
+| danangtravelguide.html | amzn.to | Sony A7C II | mid-article | no |
+| danangtravelguide.html | amzn.to | DJI Pocket 3 | mid-article | no |
+| danangtravelguide.html | amzn.to | Tamron 28–200 | mid-article | no |
+| danangtravelguide.html | amzn.to | RØDE Wireless PRO | mid-article | no |
+| danangtravelguide.html | amzn.to | Think Tank Backpack | mid-article | no |
+| danangtravelguide.html | amzn.to | DJI Flip | mid-article | no |
+| danangtravelguide.html | amzn.to | Sony A7C II | mid-article | no |
+| danangtravelguide.html | amzn.to | DJI Osmo Pocket 3 | mid-article | no |
+| danangtravelguide.html | amzn.to | Tamron 24–200 | mid-article | no |
+| danangtravelguide.html | amzn.to | RØDE Wireless PRO | mid-article | no |
+| danangtravelguide.html | amzn.to | Think Tank Backpack | mid-article | no |
+| destinations.html | wise.com | Sign up here | mid-article | no |
+| destinations.html | www.dehancer.com | dehancer.com/subscribe | mid-article | no |
+| destinations.html | amzn.to | DJI Flip | mid-article | no |
+| destinations.html | amzn.to | Sony A7C II | mid-article | no |
+| destinations.html | amzn.to | DJI Pocket 3 | mid-article | no |
+| destinations.html | amzn.to | Tamron 28–200 | mid-article | no |
+| destinations.html | amzn.to | RØDE Wireless PRO | mid-article | no |
+| destinations.html | amzn.to | Think Tank Backpack | mid-article | no |
+| destinations.html | amzn.to | DJI Flip | mid-article | no |
+| destinations.html | amzn.to | Sony A7C II | mid-article | no |
+| destinations.html | amzn.to | DJI Osmo Pocket 3 | mid-article | no |
+| destinations.html | amzn.to | Tamron 24–200 | mid-article | no |
+| destinations.html | amzn.to | RØDE Wireless PRO | mid-article | no |
+| destinations.html | amzn.to | Think Tank Backpack | mid-article | no |
+| dji-mini-3-pro-review.html | amzn.to | DJI Mini 3 Pro (or newer models) | mid-article | yes |
+| dji-mini-3-pro-review.html | amzn.to | Main Camera (Sony A7CII) | mid-article | yes |
+| dji-mini-3-pro-review.html | amzn.to | DJI Pocket 3 | mid-article | yes |
+| dji-mini-3-pro-review.html | amzn.to | Camera Backpack | mid-article | yes |
+| dji-mini-3-pro-review.html | amzn.to | Ray-Ban Meta Smart Glasses | mid-article | yes |
+| dji-mini-3-pro-review.html | amzn.to | Tamron 24–200mm Lens | mid-article | yes |
+| dji-mini-3-pro-review.html | amzn.to | Tripod | mid-article | yes |
+| dji-mini-3-pro-review.html | amzn.to | Lighting Setup | mid-article | yes |
+| finedininginhanoi.html | amzn.to | DJI Flip | mid-article | no |
+| finedininginhanoi.html | amzn.to | Sony A7C II | mid-article | no |
+| finedininginhanoi.html | amzn.to | DJI Pocket 3 (Creator Combo) | mid-article | no |
+| finedininginhanoi.html | amzn.to | Tamron 28–200mm (Full-Frame) | mid-article | no |
+| finedininginhanoi.html | amzn.to | Rode Wireless PRO (Mics) | mid-article | no |
+| finedininginhanoi.html | amzn.to | Thinktank Travel Commuter Backpack | mid-article | no |
+| finedininginhanoi.html | amzn.to | DJI Flip | mid-article | no |
+| finedininginhanoi.html | amzn.to | Sony A7C II | mid-article | no |
+| finedininginhanoi.html | amzn.to | DJI Osmo Pocket 3 | mid-article | no |
+| finedininginhanoi.html | amzn.to | Tamron 24–200mm Lens for Sony | mid-article | no |
+| finedininginhanoi.html | amzn.to | Rode Wireless PRO | mid-article | no |
+| finedininginhanoi.html | amzn.to | Thinktank Travel Commuter Backpack | mid-article | no |
+| gear.html | wise.com | Sign up here | mid-article | no |
+| gear.html | www.dehancer.com | dehancer.com/subscribe | mid-article | no |
+| gear.html | amzn.to | DJI Flip | mid-article | no |
+| gear.html | amzn.to | Sony A7C II | mid-article | no |
+| gear.html | amzn.to | DJI Pocket 3 | mid-article | no |
+| gear.html | amzn.to | Tamron 28–200 | mid-article | no |
+| gear.html | amzn.to | RØDE Wireless PRO | mid-article | no |
+| gear.html | amzn.to | Think Tank Backpack | mid-article | no |
+| gear.html | amzn.to | DJI Flip | mid-article | no |
+| gear.html | amzn.to | Sony A7C II | mid-article | no |
+| gear.html | amzn.to | DJI Osmo Pocket 3 | mid-article | no |
+| gear.html | amzn.to | Tamron 24–200 | mid-article | no |
+| gear.html | amzn.to | RØDE Wireless PRO | mid-article | no |
+| gear.html | amzn.to | Think Tank Backpack | mid-article | no |
+| getyourwisecard.html | wise.com | Get Your Wise Card | mid-article | no |
+| getyourwisecard.html | wise.com | Wise card | mid-article | no |
+| getyourwisecard.html | wise.com | Get your Wise card using my link here | mid-article | no |
+| getyourwisecard.html | wise.com | Get Your Wise Card Now | mid-article | no |
+| getyourwisecard.html | wise.com | Get Your Wise Card | mid-article | no |
+| getyourwisecard.html | wise.com | Wise card | mid-article | no |
+| ha-long-bay-travel-guide/index.html | wise.com | Sign up here | mid-article | no |
+| ha-long-bay-travel-guide/index.html | www.dehancer.com | dehancer.com/subscribe | mid-article | no |
+| ha-long-bay-travel-guide/index.html | amzn.to | DJI Flip | end/recap | no |
+| ha-long-bay-travel-guide/index.html | amzn.to | Sony A7C II | end/recap | no |
+| ha-long-bay-travel-guide/index.html | amzn.to | DJI Pocket 3 | end/recap | no |
+| ha-long-bay-travel-guide/index.html | amzn.to | Tamron 28–200 | end/recap | no |
+| ha-long-bay-travel-guide/index.html | amzn.to | RØDE Wireless PRO | end/recap | no |
+| ha-long-bay-travel-guide/index.html | amzn.to | Think Tank Backpack | end/recap | no |
+| ha-long-bay-travel-guide/index.html | amzn.to | DJI Flip | end/recap | no |
+| ha-long-bay-travel-guide/index.html | amzn.to | Sony A7C II | end/recap | no |
+| ha-long-bay-travel-guide/index.html | amzn.to | DJI Osmo Pocket 3 | end/recap | no |
+| ha-long-bay-travel-guide/index.html | amzn.to | Tamron 24–200 | end/recap | no |
+| ha-long-bay-travel-guide/index.html | amzn.to | RØDE Wireless PRO | end/recap | no |
+| ha-long-bay-travel-guide/index.html | amzn.to | Think Tank Backpack | end/recap | no |
+| hanoi-by-night.html | amzn.to | DJI Flip | end/recap | yes |
+| hanoi-by-night.html | amzn.to | Sony A7C II | end/recap | yes |
+| hanoi-by-night.html | amzn.to | DJI Pocket 3 (Creator Combo) | end/recap | yes |
+| hanoi-by-night.html | amzn.to | Tamron 28–200mm (Full-Frame) | end/recap | yes |
+| hanoi-by-night.html | amzn.to | Rode Wireless PRO | end/recap | yes |
+| hanoi-by-night.html | amzn.to | Thinktank Travel Commuter Backpack | end/recap | yes |
+| hanoi-by-night.html | amzn.to | DJI Flip | end/recap | yes |
+| hanoi-by-night.html | amzn.to | Sony 7CII | end/recap | yes |
+| hanoi-by-night.html | amzn.to | DJI Osmo Pocket 3 | end/recap | yes |
+| hanoi-by-night.html | amzn.to | Tamron 24–200 Lens for Sony | end/recap | yes |
+| hanoi-by-night.html | amzn.to | Rode Wireless Pro | end/recap | yes |
+| hanoi-by-night.html | amzn.to | Thinktank Travel Commuter Backpack | end/recap | yes |
+| hanoitravelguide.html | wise.com | Sign up here | mid-article | yes |
+| hanoitravelguide.html | www.dehancer.com | dehancer.com/subscribe | mid-article | yes |
+| hanoitravelguide.html | amzn.to | DJI Flip | mid-article | yes |
+| hanoitravelguide.html | amzn.to | Sony A7C II | mid-article | yes |
+| hanoitravelguide.html | amzn.to | DJI Pocket 3 | mid-article | yes |
+| hanoitravelguide.html | amzn.to | Tamron 28–200 | mid-article | yes |
+| hanoitravelguide.html | amzn.to | RØDE Wireless PRO | mid-article | yes |
+| hanoitravelguide.html | amzn.to | Think Tank Backpack | mid-article | yes |
+| hanoitravelguide.html | amzn.to | DJI Flip | end/recap | yes |
+| hanoitravelguide.html | amzn.to | Sony A7C II | end/recap | yes |
+| hanoitravelguide.html | amzn.to | DJI Osmo Pocket 3 | end/recap | yes |
+| hanoitravelguide.html | amzn.to | Tamron 24–200 | end/recap | yes |
+| hanoitravelguide.html | amzn.to | RØDE Wireless PRO | end/recap | yes |
+| hanoitravelguide.html | amzn.to | Think Tank Backpack | end/recap | yes |
+| hiroshima-travel-guide.html | wise.com | Sign up here | mid-article | yes |
+| hiroshima-travel-guide.html | www.dehancer.com | dehancer.com/subscribe | mid-article | yes |
+| hiroshima-travel-guide.html | amzn.to | DJI Flip | mid-article | yes |
+| hiroshima-travel-guide.html | amzn.to | Sony A7C II | mid-article | yes |
+| hiroshima-travel-guide.html | amzn.to | DJI Pocket 3 | mid-article | yes |
+| hiroshima-travel-guide.html | amzn.to | Tamron 28–200 | mid-article | yes |
+| hiroshima-travel-guide.html | amzn.to | RØDE Wireless PRO | mid-article | yes |
+| hiroshima-travel-guide.html | amzn.to | Think Tank Backpack | mid-article | yes |
+| hiroshima-travel-guide.html | amzn.to | DJI Flip | mid-article | yes |
+| hiroshima-travel-guide.html | amzn.to | Sony A7C II | mid-article | yes |
+| hiroshima-travel-guide.html | amzn.to | DJI Osmo Pocket 3 | mid-article | yes |
+| hiroshima-travel-guide.html | amzn.to | Tamron 24–200 | mid-article | yes |
+| hiroshima-travel-guide.html | amzn.to | RØDE Wireless PRO | mid-article | yes |
+| hiroshima-travel-guide.html | amzn.to | Think Tank Backpack | mid-article | yes |
+| hon-chong-rocks-nha-trang.html | wise.com | Sign up here | mid-article | no |
+| hon-chong-rocks-nha-trang.html | www.dehancer.com | dehancer.com/subscribe | mid-article | no |
+| hon-chong-rocks-nha-trang.html | amzn.to | DJI Flip | mid-article | no |
+| hon-chong-rocks-nha-trang.html | amzn.to | Sony A7C II | mid-article | no |
+| hon-chong-rocks-nha-trang.html | amzn.to | DJI Pocket 3 | mid-article | no |
+| hon-chong-rocks-nha-trang.html | amzn.to | Tamron 28–200 | mid-article | no |
+| hon-chong-rocks-nha-trang.html | amzn.to | RØDE Wireless PRO | mid-article | no |
+| hon-chong-rocks-nha-trang.html | amzn.to | Think Tank Backpack | mid-article | no |
+| hon-chong-rocks-nha-trang.html | amzn.to | DJI Flip | mid-article | no |
+| hon-chong-rocks-nha-trang.html | amzn.to | Sony A7C II | mid-article | no |
+| hon-chong-rocks-nha-trang.html | amzn.to | DJI Osmo Pocket 3 | mid-article | no |
+| hon-chong-rocks-nha-trang.html | amzn.to | Tamron 24–200 | mid-article | no |
+| hon-chong-rocks-nha-trang.html | amzn.to | RØDE Wireless PRO | mid-article | no |
+| hon-chong-rocks-nha-trang.html | amzn.to | Think Tank Backpack | mid-article | no |
+| how-to-make-your-videos-look-cinematic.html | www.dehancer.com | Get Dehancer here | mid-article | no |
+| howtofoldapopuptent.html | amzn.to | Pop-Up Tent | mid-article | yes |
+| howtofoldapopuptent.html | amzn.to | Ultra-Portable Lightweight Raincoat | mid-article | yes |
+| howtofoldapopuptent.html | amzn.to | Compact Microfiber Towels | mid-article | yes |
+| index.html | wise.com | Sign up here | mid-article | no |
+| index.html | www.dehancer.com | dehancer.com/subscribe | mid-article | no |
+| index.html | amzn.to | DJI Flip | mid-article | no |
+| index.html | amzn.to | Sony A7C II | mid-article | no |
+| index.html | amzn.to | DJI Pocket 3 | mid-article | no |
+| index.html | amzn.to | Tamron 28–200 | mid-article | no |
+| index.html | amzn.to | RØDE Wireless PRO | mid-article | no |
+| index.html | amzn.to | Think Tank Backpack | mid-article | no |
+| index.html | amzn.to | DJI Flip | mid-article | no |
+| index.html | amzn.to | Sony A7C II | mid-article | no |
+| index.html | amzn.to | DJI Osmo Pocket 3 | mid-article | no |
+| index.html | amzn.to | Tamron 24–200 | mid-article | no |
+| index.html | amzn.to | RØDE Wireless PRO | mid-article | no |
+| index.html | amzn.to | Think Tank Backpack | mid-article | no |
+| korcula.html | wise.com | Sign up here | mid-article | no |
+| korcula.html | www.dehancer.com | dehancer.com/subscribe | mid-article | no |
+| korcula.html | amzn.to | DJI Flip | mid-article | no |
+| korcula.html | amzn.to | Sony A7C II | mid-article | no |
+| korcula.html | amzn.to | DJI Pocket 3 | mid-article | no |
+| korcula.html | amzn.to | Tamron 28–200 | mid-article | no |
+| korcula.html | amzn.to | RØDE Wireless PRO | mid-article | no |
+| korcula.html | amzn.to | Think Tank Backpack | mid-article | no |
+| korcula.html | amzn.to | DJI Flip | mid-article | no |
+| korcula.html | amzn.to | Sony A7C II | mid-article | no |
+| korcula.html | amzn.to | DJI Osmo Pocket 3 | mid-article | no |
+| korcula.html | amzn.to | Tamron 24–200 | mid-article | no |
+| korcula.html | amzn.to | RØDE Wireless PRO | mid-article | no |
+| korcula.html | amzn.to | Think Tank Backpack | mid-article | no |
+| kyototravelguide.html | wise.com | Sign up here | mid-article | no |
+| kyototravelguide.html | www.dehancer.com | dehancer.com/subscribe | mid-article | no |
+| kyototravelguide.html | amzn.to | DJI Flip | mid-article | no |
+| kyototravelguide.html | amzn.to | Sony A7C II | mid-article | no |
+| kyototravelguide.html | amzn.to | DJI Pocket 3 | mid-article | no |
+| kyototravelguide.html | amzn.to | Tamron 28–200 | mid-article | no |
+| kyototravelguide.html | amzn.to | RØDE Wireless PRO | mid-article | no |
+| kyototravelguide.html | amzn.to | Think Tank Backpack | mid-article | no |
+| kyototravelguide.html | amzn.to | DJI Flip | mid-article | no |
+| kyototravelguide.html | amzn.to | Sony A7C II | mid-article | no |
+| kyototravelguide.html | amzn.to | DJI Osmo Pocket 3 | mid-article | no |
+| kyototravelguide.html | amzn.to | Tamron 24–200 | mid-article | no |
+| kyototravelguide.html | amzn.to | RØDE Wireless PRO | mid-article | no |
+| kyototravelguide.html | amzn.to | Think Tank Backpack | mid-article | no |
+| lotte-world-aquarium-hanoi.html | amzn.to | DJI Flip | mid-article | yes |
+| lotte-world-aquarium-hanoi.html | amzn.to | Sony A7C II | mid-article | yes |
+| lotte-world-aquarium-hanoi.html | amzn.to | DJI Pocket 3 (Creator Combo) | mid-article | yes |
+| lotte-world-aquarium-hanoi.html | amzn.to | Tamron 28–200mm (Full-Frame) | mid-article | yes |
+| lotte-world-aquarium-hanoi.html | amzn.to | Rode Wireless PRO (Mics) | mid-article | yes |
+| lotte-world-aquarium-hanoi.html | amzn.to | Thinktank Travel Commuter Backpack | mid-article | yes |
+| lotte-world-aquarium-hanoi.html | amzn.to | DJI Flip | mid-article | yes |
+| lotte-world-aquarium-hanoi.html | amzn.to | Sony 7CII | mid-article | yes |
+| lotte-world-aquarium-hanoi.html | amzn.to | DJI Osmo Pocket 3 | mid-article | yes |
+| lotte-world-aquarium-hanoi.html | amzn.to | Tamron 24–200 Lens for Sony | mid-article | yes |
+| lotte-world-aquarium-hanoi.html | amzn.to | Rode Wireless Pro | mid-article | yes |
+| lotte-world-aquarium-hanoi.html | amzn.to | Thinktank Travel Commuter Backpack | mid-article | yes |
+| lotte-world-aquarium-hanoi.html | wise.com | Sign up here | mid-article | yes |
+| lotte-world-aquarium-hanoi.html | www.dehancer.com | dehancer.com/subscribe | mid-article | yes |
+| lotte-world-aquarium-hanoi.html | amzn.to | DJI Flip | mid-article | yes |
+| lotte-world-aquarium-hanoi.html | amzn.to | Sony A7C II | mid-article | yes |
+| lotte-world-aquarium-hanoi.html | amzn.to | DJI Pocket 3 | mid-article | yes |
+| lotte-world-aquarium-hanoi.html | amzn.to | Tamron 28–200 | mid-article | yes |
+| lotte-world-aquarium-hanoi.html | amzn.to | RØDE Wireless PRO | mid-article | yes |
+| lotte-world-aquarium-hanoi.html | amzn.to | Think Tank Backpack | mid-article | yes |
+| lotte-world-aquarium-hanoi.html | amzn.to | DJI Flip | mid-article | yes |
+| lotte-world-aquarium-hanoi.html | amzn.to | Sony A7C II | mid-article | yes |
+| lotte-world-aquarium-hanoi.html | amzn.to | DJI Osmo Pocket 3 | mid-article | yes |
+| lotte-world-aquarium-hanoi.html | amzn.to | Tamron 24–200 | mid-article | yes |
+| lotte-world-aquarium-hanoi.html | amzn.to | RØDE Wireless PRO | mid-article | yes |
+| lotte-world-aquarium-hanoi.html | amzn.to | Think Tank Backpack | mid-article | yes |
+| make-money-online-while-traveling.html | wise.com | Invite link | mid-article | yes |
+| make-money-online-while-traveling.html | amzn.to | DJI Flip | mid-article | yes |
+| make-money-online-while-traveling.html | amzn.to | Sony A7C II | mid-article | yes |
+| make-money-online-while-traveling.html | amzn.to | DJI Pocket 3 | mid-article | yes |
+| make-money-online-while-traveling.html | amzn.to | Tamron 28–200 | mid-article | yes |
+| make-money-online-while-traveling.html | amzn.to | RØDE Wireless PRO | mid-article | yes |
+| make-money-online-while-traveling.html | amzn.to | Think Tank Backpack | mid-article | yes |
+| make-money-online-while-traveling.html | amzn.to | DJI Flip | mid-article | yes |
+| make-money-online-while-traveling.html | amzn.to | Sony A7C II | mid-article | yes |
+| make-money-online-while-traveling.html | amzn.to | DJI Osmo Pocket 3 | mid-article | yes |
+| make-money-online-while-traveling.html | amzn.to | Tamron 24–200 | mid-article | yes |
+| make-money-online-while-traveling.html | amzn.to | RØDE Wireless PRO | mid-article | yes |
+| make-money-online-while-traveling.html | amzn.to | Think Tank Backpack | mid-article | yes |
+| melbournetravelguide.html | wise.com | Sign up here | mid-article | no |
+| melbournetravelguide.html | www.dehancer.com | dehancer.com/subscribe | mid-article | no |
+| melbournetravelguide.html | amzn.to | DJI Flip | mid-article | no |
+| melbournetravelguide.html | amzn.to | Sony A7C II | mid-article | no |
+| melbournetravelguide.html | amzn.to | DJI Pocket 3 | mid-article | no |
+| melbournetravelguide.html | amzn.to | Tamron 28–200 | mid-article | no |
+| melbournetravelguide.html | amzn.to | RØDE Wireless PRO | mid-article | no |
+| melbournetravelguide.html | amzn.to | Think Tank Backpack | mid-article | no |
+| melbournetravelguide.html | amzn.to | DJI Flip | mid-article | no |
+| melbournetravelguide.html | amzn.to | Sony A7C II | mid-article | no |
+| melbournetravelguide.html | amzn.to | DJI Osmo Pocket 3 | mid-article | no |
+| melbournetravelguide.html | amzn.to | Tamron 24–200 | mid-article | no |
+| melbournetravelguide.html | amzn.to | RØDE Wireless PRO | mid-article | no |
+| melbournetravelguide.html | amzn.to | Think Tank Backpack | mid-article | no |
+| mytop10travelhacks.html | www.saily.com | Saily | mid-article | no |
+| ninhbinhtravelguide.html | wise.com | Sign up here | mid-article | no |
+| ninhbinhtravelguide.html | www.dehancer.com | dehancer.com/subscribe | mid-article | no |
+| ninhbinhtravelguide.html | amzn.to | DJI Flip | mid-article | no |
+| ninhbinhtravelguide.html | amzn.to | Sony A7C II | mid-article | no |
+| ninhbinhtravelguide.html | amzn.to | DJI Pocket 3 | mid-article | no |
+| ninhbinhtravelguide.html | amzn.to | Tamron 28–200 | mid-article | no |
+| ninhbinhtravelguide.html | amzn.to | RØDE Wireless PRO | mid-article | no |
+| ninhbinhtravelguide.html | amzn.to | Think Tank Backpack | mid-article | no |
+| ninhbinhtravelguide.html | amzn.to | DJI Flip | mid-article | no |
+| ninhbinhtravelguide.html | amzn.to | Sony A7C II | mid-article | no |
+| ninhbinhtravelguide.html | amzn.to | DJI Osmo Pocket 3 | mid-article | no |
+| ninhbinhtravelguide.html | amzn.to | Tamron 24–200 | mid-article | no |
+| ninhbinhtravelguide.html | amzn.to | RØDE Wireless PRO | mid-article | no |
+| ninhbinhtravelguide.html | amzn.to | Think Tank Backpack | mid-article | no |
+| nusa-lembongan-travel-guide/index.html | wise.com | Sign up here | mid-article | no |
+| nusa-lembongan-travel-guide/index.html | www.dehancer.com | dehancer.com/subscribe | mid-article | no |
+| nusa-lembongan-travel-guide/index.html | amzn.to | DJI Flip | end/recap | no |
+| nusa-lembongan-travel-guide/index.html | amzn.to | Sony A7C II | end/recap | no |
+| nusa-lembongan-travel-guide/index.html | amzn.to | DJI Pocket 3 | end/recap | no |
+| nusa-lembongan-travel-guide/index.html | amzn.to | Tamron 28–200 | end/recap | no |
+| nusa-lembongan-travel-guide/index.html | amzn.to | RØDE Wireless PRO | end/recap | no |
+| nusa-lembongan-travel-guide/index.html | amzn.to | Think Tank Backpack | end/recap | no |
+| nusa-lembongan-travel-guide/index.html | amzn.to | DJI Flip | end/recap | no |
+| nusa-lembongan-travel-guide/index.html | amzn.to | Sony A7C II | end/recap | no |
+| nusa-lembongan-travel-guide/index.html | amzn.to | DJI Osmo Pocket 3 | end/recap | no |
+| nusa-lembongan-travel-guide/index.html | amzn.to | Tamron 24–200 | end/recap | no |
+| nusa-lembongan-travel-guide/index.html | amzn.to | RØDE Wireless PRO | end/recap | no |
+| nusa-lembongan-travel-guide/index.html | amzn.to | Think Tank Backpack | end/recap | no |
+| one-day-in-hcmc-guide.html | wise.com | Sign up here | mid-article | no |
+| one-day-in-hcmc-guide.html | www.dehancer.com | dehancer.com/subscribe | mid-article | no |
+| one-day-in-hcmc-guide.html | amzn.to | DJI Flip | mid-article | no |
+| one-day-in-hcmc-guide.html | amzn.to | Sony A7C II | mid-article | no |
+| one-day-in-hcmc-guide.html | amzn.to | DJI Pocket 3 | mid-article | no |
+| one-day-in-hcmc-guide.html | amzn.to | Tamron 28–200 | mid-article | no |
+| one-day-in-hcmc-guide.html | amzn.to | RØDE Wireless PRO | mid-article | no |
+| one-day-in-hcmc-guide.html | amzn.to | Think Tank Backpack | mid-article | no |
+| one-day-in-hcmc-guide.html | amzn.to | DJI Flip | mid-article | no |
+| one-day-in-hcmc-guide.html | amzn.to | Sony A7C II | mid-article | no |
+| one-day-in-hcmc-guide.html | amzn.to | DJI Osmo Pocket 3 | mid-article | no |
+| one-day-in-hcmc-guide.html | amzn.to | Tamron 24–200 | mid-article | no |
+| one-day-in-hcmc-guide.html | amzn.to | RØDE Wireless PRO | mid-article | no |
+| one-day-in-hcmc-guide.html | amzn.to | Think Tank Backpack | mid-article | no |
+| osakatravelguide.html | wise.com | Sign up here | mid-article | no |
+| osakatravelguide.html | www.dehancer.com | dehancer.com/subscribe | mid-article | no |
+| osakatravelguide.html | amzn.to | DJI Flip | mid-article | no |
+| osakatravelguide.html | amzn.to | Sony A7C II | mid-article | no |
+| osakatravelguide.html | amzn.to | DJI Pocket 3 | mid-article | no |
+| osakatravelguide.html | amzn.to | Tamron 28–200 | mid-article | no |
+| osakatravelguide.html | amzn.to | RØDE Wireless PRO | mid-article | no |
+| osakatravelguide.html | amzn.to | Think Tank Backpack | mid-article | no |
+| osakatravelguide.html | amzn.to | DJI Flip | mid-article | no |
+| osakatravelguide.html | amzn.to | Sony A7C II | mid-article | no |
+| osakatravelguide.html | amzn.to | DJI Osmo Pocket 3 | mid-article | no |
+| osakatravelguide.html | amzn.to | Tamron 24–200 | mid-article | no |
+| osakatravelguide.html | amzn.to | RØDE Wireless PRO | mid-article | no |
+| osakatravelguide.html | amzn.to | Think Tank Backpack | mid-article | no |
+| phuketravelguide.html | wise.com | Sign up here | mid-article | no |
+| phuketravelguide.html | www.dehancer.com | dehancer.com/subscribe | mid-article | no |
+| phuketravelguide.html | amzn.to | DJI Flip | mid-article | no |
+| phuketravelguide.html | amzn.to | Sony A7C II | mid-article | no |
+| phuketravelguide.html | amzn.to | DJI Pocket 3 | mid-article | no |
+| phuketravelguide.html | amzn.to | Tamron 28–200 | mid-article | no |
+| phuketravelguide.html | amzn.to | RØDE Wireless PRO | mid-article | no |
+| phuketravelguide.html | amzn.to | Think Tank Backpack | mid-article | no |
+| phuketravelguide.html | amzn.to | DJI Flip | mid-article | no |
+| phuketravelguide.html | amzn.to | Sony A7C II | mid-article | no |
+| phuketravelguide.html | amzn.to | DJI Osmo Pocket 3 | mid-article | no |
+| phuketravelguide.html | amzn.to | Tamron 24–200 | mid-article | no |
+| phuketravelguide.html | amzn.to | RØDE Wireless PRO | mid-article | no |
+| phuketravelguide.html | amzn.to | Think Tank Backpack | mid-article | no |
+| port-douglas-travel-guide/index.html | wise.com | Sign up here | mid-article | no |
+| port-douglas-travel-guide/index.html | www.dehancer.com | dehancer.com/subscribe | mid-article | no |
+| port-douglas-travel-guide/index.html | amzn.to | DJI Flip | end/recap | no |
+| port-douglas-travel-guide/index.html | amzn.to | Sony A7C II | end/recap | no |
+| port-douglas-travel-guide/index.html | amzn.to | DJI Pocket 3 | end/recap | no |
+| port-douglas-travel-guide/index.html | amzn.to | Tamron 28–200 | end/recap | no |
+| port-douglas-travel-guide/index.html | amzn.to | RØDE Wireless PRO | end/recap | no |
+| port-douglas-travel-guide/index.html | amzn.to | Think Tank Backpack | end/recap | no |
+| port-douglas-travel-guide/index.html | amzn.to | DJI Flip | end/recap | no |
+| port-douglas-travel-guide/index.html | amzn.to | Sony A7C II | end/recap | no |
+| port-douglas-travel-guide/index.html | amzn.to | DJI Osmo Pocket 3 | end/recap | no |
+| port-douglas-travel-guide/index.html | amzn.to | Tamron 24–200 | end/recap | no |
+| port-douglas-travel-guide/index.html | amzn.to | RØDE Wireless PRO | end/recap | no |
+| port-douglas-travel-guide/index.html | amzn.to | Think Tank Backpack | end/recap | no |
+| saily-e-simguide.html | www.saily.com | Visit Saily | mid-article | no |
+| sony-a7cii-review.html | amzn.to | Main Camera (Sony A7CII) | mid-article | yes |
+| sony-a7cii-review.html | amzn.to | Camera Backpack | mid-article | yes |
+| sony-a7cii-review.html | amzn.to | Lens: Tamron 24–200mm | mid-article | yes |
+| sony-a7cii-review.html | amzn.to | Field Monitor | mid-article | yes |
+| sony-a7cii-review.html | amzn.to | RØDE Wireless Pro | mid-article | yes |
+| sony-a7cii-review.html | amzn.to | Lighting Kit | mid-article | yes |
+| tech-review-dji-mavic3.html | amzn.to | DJI Mavic 3 (Standard Combo) | mid-article | yes |
+| tech-review-dji-mavic3.html | amzn.to | DJI ND Filter Set | mid-article | yes |
+| tech-review-dji-mavic3.html | amzn.to | Mavic 3 Extra Battery | mid-article | yes |
+| tech-review-dji-mavic3.html | amzn.to | Drone Carry Case | mid-article | yes |
+| tech-review-sony-a7siii.html | amzn.to | See Current Deals | mid-article | no |
+| tech-review-sony-a7siii.html | amzn.to | Buy the Sony A7III on Amazon | mid-article | no |
+| tech-review-zhiyun-weebill2.html | amzn.to | Check Price | mid-article | no |
+| thebesttemplesinhanoi.html | amzn.to | DJI Flip (US) | mid-article | no |
+| thebesttemplesinhanoi.html | amzn.to | Sony A7C II (US) | mid-article | no |
+| thebesttemplesinhanoi.html | amzn.to | DJI Pocket 3 Creator Combo (US) | mid-article | no |
+| thebesttemplesinhanoi.html | amzn.to | Tamron 28–200mm (US) | mid-article | no |
+| thebesttemplesinhanoi.html | amzn.to | Rode Wireless PRO (US) | mid-article | no |
+| thebesttemplesinhanoi.html | amzn.to | Thinktank Travel Commuter Backpack (US) | mid-article | no |
+| thebesttemplesinhanoi.html | amzn.to | DJI Flip | mid-article | no |
+| thebesttemplesinhanoi.html | amzn.to | Sony 7CII | mid-article | no |
+| thebesttemplesinhanoi.html | amzn.to | DJI Osmo Pocket 3 | mid-article | no |
+| thebesttemplesinhanoi.html | amzn.to | Tamron 24–200mm | mid-article | no |
+| thebesttemplesinhanoi.html | amzn.to | Rode Wireless Pro | mid-article | no |
+| thebesttemplesinhanoi.html | amzn.to | Thinktank Travel Commuter Backpack | mid-article | no |
+| thebesttemplesinhanoi.html | wise.com | Sign up here | mid-article | no |
+| thebesttemplesinhanoi.html | www.dehancer.com | dehancer.com/subscribe | mid-article | no |
+| thebesttemplesinhanoi.html | amzn.to | DJI Flip | mid-article | no |
+| thebesttemplesinhanoi.html | amzn.to | Sony A7C II | mid-article | no |
+| thebesttemplesinhanoi.html | amzn.to | DJI Pocket 3 | mid-article | no |
+| thebesttemplesinhanoi.html | amzn.to | Tamron 28–200 | mid-article | no |
+| thebesttemplesinhanoi.html | amzn.to | RØDE Wireless PRO | mid-article | no |
+| thebesttemplesinhanoi.html | amzn.to | Think Tank Backpack | mid-article | no |
+| thebesttemplesinhanoi.html | amzn.to | DJI Flip | mid-article | no |
+| thebesttemplesinhanoi.html | amzn.to | Sony A7C II | mid-article | no |
+| thebesttemplesinhanoi.html | amzn.to | DJI Osmo Pocket 3 | mid-article | no |
+| thebesttemplesinhanoi.html | amzn.to | Tamron 24–200 | mid-article | no |
+| thebesttemplesinhanoi.html | amzn.to | RØDE Wireless PRO | mid-article | no |
+| thebesttemplesinhanoi.html | amzn.to | Think Tank Backpack | mid-article | no |
+| tokyotravelguide.html | wise.com | Sign up here | mid-article | no |
+| tokyotravelguide.html | www.dehancer.com | dehancer.com/subscribe | mid-article | no |
+| tokyotravelguide.html | amzn.to | DJI Flip | mid-article | no |
+| tokyotravelguide.html | amzn.to | Sony A7C II | mid-article | no |
+| tokyotravelguide.html | amzn.to | DJI Pocket 3 | mid-article | no |
+| tokyotravelguide.html | amzn.to | Tamron 28–200 | mid-article | no |
+| tokyotravelguide.html | amzn.to | RØDE Wireless PRO | mid-article | no |
+| tokyotravelguide.html | amzn.to | Think Tank Backpack | mid-article | no |
+| tokyotravelguide.html | amzn.to | DJI Flip | mid-article | no |
+| tokyotravelguide.html | amzn.to | Sony A7C II | mid-article | no |
+| tokyotravelguide.html | amzn.to | DJI Osmo Pocket 3 | mid-article | no |
+| tokyotravelguide.html | amzn.to | Tamron 24–200 | mid-article | no |
+| tokyotravelguide.html | amzn.to | RØDE Wireless PRO | mid-article | no |
+| tokyotravelguide.html | amzn.to | Think Tank Backpack | mid-article | no |
+| top-10-things-to-do-in-hanoi.html | wise.com | Sign up here | mid-article | no |
+| top-10-things-to-do-in-hanoi.html | www.dehancer.com | dehancer.com/subscribe | mid-article | no |
+| top-10-things-to-do-in-hanoi.html | amzn.to | DJI Flip | mid-article | no |
+| top-10-things-to-do-in-hanoi.html | amzn.to | Sony A7C II | mid-article | no |
+| top-10-things-to-do-in-hanoi.html | amzn.to | DJI Pocket 3 | mid-article | no |
+| top-10-things-to-do-in-hanoi.html | amzn.to | Tamron 28–200 | mid-article | no |
+| top-10-things-to-do-in-hanoi.html | amzn.to | RØDE Wireless PRO | mid-article | no |
+| top-10-things-to-do-in-hanoi.html | amzn.to | Think Tank Backpack | mid-article | no |
+| top-10-things-to-do-in-hanoi.html | amzn.to | DJI Flip | mid-article | no |
+| top-10-things-to-do-in-hanoi.html | amzn.to | Sony A7C II | mid-article | no |
+| top-10-things-to-do-in-hanoi.html | amzn.to | DJI Osmo Pocket 3 | mid-article | no |
+| top-10-things-to-do-in-hanoi.html | amzn.to | Tamron 24–200 | mid-article | no |
+| top-10-things-to-do-in-hanoi.html | amzn.to | RØDE Wireless PRO | mid-article | no |
+| top-10-things-to-do-in-hanoi.html | amzn.to | Think Tank Backpack | mid-article | no |
+| travel-gear-2025.html | amzn.to | Sony A7C II | mid-article | yes |
+| travel-gear-2025.html | amzn.to | Tamron 24-200mm lens | mid-article | yes |
+| travel-gear-2025.html | www.amazon.com | Neewer 99W V-Mount Battery | mid-article | yes |
+| travel-gear-2025.html | www.amazon.com | Feelworld 5.5” Touchscreen Monitor | mid-article | yes |
+| travel-gear-2025.html | www.amazon.com | Rode Wireless PRO | mid-article | yes |
+| travel-gear-2025.html | amzn.to | Aputure MC Pro and MT Pro | mid-article | yes |
+| travel-gear-2025.html | amzn.to | DJI Osmo Pocket 3 Creator Combo | mid-article | yes |
+| travel-gear-2025.html | amzn.to | Ray-Ban Meta Smart Glasses | mid-article | yes |
+| travel-gear-2025.html | amzn.to | Manfrotto Travel Tripod | mid-article | yes |
+| travel-gear-2025.html | www.amazon.com | Neewer 99W V-Mount Battery | mid-article | yes |
+| travel-gear-2025.html | www.amazon.com | Feelworld 5.5” Touchscreen Monitor | mid-article | yes |
+| travel-gear-2025.html | amzn.to | ThinkTank Airport Commuter Backpack | mid-article | yes |
+| travel-gear-2025.html | amzn.to | Sony A7C II | mid-article | yes |
+| travel-gear-2025.html | amzn.to | Tamron 24-200mm Lens | mid-article | yes |
+| travel-gear-2025.html | www.amazon.com | Rode Wireless PRO | mid-article | yes |
+| travel-gear-2025.html | amzn.to | Aputure MC Pro + MT Pro | mid-article | yes |
+| travel-gear-2025.html | amzn.to | Manfrotto Travel Tripod | mid-article | yes |
+| travel-gear-2025.html | amzn.to | DJI Osmo Pocket 3 Creator Combo | mid-article | yes |
+| travel-gear-2025.html | amzn.to | Ray-Ban Meta Smart Glasses | mid-article | yes |
+| travel-gear-2025.html | www.amazon.com | Neewer 99W V-Mount Battery | mid-article | yes |
+| travel-gear-2025.html | www.amazon.com | Feelworld 5.5” Monitor | mid-article | yes |
+| travel-gear-2025.html | amzn.to | ThinkTank Airport Commuter | mid-article | yes |
+| videos/beginners-guide-davinci-resolve-2025.html | amzn.to | Sony A7C II | mid-article | yes |
+| videos/beginners-guide-davinci-resolve-2025.html | amzn.to | DJI Pocket 3 | mid-article | yes |
+| videos/beginners-guide-davinci-resolve-2025.html | amzn.to | RØDE Wireless PRO | mid-article | yes |
+| videos/beginners-guide-davinci-resolve-2025.html | amzn.to | Thinktank Travel Commuter | end/recap | yes |
+| vinwonders-nha-trang.html | amzn.to | DJI Flip | mid-article | no |
+| vinwonders-nha-trang.html | amzn.to | Sony A7C II | mid-article | no |
+| vinwonders-nha-trang.html | amzn.to | DJI Pocket 3 (Creator Combo) | mid-article | no |
+| vinwonders-nha-trang.html | amzn.to | Tamron 28–200mm (Full-Frame) | mid-article | no |
+| vinwonders-nha-trang.html | amzn.to | Rode Wireless PRO | mid-article | no |
+| vinwonders-nha-trang.html | amzn.to | Thinktank Travel Commuter Backpack | mid-article | no |
+| vinwonders-nha-trang.html | amzn.to | DJI Flip | mid-article | no |
+| vinwonders-nha-trang.html | amzn.to | Sony 7CII | mid-article | no |
+| vinwonders-nha-trang.html | amzn.to | DJI Osmo Pocket 3 | mid-article | no |
+| vinwonders-nha-trang.html | amzn.to | Tamron 24–200mm for Sony | mid-article | no |
+| vinwonders-nha-trang.html | amzn.to | Rode Wireless Pro | mid-article | no |
+| vinwonders-nha-trang.html | amzn.to | Thinktank Travel Commuter Backpack | mid-article | no |
+| vinwonders-nha-trang.html | wise.com | Sign up here | mid-article | no |
+| vinwonders-nha-trang.html | www.dehancer.com | dehancer.com/subscribe | mid-article | no |
+| vinwonders-nha-trang.html | amzn.to | DJI Flip | mid-article | no |
+| vinwonders-nha-trang.html | amzn.to | Sony A7C II | mid-article | no |
+| vinwonders-nha-trang.html | amzn.to | DJI Pocket 3 | mid-article | no |
+| vinwonders-nha-trang.html | amzn.to | Tamron 28–200 | mid-article | no |
+| vinwonders-nha-trang.html | amzn.to | RØDE Wireless PRO | mid-article | no |
+| vinwonders-nha-trang.html | amzn.to | Think Tank Backpack | mid-article | no |
+| vinwonders-nha-trang.html | amzn.to | DJI Flip | mid-article | no |
+| vinwonders-nha-trang.html | amzn.to | Sony A7C II | mid-article | no |
+| vinwonders-nha-trang.html | amzn.to | DJI Osmo Pocket 3 | mid-article | no |
+| vinwonders-nha-trang.html | amzn.to | Tamron 24–200 | mid-article | no |
+| vinwonders-nha-trang.html | amzn.to | RØDE Wireless PRO | mid-article | no |
+| vinwonders-nha-trang.html | amzn.to | Think Tank Backpack | mid-article | no |
+| yesim-guide.html | yesim.app | Download Yesim | mid-article | yes |
+| yesim-guide.html | yesim.app | Get Yesim Now | mid-article | yes |

--- a/docs/affiliate-cta-test-plan.md
+++ b/docs/affiliate-cta-test-plan.md
@@ -1,0 +1,38 @@
+# Affiliate CTA A/B test plan
+
+## What was changed
+- Added a reusable affiliate CTA block component with three variants (value-first, creator-support, comparison).
+- Implemented intent classification (Story/Rant, Destination/Guide, Gear/Workflow, Utility/How-to) with manual override support.
+- Added deterministic A/B assignment via localStorage (`ctaVariant` set to 1/2/3).
+- Implemented lightweight event tracking for affiliate clicks, scroll depth, and time-on-page buckets.
+- Added disclosures near the first affiliate links on key pages and included micro-disclosure in each CTA block.
+- Applied CTA placements and resource sections to the homepage and the selected top pages.
+
+## How variants work
+- **Variant 1 (Value-first):** Title “Quick recommendation”, 1-sentence benefit + audience fit, CTA “Check price”.
+- **Variant 2 (Creator-support):** Title “Support the channel”, copy “If you’re buying anyway…”, CTA “Grab it on Amazon”.
+- **Variant 3 (Comparison):** Title “My pick (and why)”, two bullet reasons + one alternative, CTA “See options”.
+
+Variant assignment is deterministic per browser:
+- `localStorage.ctaVariant` is set once and reused.
+- Split is 33/33/33 based on a single random draw.
+
+## Where placements are added
+Placement rules align with intent:
+- **A Story/Rant:** 1 CTA block near end + 1 simple text link near the intro.
+- **B Destination/Guide:** 1 CTA block after intro + “Resources for this trip” near end.
+- **C Gear/Workflow:** CTA block near first mention + “Full kit list” at end.
+- **D Utility/How-to:** CTA block after the step that matters + end-of-article recap CTA.
+
+## Success metrics
+Primary:
+- **Affiliate click rate per 100 pageviews** (event: `affiliate_click`).
+- **Affiliate clicks by intent type** (segment by `intent_type`).
+
+Secondary:
+- **Scroll depth completion** (25/50/75/90) to ensure engagement isn’t harmed.
+- **Time-on-page bucket** (30s, 60s, 120s) for early bounce or deeper reads.
+
+## Notes
+- CTA variant and placement are passed in event params so variant-level performance can be compared in GA4.
+- All tracking respects Do Not Track and fails safely if GA4 is unavailable.

--- a/docs/how-to-read-ga4.md
+++ b/docs/how-to-read-ga4.md
@@ -1,0 +1,42 @@
+# How to read affiliate CTA results in GA4
+
+## Events to look for
+- **affiliate_click**
+  - Params: `page_path`, `intent_type`, `placement`, `cta_variant`, `link_domain`, `link_label`
+- **scroll_depth**
+  - Params: `page_path`, `depth` (25/50/75/90)
+- **time_on_page**
+  - Params: `page_path`, `bucket` (30s/60s/120s)
+
+## Where to find events
+1. **Reports → Engagement → Events**
+   - Search for `affiliate_click`, `scroll_depth`, `time_on_page`.
+2. **Reports → Engagement → Pages and screens**
+   - Add a comparison or secondary dimension for `event name`.
+
+## Recommended explorations
+1. **CTA Variant Performance**
+   - Exploration type: Free form.
+   - Rows: `event name` (filter to `affiliate_click`).
+   - Columns: `cta_variant`.
+   - Values: `Event count`.
+   - Add filter for `intent_type` to compare A/B results by content intent.
+
+2. **Placement Effectiveness**
+   - Rows: `placement`.
+   - Columns: `intent_type`.
+   - Values: `Event count`.
+
+3. **Engagement Check**
+   - Rows: `page_path`.
+   - Columns: `depth` (from `scroll_depth` event).
+   - Values: `Event count`.
+
+## If GA4 is not connected yet
+A lightweight fallback stores events in `localStorage` and logs to the console on localhost.
+- Look for `affiliateEventLog` in localStorage for recent events.
+- When GA4 is added, events will start flowing automatically without changing the code.
+
+## Next steps
+- Track clicks per 100 pageviews and compare by intent/variant.
+- Pause or replace any CTA variant that underperforms by intent type.

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
 
     <!-- Meta Tags -->
     <meta name="description" content="Join Carl Tomich on a cinematic journey blending travel, tech, and filmmaking. Explore stunning films, travel stories, and gear reviews.">
+    <meta name="affiliateIntent" content="B">
     <meta name="keywords" content="Carl Tomich, Travel Filmmaker, Cinematic Travel, Tech Reviews, Film Portfolio, Adventure Stories">
     <meta name="author" content="Carl Tomich">
     <!-- Open Graph Meta Tags -->
@@ -590,23 +591,25 @@
                 <span class="text-yellow-500 font-medium mb-2 inline-block">CREATOR CORNER</span>
                 <h2 class="heading-font text-3xl md:text-4xl font-bold text-white mb-4">Travel Essentials &amp; Creator Gear</h2>
                 <p class="text-gray-400 max-w-3xl mx-auto">The same kit I recommend on the Destinations page—perfect for keeping you connected and your content crisp while you explore.</p>
+                <p class="affiliate-disclosure-line max-w-3xl mx-auto">Disclosure: Some links below are affiliate links. If you buy through them, I may earn a commission at no extra cost to you.</p>
             </div>
+            <div class="affiliate-cta" data-placement="homepage-hero" data-link="https://yesim.app" data-label="Yesim eSIM" data-title="Stay connected on day one" data-benefit="Skip airport SIM lines with an eSIM you can install before you land." data-who="Perfect for short trips and multi-country routes." data-thumbnail="/esim.jpg"></div>
             <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-4">
-                <div class="glass-card rounded-3xl p-8 space-y-4 shadow-xl">
+                <div class="glass-card rounded-3xl p-8 space-y-4 shadow-xl" data-affiliate-placement="essentials-list">
                     <h3 class="heading-font text-2xl text-white">Travel Essentials</h3>
                     <ul class="list-disc list-inside text-gray-300 space-y-2">
                         <li>Saily eSIM (200+ countries): Use code <span class="font-semibold">CARLRI5370</span> for $5 off (I receive $5 credit)</li>
                         <li>Wise (multi-currency card): <a href="https://wise.com/invite/irhc/carlt62" class="text-yellow-500 hover:text-yellow-400">Sign up here</a></li>
                     </ul>
                 </div>
-                <div class="glass-card rounded-3xl p-8 space-y-4 shadow-xl">
+                <div class="glass-card rounded-3xl p-8 space-y-4 shadow-xl" data-affiliate-placement="creator-tools">
                     <h3 class="heading-font text-2xl text-white">Creator Tools</h3>
                     <ul class="list-disc list-inside text-gray-300 space-y-2">
                         <li>Dehancer (film emulation): Code <span class="font-semibold">CARLTRAVELS</span> for 10% off → <a href="https://www.dehancer.com/subscribe" class="text-yellow-500 hover:text-yellow-400">dehancer.com/subscribe</a></li>
                         <li>Adobe Enhance VO (FREE): <a href="https://podcast.adobe.com/en/enhance" class="text-yellow-500 hover:text-yellow-400">podcast.adobe.com/en/enhance</a></li>
                     </ul>
                 </div>
-                <div class="glass-card rounded-3xl p-8 space-y-4 shadow-xl">
+                <div class="glass-card rounded-3xl p-8 space-y-4 shadow-xl" data-affiliate-placement="gear-us">
                     <h3 class="heading-font text-2xl text-white">My Gear – US Links</h3>
                     <ul class="list-disc list-inside text-gray-300 space-y-2">
                         <li><a href="https://amzn.to/45iZULT" class="text-yellow-500 hover:text-yellow-400">DJI Flip</a></li>
@@ -617,7 +620,7 @@
                         <li><a href="https://amzn.to/467fEAU" class="text-yellow-500 hover:text-yellow-400">Think Tank Backpack</a></li>
                     </ul>
                 </div>
-                <div class="glass-card rounded-3xl p-8 space-y-4 shadow-xl">
+                <div class="glass-card rounded-3xl p-8 space-y-4 shadow-xl" data-affiliate-placement="gear-au">
                     <h3 class="heading-font text-2xl text-white">My Gear – AU Links</h3>
                     <ul class="list-disc list-inside text-gray-300 space-y-2">
                         <li><a href="https://amzn.to/41zmAVV" class="text-yellow-500 hover:text-yellow-400">DJI Flip</a></li>

--- a/tokyotravelguide.html
+++ b/tokyotravelguide.html
@@ -8,6 +8,7 @@
     <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="e44b7cd2-126b-4f49-8aee-22495afe3ece" type="text/javascript" async></script>
     <!-- Meta Tags -->
     <meta name="description" content="Explore Tokyo, Japan with Carl Travels’ 2025 guide. Discover Shibuya Crossing, Akihabara’s neon nights, budget stays, and vibrant nightlife.">
+    <meta name="affiliateIntent" content="B">
     <meta name="keywords" content="Tokyo travel guide 2025, Japan budget travel, Shibuya Crossing, Akihabara nightlife, Carl Travels">
     <meta name="author" content="Carl Ostomich">
     <!-- Open Graph Meta Tags -->
@@ -264,6 +265,8 @@
                         <p class="text-gray-600 mb-8">
                             Landing in Tokyo felt like stepping into a sci-fi movie—neon lights, bustling crowds, and an energy that pulses 24/7. From crossing Shibuya’s iconic scramble to wandering Akihabara’s glowing streets, my first days in Tokyo were a whirlwind of culture, food, and nightlife. This guide shares tips from my adventure, with two vlogs to bring it to life. Carl Travels uses Cookiebot to manage cookie consent, ensuring GDPR compliance.
                         </p>
+                        <p class="affiliate-disclosure-line">Disclosure: This page contains affiliate links. If you buy through them, I may earn a commission at no extra cost to you.</p>
+                        <div class="affiliate-cta" data-placement="intro" data-link="https://yesim.app" data-label="Yesim eSIM" data-title="Land in Tokyo with data ready" data-benefit="Activate an eSIM before you fly so Google Maps and transit apps work the moment you arrive." data-who="Best for short trips and multi-city Japan itineraries." data-thumbnail="/esim.jpg"></div>
                         
                         <div class="bg-gray-50 rounded-xl p-6 shadow-lg mb-8">
                             <h2 class="text-2xl font-bold text-gray-800 mb-4"><i class="fas fa-home mr-2 text-yellow-500"></i> Welcome to Tokyo</h2>
@@ -406,6 +409,14 @@
                             </table>
                         </div>
                         
+                        <div class="bg-gray-50 rounded-xl p-6 shadow-lg mb-8" data-affiliate-placement="resources">
+                            <h2 class="text-2xl font-bold text-gray-800 mb-4"><i class="fas fa-suitcase mr-2 text-yellow-500"></i> Resources for this trip</h2>
+                            <ul class="list-disc pl-6 mb-4 text-gray-600">
+                                <li>Stay connected: <a href="https://yesim.app" class="text-yellow-500 hover:text-yellow-500">Yesim eSIM</a> for quick setup before you land.</li>
+                                <li>Money on the move: <a href="https://wise.com/invite/irhc/carlt62" class="text-yellow-500 hover:text-yellow-500">Wise multi-currency card</a> to skip bad exchange rates.</li>
+                                <li>Pack light: <a href="https://amzn.to/4miS3UJ" class="text-yellow-500 hover:text-yellow-500">DJI Pocket 3</a> for compact travel video.</li>
+                            </ul>
+                        </div>
                         <div class="bg-gray-50 rounded-xl p-6 shadow-lg mb-8">
                             <h2 class="text-2xl font-bold text-gray-800 mb-4"><i class="fas fa-flag-checkered mr-2 text-yellow-500"></i> Final Thoughts</h2>
                             <p class="text-gray-600 mb-4">Tokyo is a sensory overload in the best way—vibrant, welcoming, and endlessly fascinating. Don’t miss Shibuya Crossing or Akihabara’s neon nights. Stay a few days, eat ramen, sing karaoke, and lose yourself in the city’s energy.</p>

--- a/travel-gear-2025.html
+++ b/travel-gear-2025.html
@@ -14,6 +14,7 @@ Curiosity-driven: The small piece of gear that saves my shoots
     <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="e44b7cd2-126b-4f49-8aee-22495afe3ece" type="text/javascript" async></script>
     <!-- SEO Meta Tags -->
     <meta name="description" content="A breakdown of the travel filmmaking kit I carry in 2025 and how each piece earns its spot in the bag." />
+    <meta name="affiliateIntent" content="C">
     <meta name="keywords" content="travel filmmaking gear 2025, Sony A7C II travel, DJI Osmo Pocket 3 vlogging, Ray-Ban Meta Glasses, travel vlog gear, Carl Travels">
     <!-- Open Graph -->
     <meta property="og:title" content="My Essential Travel Filmmaking Kit (2025) – Carl Travels">
@@ -197,6 +198,7 @@ Curiosity-driven: The small piece of gear that saves my shoots
                 <div class="prose prose-lg text-gray-800">
                     <h2 class="heading-font text-3xl font-bold mb-6">🎒 Everything I Use to Film On the Road</h2>
                     <p>Travel filmmaking is my passion, but let’s be real—it’s a hustle. You’re dodging crowds in Hanoi’s Old Quarter, chasing sunsets in Budva, or setting up an interview in a cramped Melbourne café. Your gear needs to keep up, stay compact, and deliver pro-level results. After years of tweaking (and a few gear fails), I’ve nailed my 2025 kit. Here’s what I carry, why I love it, and how it all fits in one backpack.</p>
+                    <div class="affiliate-cta" data-placement="gear-intro" data-link="https://amzn.to/4c41Mde" data-label="Sony A7C II" data-title="My exact travel camera setup" data-benefit="This is the body I trust for travel doc work because it stays lightweight without giving up full-frame quality." data-who="Best for creators who shoot both photo and video on the move." data-thumbnail="/sonya7ciii.jpg"></div>
 
                     <h3 class="heading-font text-2xl font-semibold mt-8 mb-4">📷 Main Camera: Sony A7C II + Tamron 24-200mm Lens</h3>
                     <p>The <a href="https://amzn.to/4c41Mde" target="_blank" class="text-yellow-500 hover:text-yellow-500">Sony A7C II</a> is my workhorse. This full-frame mirrorless camera is a beast in a tiny body—perfect for travel. Its dynamic range captures vibrant Osaka street scenes, and the autofocus locks onto subjects even in Berlin’s dim nightlife. Paired with the <a href="https://amzn.to/4hy5EUQ" target="_blank" class="text-yellow-500 hover:text-yellow-500">Tamron 24-200mm lens</a>, I can shoot wide landscapes in Cairns or tight portraits in Prague without swapping lenses.</p>
@@ -248,8 +250,9 @@ Curiosity-driven: The small piece of gear that saves my shoots
 
                     <h3 class="heading-font text-2xl font-semibold mt-8 mb-4">🧠 Final Thoughts</h3>
                     <p>This kit is my travel filmmaking lifeline. It’s flexible enough for polished documentaries or quick YouTube vlogs, letting me capture the chaos of Hanoi’s streets or the serenity of Budva’s coast. Whether you’re starting your travel vlog journey or leveling up, I hope my setup inspires you.</p>
+                    <h3 class="heading-font text-2xl font-semibold mt-6 mb-4">Full kit list</h3>
                     <p>Want to grab some of my gear? Here’s a quick rundown with links:</p>
-                    <ul class="list-disc pl-6 mb-6">
+                    <ul class="list-disc pl-6 mb-6" data-affiliate-placement="full-kit-list">
                         <li><a href="https://amzn.to/4c41Mde" target="_blank" class="text-yellow-500 hover:text-yellow-500">Sony A7C II</a> – Main camera</li>
                         <li><a href="https://amzn.to/4hy5EUQ" target="_blank" class="text-yellow-500 hover:text-yellow-500">Tamron 24-200mm Lens</a> – Versatile zoom</li>
                         <li><a href="https://www.amazon.com/Rode-Wireless-PRO-Microphone-System/dp/B0C2T3V9G3" target="_blank" class="text-yellow-500 hover:text-yellow-500">Rode Wireless PRO</a> – Crystal-clear audio</li>

--- a/what-i-learned-after-returning-to-australia-and-why-i-LEFT-again.html
+++ b/what-i-learned-after-returning-to-australia-and-why-i-LEFT-again.html
@@ -8,6 +8,7 @@
     <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="e44b7cd2-126b-4f49-8aee-22495afe3ece" type="text/javascript" async></script>
     <!-- Meta Tags -->
     <meta name="description" content="A personal reflection on returning to Australia, the cultural shifts that stood out after living abroad, and why I chose to leave again." />
+    <meta name="affiliateIntent" content="A">
     <meta name="keywords" content="returning to Australia, why I left again, living overseas perspective, Berlin travel, Vietnam life, Australia travel blog">
     <meta name="author" content="Carl Ostomich">
     <!-- Open Graph Meta Tags -->
@@ -193,6 +194,10 @@
                         <p class="text-gray-600 mb-8">
                             I came back to Australia expecting a familiar comfort, but everything felt louder than I remembered. The distance, the cost, the rules, and the pace of life all hit differently once I had lived in places like Berlin, Vietnam, and Japan. Here are the moments that stood out, and why I ended up leaving again.
                         </p>
+                        <p class="affiliate-disclosure-line">Disclosure: Some links in this story are affiliate links. If you buy through them, I may earn a commission at no extra cost to you.</p>
+                        <p class="text-gray-600 mb-8" data-affiliate-placement="story-intro">
+                            Support the channel: the lightweight camera I travel with is the <a href="https://amzn.to/4mHhQ8H" class="text-yellow-500 hover:text-yellow-500">Sony A7C II</a>.
+                        </p>
 
                         <p class="text-gray-600 italic mb-8">If this saved you time or money, there’s a coffee link below.</p>
                         
@@ -231,6 +236,7 @@
                             <p class="text-gray-600 mb-4">Leaving was not about rejecting Australia. It was about recognising that the way I now live did not fit the structure Australia quietly demands. Home is not just where you are from. It is where the way you live actually makes sense.</p>
 
                             <p class="text-gray-600 italic mb-4">I don’t sell courses or hype. If this helped, you know where the button is.</p>
+                            <div class="affiliate-cta" data-placement="end" data-link="https://amzn.to/45Qk2Fw" data-label="Sony A7C II" data-title="Support the channel on the road" data-benefit="If you’re upgrading your camera anyway, this is the body I keep reaching for." data-who="Great for creators who want full-frame quality in a travel-friendly size." data-thumbnail="/sonya7ciii.jpg"></div>
                         </div>
                     </div>
                 </div>

--- a/whyileftaustralia.html
+++ b/whyileftaustralia.html
@@ -14,6 +14,7 @@ Curiosity-driven: The moment I knew I had to leave Australia
     <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="e44b7cd2-126b-4f49-8aee-22495afe3ece" type="text/javascript" async></script>
     <!-- Meta Tags -->
     <meta name="description" content="A personal reflection on why I left Australia, the costs and creative pressure that built up, and what I was looking for abroad." />
+    <meta name="affiliateIntent" content="A">
     <meta name="keywords" content="why I left Australia, expat life 2025, moving abroad from Australia, Carl Travels">
     <meta name="author" content="Carl Ostomich">
     <!-- Open Graph Meta Tags -->
@@ -199,6 +200,10 @@ Curiosity-driven: The moment I knew I had to leave Australia
                         <p class="text-gray-600 mb-8">
                             One night in Melbourne, I sat staring at a rent bill that felt like a punch in the gut—$600 a week for a tiny flat, and I was barely scraping by. That’s when it hit me: the “lucky country” wasn’t feeling so lucky anymore. This is my story of why I left Australia, not because I hated it, but because I needed a life that lit me up. Carl Travels uses Cookiebot to manage cookie consent, ensuring GDPR compliance.
                         </p>
+                        <p class="affiliate-disclosure-line">Disclosure: Some links in this story are affiliate links. If you buy through them, I may earn a commission at no extra cost to you.</p>
+                        <p class="text-gray-600 mb-8" data-affiliate-placement="story-intro">
+                            Support the channel: the compact camera I keep in my day bag is the <a href="https://amzn.to/4miS3UJ" class="text-yellow-500 hover:text-yellow-500">DJI Pocket 3</a>.
+                        </p>
 
                         <p class="text-gray-600 italic mb-8">If this saved you time or money, there’s a coffee link below.</p>
                         
@@ -248,6 +253,8 @@ Curiosity-driven: The moment I knew I had to leave Australia
                             <p class="text-gray-600 mb-4">This video dives deeper into my reasons for leaving and what I’m chasing abroad—hope it resonates!</p>
 
                             <p class="text-gray-600 italic mb-4">I don’t sell courses or hype. If this helped, you know where the button is.</p>
+
+                            <div class="affiliate-cta" data-placement="end" data-link="https://amzn.to/45iZULT" data-label="DJI Flip" data-title="Support the channel on the road" data-benefit="If you’re picking up a travel drone anyway, this one keeps my kit lightweight." data-who="Great for creators who want cinematic b-roll without a big setup." data-thumbnail="/djiflip.jpg"></div>
                             
                             <p class="text-gray-600 mb-4">And if there’s even a <strong>small voice inside you</strong> asking if there might be something more out there for you too—<strong>listen to it.</strong> You don’t have to stay stuck. You don’t have to settle. Change is scary, yeah. But sometimes, it’s the best thing you’ll ever do.</p>
                             


### PR DESCRIPTION
### Motivation
- Increase outbound affiliate clicks and funnel readers to money pages while preserving UX and SEO by adding consistent, intent-aware CTAs and minimal tracking. 
- Provide a lightweight, first‑party measurement and deterministic A/B framework that does not rely on third‑party A/B tools and respects Do Not Track. 
- Ship clear documentation so results can be read in GA4 (or a fallback) and stakeholders can interpret variant performance. 

### Description
- Added an automated site scan and a comprehensive audit written to `docs/affiliate-audit.md` that enumerates affiliate links and placement heuristics across the site. 
- Implemented an intent classifier and deterministic 3-way CTA variant assignment in `assets/js/site.js` using a `meta[name="affiliateIntent"]` override and a `localStorage` key `ctaVariant` for a 33/33/33 split. 
- Built a reusable, lightweight Affiliate CTA component (styles in `assets/css/styles.css`, renderer and variant logic in `assets/js/site.js`) with three variants: Value-first, Creator-support, and Comparison; CTAs include in-block micro-disclosure text. 
- Implemented minimal first‑party tracking (GA4-safe): `affiliate_click` event with params `page_path`, `intent_type`, `placement`, `cta_variant`, `link_domain`, `link_label`, plus `scroll_depth` (25/50/75/90) and `time_on_page` buckets (30s/60s/120s); includes a localStorage fallback `affiliateEventLog` when GA is not present. 
- Applied CTA blocks and disclosures to the homepage and five high-impact pages (destination/guide, gear, and story pages) following the placement rules; added small resource sections near recaps where appropriate. 
- Added docs `docs/affiliate-cta-test-plan.md` and `docs/how-to-read-ga4.md` describing the test plan, variant behavior, tracking schema, and recommended GA4 explorations. 

### Testing
- Ran the automated affiliate scan that produced `docs/affiliate-audit.md` (scan output written and verified), confirming affiliate links were discovered and table rows were generated. 
- Served the site locally (`python -m http.server`) and loaded `index.html` with Playwright to capture a screenshot of the homepage CTA to confirm rendering and non-intrusive placement, which completed successfully. 
- Smoke-tested the client JS by loading pages and exercising CTA rendering and click handlers (events are written to `localStorage` when GA is absent), and observed expected event payloads in the fallback `affiliateEventLog` on localhost.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69683ce367a88323a997ce3970e708ee)