### PR TITLE
Increase about portrait height and add IMDb link for Busk Life

### DIFF
--- a/about.html
+++ b/about.html
@@ -163,7 +163,7 @@
                     <div class="relative max-w-md mx-auto">
                         <div class="absolute inset-0 bg-yellow-500/10 blur-2xl rounded-full"></div>
                         <img src="carlaboutme.jpg" alt="Portrait of filmmaker Carl Tomich"
-                            class="relative rounded-2xl shadow-2xl border border-yellow-500/40">
+                            class="relative w-full h-[540px] md:h-[600px] object-cover object-top rounded-2xl shadow-2xl border border-yellow-500/40">
                     </div>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -325,10 +325,16 @@
                             Returned to Berlin's streets a decade later. A sequel exploring how the busking scene
                             evolved and what happened to the artists.
                         </p>
-                        <a href="https://www.youtube.com/watch?v=S8L4Hmwkgiw" target="_blank"
-                            class="text-sm font-semibold" style="color: var(--primary);">
-                            <i class="fab fa-youtube"></i> Watch Film →
-                        </a>
+                        <div class="flex gap-3">
+                            <a href="https://www.youtube.com/watch?v=S8L4Hmwkgiw" target="_blank"
+                                class="text-sm font-semibold" style="color: var(--primary);">
+                                <i class="fab fa-youtube"></i> Watch Film →
+                            </a>
+                            <a href="https://www.imdb.com/title/tt35471599/" target="_blank"
+                                class="text-sm font-semibold" style="color: var(--primary);">
+                                <i class="fab fa-imdb"></i> IMDb →
+                            </a>
+                        </div>
                     </div>
                 </div>
 


### PR DESCRIPTION
### Motivation
- Ensure the filmography is complete by adding the missing IMDb entry for "Busk Life" so visitors can reach its IMDb page.
- Fix the about-page portrait cropping so the image shows more vertical content (the previous change made it wider instead of taller).

### Description
- Added an IMDb link for "Busk Life" and grouped action links in a `div` with `class="flex gap-3"` in `index.html` to keep links spaced consistently.
- Restored the portrait container width on `about.html` to `max-w-md` and applied explicit sizing and fit to the image via `class="w-full h-[540px] md:h-[600px] object-cover object-top ..."` so the photo displays taller and crops from the bottom instead of expanding horizontally.
- Minor HTML adjustments only; files modified: `index.html` and `about.html`.

### Testing
- Launched a local static server with `python -m http.server 8000` and confirmed the site served successfully (succeeded).
- Captured screenshots of `about.html` with a Playwright script to verify the portrait layout before and after the fix, producing artifacts `artifacts/about-portrait.png` and `artifacts/about-portrait-updated.png` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b01bfb91883239e683832f76f2bf7)