### PR TITLE
Add canonical tags to pages and update sitemap

### DIFF
--- a/about.html
+++ b/about.html
@@ -6,6 +6,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>About Carl Tomich – Carl Travels</title>
+    <link rel="canonical" href="https://www.carltravels.com/about.html">
 
     <!-- Meta Tags -->
     <meta name="description" content="Learn about Carl Tomich, a filmmaker, editor, and full-time content creator with 14 years behind the camera, working across travel, documentary, and online media.">

--- a/blog.html
+++ b/blog.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Tips and Tricks on Getting Around Europe, Saving Money While Traveling And Travel Life Hacks - Carl Travels</title>
+    <link rel="canonical" href="https://www.carltravels.com/blog.html">
     <!-- Cookiebot for GDPR Compliance -->
     <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="e44b7cd2-126b-4f49-8aee-22495afe3ece" type="text/javascript" async></script>
     <!-- Google tag (gtag.js) -->

--- a/contact.html
+++ b/contact.html
@@ -8,6 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="google-adsense-account" content="ca-pub-6483721386563068">
     <title>Contact - Carl Travels</title>
+    <link rel="canonical" href="https://www.carltravels.com/contact.html">
 
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-G72KT5ZW2J"></script>

--- a/destinations.html
+++ b/destinations.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Destinations – Carl Travels: Explore the World’s Best Cities and Hidden Gems</title>
+    <link rel="canonical" href="https://www.carltravels.com/destinations.html">
     <!-- Cookiebot for GDPR Compliance -->
     <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="e44b7cd2-126b-4f49-8aee-22495afe3ece" type="text/javascript" async></script>
     <!-- SEO Meta Tags -->

--- a/gear.html
+++ b/gear.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Gear Reviews - Carl Tomich Tech</title>
+    <link rel="canonical" href="https://www.carltravels.com/gear.html">
     <meta name="description" content="Honest reviews of travel and audio gear from Carl Tomich. Discover the best tools for creators on the move.">
     <meta name="keywords" content="gear reviews, audio gear, travel tech, Carl Tomich">
     <meta name="author" content="Carl Tomich">

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Carl Tomich - Cinematic Journeys</title>
+    <link rel="canonical" href="https://www.carltravels.com/">
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-G72KT5ZW2J"></script>
     <script>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Privacy Policy - Carl Travels</title>
+    <link rel="canonical" href="https://www.carltravels.com/privacy-policy.html">
     <!-- Cookiebot for GDPR Compliance -->
     <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="e44b7cd2-126b-4f49-8aee-22495afe3ece" type="text/javascript" async></script>
     <!-- Meta Tags -->

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -31,7 +31,7 @@
   <url><loc>https://www.carltravels.com/howtofoldapopuptent.html</loc></url>
   <url><loc>https://www.carltravels.com/howtomakemoneyonlinesellingstockfootage.html</loc></url>
   <url><loc>https://www.carltravels.com/make-money-online-while-traveling.html</loc></url>
-  <url><loc>https://www.carltravels.com/index.html</loc></url>
+  <url><loc>https://www.carltravels.com/blog/horse-riding-near-hanoi-countryside-experience.html</loc></url>
   <url><loc>https://www.carltravels.com/japanonabudget.html</loc></url>
   <url><loc>https://www.carltravels.com/korcula.html</loc></url>
   <url><loc>https://www.carltravels.com/kyototravelguide.html</loc></url>

--- a/terms-and-conditions.html
+++ b/terms-and-conditions.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Terms & Conditions - Carl Travels</title>
+    <link rel="canonical" href="https://www.carltravels.com/terms-and-conditions.html">
     <!-- Cookiebot for GDPR Compliance -->
     <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="e44b7cd2-126b-4f49-8aee-22495afe3ece" type="text/javascript" async></script>
     <!-- Meta Tags -->


### PR DESCRIPTION
### Motivation
- Improve SEO and reduce duplicate-content/indexing issues by adding explicit canonical URLs to core pages.
- Ensure the sitemap accurately reflects site content by removing a duplicate home entry and including a missing blog post URL.

### Description
- Add `<link rel="canonical">` tags to `index.html`, `blog.html`, `destinations.html`, `about.html`, `gear.html`, `contact.html`, `privacy-policy.html`, and `terms-and-conditions.html` to standardize canonical URLs.
- Update `sitemap.xml` to replace the duplicate `https://www.carltravels.com/index.html` entry with `https://www.carltravels.com/blog/horse-riding-near-hanoi-countryside-experience.html` so the blog post is included.
- Only static HTML/XML changes were made to improve indexation signals and sitemap accuracy.

### Testing
- No automated tests were run for these static HTML/XML changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696901b8995483238cb80ced992782b3)