### PR TITLE
Add Busk Life IMDb link and enlarge about page portrait

### DIFF
--- a/about.html
+++ b/about.html
@@ -160,7 +160,7 @@
                     </p>
                 </div>
                 <div class="fade-in">
-                    <div class="relative max-w-md mx-auto">
+                    <div class="relative max-w-2xl mx-auto">
                         <div class="absolute inset-0 bg-yellow-500/10 blur-2xl rounded-full"></div>
                         <img src="carlaboutme.jpg" alt="Portrait of filmmaker Carl Tomich"
                             class="relative rounded-2xl shadow-2xl border border-yellow-500/40">

--- a/index.html
+++ b/index.html
@@ -325,10 +325,16 @@
                             Returned to Berlin's streets a decade later. A sequel exploring how the busking scene
                             evolved and what happened to the artists.
                         </p>
-                        <a href="https://www.youtube.com/watch?v=S8L4Hmwkgiw" target="_blank"
-                            class="text-sm font-semibold" style="color: var(--primary);">
-                            <i class="fab fa-youtube"></i> Watch Film →
-                        </a>
+                        <div class="flex gap-3">
+                            <a href="https://www.youtube.com/watch?v=S8L4Hmwkgiw" target="_blank"
+                                class="text-sm font-semibold" style="color: var(--primary);">
+                                <i class="fab fa-youtube"></i> Watch Film →
+                            </a>
+                            <a href="https://www.imdb.com/title/tt35471599/" target="_blank"
+                                class="text-sm font-semibold" style="color: var(--primary);">
+                                <i class="fab fa-imdb"></i> IMDb →
+                            </a>
+                        </div>
                     </div>
                 </div>
 


### PR DESCRIPTION
### Motivation
- Ensure the filmography is complete by adding the missing IMDb link for "Busk Life" so visitors can access its IMDb page. 
- Improve the about page portrait presentation by giving the image container more vertical room so the photo is less cropped.

### Description
- Added an IMDb link for Busk Life (`https://www.imdb.com/title/tt35471599/`) next to the YouTube link in the filmography on `index.html`, and wrapped the action links in a `div` with `class="flex gap-3"` for consistent spacing. 
- Increased the portrait container width on the about page by changing the wrapper from `max-w-md` to `max-w-2xl` in `about.html` to allow the image to display with approximately 50% more vertical space. 
- Files modified: `index.html` and `about.html`.

### Testing
- Launched a local static server with `python -m http.server 8000` and verified the site served successfully. (succeeded)
- Captured a screenshot of `http://localhost:8000/about.html` using a Playwright script to confirm the portrait layout change, producing an artifact at `artifacts/about-portrait.png`. (succeeded)
- No unit tests apply to these static HTML/CSS edits. (not applicable)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b01bfb91883239e683832f76f2bf7)