### PR TITLE
Insert homepage intro section between hero and Travel Stories

### DIFF
--- a/index.html
+++ b/index.html
@@ -234,6 +234,20 @@
         </div>
     </section>
 
+    <!-- About Section -->
+    <section class="py-16 bg-dark">
+        <div class="container mx-auto px-6">
+            <div class="max-w-4xl mx-auto text-gray-300 leading-relaxed space-y-6">
+                <p>
+                    Carl Travels is a travel and filmmaking platform built around real-world experience, long-term living abroad, and the creative process behind documenting it. This is not short trip content or surface-level travel advice. It is slow travel, digital nomad life, and cinematic storytelling shaped by living and working across Europe and Asia. I focus on what happens after the excitement fades: building routines in new cities, managing money, health, work, and creativity while constantly on the move. My goal is to go beyond showing destinations and instead explore what it actually feels like to live inside them.
+                </p>
+                <p>
+                    On this site you will find in-depth destination guides, personal travel stories, cinematic travel films, and practical gear reviews based on equipment I use daily as a filmmaker and content creator. From cost of living and visas to cameras, drones, backpacks, and editing workflows, everything here is based on lived experience, not theory. My aim is to stay true to my core values. I am not here to sell you a course, a dream, or a fantasy. I am here to show you the reality of the world, whether that is through travel, personal experience, or the products I actually use.
+                </p>
+            </div>
+        </div>
+    </section>
+
     <!-- Featured Destinations -->
     <section id="destinations" class="py-20 bg-dark">
         <div class="container mx-auto px-6">


### PR DESCRIPTION
### Motivation
- Add an introductory content block on the homepage between the hero CTA and the “TRAVEL STORIES / CINEMATIC DESTINATIONS” section to explain the site’s mission and scope.

### Description
- Inserted a new `section` after the hero with the exact two-paragraph text provided and preserved the wording unchanged inside `index.html`.
- The new section uses the existing site styling conventions (`py-16 bg-dark`, `container mx-auto px-6`, `max-w-4xl mx-auto text-gray-300 leading-relaxed`) to match dark theme, constrained width, padding, and readable body text without adding buttons or links.
- Kept layout and classes consistent with surrounding sections so the block is mobile-friendly and matches site's typography and spacing.

### Testing
- Started a local server with `python -m http.server 8000` and produced visual verification screenshots for desktop and mobile using Playwright, which succeeded and saved `artifacts/home-about-desktop.png` and `artifacts/home-about-mobile.png`.
- Committed the change to the repository and verified `index.html` is updated (commit message: `Add homepage intro section`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696eefb85ce88323bcf25f136560072d)