### PR TITLE
Add 'Turning 40' second video section to HIFU article

### DIFF
--- a/Hifuinhanoi.html
+++ b/Hifuinhanoi.html
@@ -376,6 +376,30 @@ Curiosity-driven: The moment I decided HIFU was worth trying
                 </div>
 
                 <div class="content-card space-y-4">
+                    <div class="flex flex-wrap items-center gap-3">
+                        <span class="badge"><i class="fas fa-video"></i> Turning 40</span>
+                        <p class="text-sm text-gray-300">Personal reflections from Vietnam</p>
+                    </div>
+                    <h3 class="text-xl font-semibold text-white">Turning 40 in Vietnam: Maintenance, Not a Makeover</h3>
+                    <div class="relative w-full overflow-hidden rounded-2xl shadow-2xl" style="padding-top: 56.25%;">
+                        <iframe class="absolute inset-0 w-full h-full" src="https://www.youtube.com/embed/EWJ5FgJeVGw" title="Turning 40 in Vietnam: Maintenance, Not a Makeover" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                    </div>
+                    <p class="lead">
+                        I’m turning 40, and this isn’t a glow-up or transformation story. Over the past couple of years I started noticing changes I couldn’t ignore: greying hair, under-eye bags, skin sagging, and the long-term effects of stress, travel, drinking, and smoking. Aging didn’t hit overnight—it crept in quietly.
+                    </p>
+                    <p class="lead">
+                        Living and filming in Southeast Asia, where people often look younger than their age, made me reflect on how I want to age. While in Vietnam I started looking into non-surgical options for skin tightening and general maintenance, which is how I discovered HIFU (High-Intensity Focused Ultrasound).
+                    </p>
+                    <ul class="list-disc list-inside text-gray-300 space-y-2">
+                        <li>What the HIFU treatment actually felt like</li>
+                        <li>Why I chose a non-surgical approach</li>
+                        <li>Cost comparisons with Australia, the US, and Europe</li>
+                        <li>Other upgrades I worked on: dental work, fitness, and Muay Thai</li>
+                        <li>Why this is about maintenance—not trying to stop aging</li>
+                    </ul>
+                </div>
+
+                <div class="content-card space-y-4">
                     <h3 class="text-xl font-semibold text-white">Confidence, Not Vanity</h3>
                     <p class="lead">
                         I didn’t try HIFU because I’m afraid of aging. I did it to feel like my best self heading into my 40s—on camera, in life, and in relationships. Getting older is inevitable; letting yourself go completely is optional. Vietnam made preventative care accessible, safe, and normal.


### PR DESCRIPTION
### Motivation
- Add a second, personal video to the HIFU article that covers turning 40, non-surgical maintenance, and HIFU impressions while living in Vietnam. 

### Description
- Inserted a new `content-card` block into `Hifuinhanoi.html` containing a badge, heading, embedded YouTube iframe (`https://www.youtube.com/embed/EWJ5FgJeVGw`), two intro paragraphs, and a bullet list summarising the video's talking points. 
- The new section is placed before the existing "Confidence, Not Vanity" block and follows the existing layout and styling conventions. 
- Change is a single static HTML update (24 lines inserted). 

### Testing
- No unit tests exist for this static HTML change and no automated test suite was run. 
- Started a local static server with `python -m http.server 8000` and attempted an automated Playwright screenshot verification, but the Playwright run timed out and did not complete. 
- Local inspection of `Hifuinhanoi.html` confirms the new section and iframe are present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e7c6a8bf08323889d383f9a2c791c)