### PR TITLE
Integrate expanded personal narrative into About page

### DIFF
--- a/about.html
+++ b/about.html
@@ -149,10 +149,43 @@
             <section class="max-w-4xl space-y-6 fade-in">
                 <h2 class="heading-font text-3xl md:text-4xl text-white">A practical creative path</h2>
                 <p class="text-gray-300 leading-relaxed">
-                    I started filming live music gigs and quickly moved into weddings, commercials, and long-form documentary work. Along the way I spent time as a DJ and street performer in Berlin, which taught me how to build an audience from the ground up and stay adaptable when resources are thin.
+                    My name is Carl Tomich. I’m an Australian filmmaker and YouTuber, and this site is mostly a long, messy record of me trying to build a life that feels more intentional and more honest than the one I was drifting into back home.
                 </p>
                 <p class="text-gray-300 leading-relaxed">
-                    That mix of real-world experience is still the foundation of my work today. I shoot primarily on the Sony A7C II, bring drones in when the story benefits from the perspective, and edit in DaVinci Resolve or Adobe Premiere Pro depending on the project needs. The goal is always the same: honest storytelling that reflects what it actually takes to live creatively.
+                    I didn’t grow up with some big dream of becoming a travel YouTuber or a digital nomad. I just always liked making things. Music first, then video, then photography. In my twenties I moved to Berlin, busked on the streets with a guitar, filmed music videos, scraped by doing creative work, and lived a very unstable but very alive kind of life. It was chaotic and impractical, but I felt more like myself then than I ever did later on when my life became sensible.
+                </p>
+                <p class="text-gray-300 leading-relaxed">
+                    Eventually I moved back to Australia and did what you’re supposed to do. I got a normal job. I paid rent. I built routines. On paper my life was fine. In reality it slowly started to feel smaller and more repetitive every year. It wasn’t because I hated Australia. I think I had just outlived it. I’d seen everything, done everything, and all the things I liked about it over the years slowly started to change. Rules came in. Red tape came in. A lot of the fun got regulated out of everything. My favourite bars started closing. The live music scene got worse. Everything got more expensive. Traffic got worse. Rent went up. The quality of life started to feel stale and boring in a way I couldn’t really explain properly to other people.
+                </p>
+                <p class="text-gray-300 leading-relaxed">
+                    Around the same time I started taking filmmaking seriously again. I bought a camera. I started a YouTube channel. I started filming travel, daily life, and my own attempts to build online income streams. Stock footage. YouTube ad revenue. Affiliate links. Freelance editing. None of it was glamorous. Most of it barely worked at first. But for the first time in years I felt like I was actually building something instead of just maintaining a life I didn’t really want anymore.
+                </p>
+                <p class="text-gray-300 leading-relaxed">
+                    In my late thirties I made the decision to leave Australia again. Not because I thought moving overseas would magically fix my life, but because I couldn’t ignore the feeling anymore that if I didn’t try something different now, I probably never would. I moved to Vietnam and ended up staying for a while.
+                </p>
+                <p class="text-gray-300 leading-relaxed">
+                    These days my life is a bit more fluid. I’ve been based in Vietnam, mostly in Hanoi, but I’m about to leave again and head to Europe. Albania first, then Montenegro, then Croatia. I don’t really feel like I’m “moving” to any of these places in a permanent way. It’s more that I’m still trying to work out where I actually belong, or at least where I feel most like myself. Every place changes you a little bit, and I think I’m still in the phase of my life where I need to see what’s out there properly before I lock myself into another country and call it home.
+                </p>
+                <p class="text-gray-300 leading-relaxed">
+                    My day-to-day life looks roughly the same wherever I am. I train. I edit videos in cafés or apartments. I film whatever city I’m in. I write travel guides based on places I’ve actually spent real time in. I review gear I actually use to make a living. I upload stock footage and hope it sells.
+                </p>
+                <p class="text-gray-300 leading-relaxed">
+                    Some months I make decent money. Some months I don’t. I’m not rich. I’m not broke. I’m not financially free. I’m just trying to build something that gives me a bit more control over my time and a bit more say in what my life actually looks like from one year to the next.
+                </p>
+                <p class="text-gray-300 leading-relaxed">
+                    A lot of my content ends up being about travel, but that’s not really what I’m interested in at a deeper level. I’m more interested in what happens to people when they leave their old life behind and realise nobody is coming to tell them what to do anymore. The loneliness. The discipline problems. The money anxiety. The identity crisis. The weird mix of freedom and responsibility that comes with trying to design your own life.
+                </p>
+                <p class="text-gray-300 leading-relaxed">
+                    I don’t sell courses. I don’t promise freedom. I don’t think travel fixes your problems. It just changes the background they happen against.
+                </p>
+                <p class="text-gray-300 leading-relaxed">
+                    This site exists mostly as a public record of me trying to build a life that feels honest and creative and sustainable without lying to myself or anyone else about how messy and uncertain that process actually is.
+                </p>
+                <p class="text-gray-300 leading-relaxed">
+                    If you’re here because you’re looking for perfect travel tips or a blueprint for escaping your job, you’re probably going to be disappointed. If you’re here because something in your own life feels a bit off and you’re trying to figure out what to do about it, then you might find some of this useful.
+                </p>
+                <p class="text-gray-300 leading-relaxed">
+                    At the very least, you’ll get honest travel guides, honest gear reviews, and honest writing from someone who’s still very much in the middle of figuring his own life out.
                 </p>
             </section>
 


### PR DESCRIPTION
### Motivation
- Provide a fuller, first-person autobiographical narrative on `about.html` to reflect Carl Tomich’s background, career arc, motivations, and current lifestyle. 
- Replace the prior compressed summary with the supplied, more honest and detailed story covering Berlin busking, returning to Australia, restarting filmmaking, living in Vietnam, and the site's philosophical angle on travel and work.

### Description
- Replaced the compressed "A practical creative path" content in `about.html` with multiple new paragraphs that recount early career, Berlin busking, returning to Australia, taking filmmaking seriously again, moving to Vietnam, current nomadic routine, finances, and content philosophy. 
- Kept the existing layout, classes, and styling intact so no CSS or JavaScript changes were required. 
- File modified: `about.html`.

### Testing
- No automated tests were run for this static HTML/content change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697061a73a7483239e03fcd29c2b9332)