### PR TITLE
Fix video embeds and thumbnails for new posts

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -236,7 +236,7 @@
                 <!-- Blog Post: Living in Bangkok -->
                 <div class="blog-card rounded-xl overflow-hidden shadow-lg">
                     <div class="relative overflow-hidden h-64">
-                        <img src="https://images.unsplash.com/photo-1508004526068-ff852750729c?auto=format&fit=crop&q=80&w=800"
+                        <img src="https://img.youtube.com/vi/U41rV5x6p-Y/maxresdefault.jpg"
                             alt="Bangkok city scene"
                             class="w-full h-full object-cover transform hover:scale-110 transition-transform duration-500">
                         <div class="absolute inset-0 card-overlay"></div>
@@ -296,7 +296,7 @@
                 <!-- Blog Post: Starting Over at 40 -->
                 <div class="blog-card rounded-xl overflow-hidden shadow-lg">
                     <div class="relative overflow-hidden h-64">
-                        <img src="https://images.unsplash.com/photo-1499750310107-5fef28a66643?auto=format&fit=crop&q=80&w=800"
+                        <img src="https://img.youtube.com/vi/ttrBqi-LO2g/maxresdefault.jpg"
                             alt="Reflective writing"
                             class="w-full h-full object-cover transform hover:scale-110 transition-transform duration-500">
                         <div class="absolute inset-0 card-overlay"></div>
@@ -324,7 +324,7 @@
                 <!-- Blog Post: Grand World Hanoi -->
                 <div class="blog-card rounded-xl overflow-hidden shadow-lg">
                     <div class="relative overflow-hidden h-64">
-                        <img src="https://images.unsplash.com/photo-1627394412345-09857246057a?auto=format&fit=crop&q=80&w=800"
+                        <img src="https://img.youtube.com/vi/2ZaWPVIi8o0/maxresdefault.jpg"
                             alt="Grand World Hanoi"
                             class="w-full h-full object-cover transform hover:scale-110 transition-transform duration-500">
                         <div class="absolute inset-0 card-overlay"></div>

--- a/gear.html
+++ b/gear.html
@@ -202,7 +202,7 @@
                 <!-- Card 0: MacBook Pro M4 Max -->
                 <div class="blog-card rounded-xl overflow-hidden shadow-lg">
                     <div class="relative overflow-hidden h-64">
-                        <img src="https://images.unsplash.com/photo-1517336712461-70179aa7b186?auto=format&fit=crop&q=80&w=800"
+                        <img src="https://img.youtube.com/vi/aWhkZBogql8/maxresdefault.jpg"
                             alt="MacBook Pro M4 Max"
                             class="w-full h-full object-cover transform hover:scale-110 transition-transform duration-500">
                         <div class="absolute inset-0 card-overlay"></div>
@@ -237,7 +237,7 @@
                 <!-- Card 0.5: Sony FX30 Setup Guide -->
                 <div class="blog-card rounded-xl overflow-hidden shadow-lg">
                     <div class="relative overflow-hidden h-64">
-                        <img src="https://images.unsplash.com/photo-1516035069371-29a1b244cc32?auto=format&fit=crop&q=80&w=800"
+                        <img src="https://img.youtube.com/vi/kNs-mxT_3eE/maxresdefault.jpg"
                             alt="Sony FX30 Cinema Camera"
                             class="w-full h-full object-cover transform hover:scale-110 transition-transform duration-500">
                         <div class="absolute inset-0 card-overlay"></div>

--- a/grand-world-hanoi-guide.html
+++ b/grand-world-hanoi-guide.html
@@ -14,6 +14,7 @@
     <meta name="keywords"
         content="grand world hanoi, hanoi travel guide, things to do in hanoi, vinhome ocean park 3, hanoi venice, vietnam travel 2025">
     <meta name="author" content="Carl Ostomich">
+    <meta property="og:image" content="https://img.youtube.com/vi/2ZaWPVIi8o0/maxresdefault.jpg">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <script src="https://cdn.tailwindcss.com"></script>
     <style>
@@ -38,7 +39,7 @@
         }
 
         .hero-section {
-            background: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url('https://images.unsplash.com/photo-1627394412345-09857246057a?auto=format&fit=crop&q=80&w=1200');
+            background: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url('https://img.youtube.com/vi/2ZaWPVIi8o0/maxresdefault.jpg');
             background-size: cover;
             background-position: center;
         }
@@ -186,7 +187,7 @@
             </p>
 
             <div class="aspect-video rounded-2xl overflow-hidden shadow-xl mb-12">
-                <iframe class="w-full h-full" src="https://www.youtube.com/embed/Izha3ONStb4"
+                <iframe class="w-full h-full" src="https://www.youtube.com/embed/2ZaWPVIi8o0"
                     title="Grand World Hanoi Drone Tour" frameborder="0"
                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                     allowfullscreen></iframe>

--- a/living-in-bangkok.html
+++ b/living-in-bangkok.html
@@ -14,6 +14,7 @@
     <meta name="keywords"
         content="living in bangkok, digital nomad bangkok, bangkok cost of living 2025, expat guide bangkok, bangkok vs hanoi, thailand dtv visa" />
     <meta name="author" content="Carl Ostomich">
+    <meta property="og:image" content="https://img.youtube.com/vi/U41rV5x6p-Y/maxresdefault.jpg">
     <!-- External Resources -->
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
@@ -39,7 +40,7 @@
         }
 
         .hero-bg {
-            background: linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.6)), url('https://images.unsplash.com/photo-1508004526068-ff852750729c?auto=format&fit=crop&q=80&w=1200');
+            background: linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.6)), url('https://img.youtube.com/vi/U41rV5x6p-Y/maxresdefault.jpg');
             background-size: cover;
             background-position: center;
         }
@@ -208,7 +209,7 @@
                     <div class="border-t border-gray-200 pt-16 mt-20">
                         <h3 class="text-2xl font-bold mb-6">Watch the Vlog: My First Month in Bangkok</h3>
                         <div class="aspect-video rounded-3xl overflow-hidden shadow-2xl mb-12 bg-black">
-                            <iframe class="w-full h-full" src="https://www.youtube.com/embed/Izha3ONStb4"
+                            <iframe class="w-full h-full" src="https://www.youtube.com/embed/U41rV5x6p-Y"
                                 title="Living in Bangkok Guide" frameborder="0"
                                 allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                                 allowfullscreen></iframe>

--- a/macbook-pro-m4-max-review.html
+++ b/macbook-pro-m4-max-review.html
@@ -12,7 +12,7 @@
     <meta property="og:title" content="MacBook Pro M4 Max Review (2025): A Video Editor's Dream Machine?" />
     <meta property="og:description"
         content="Is the M4 Max worth the upgrade? I put the new MacBook Pro through its paces with 8K footage and complex timelines. Here is the verdict." />
-    <meta property="og:image" content="https://www.carltravels.com/images/m4max-review.jpg" />
+    <meta property="og:image" content="https://img.youtube.com/vi/aWhkZBogql8/maxresdefault.jpg" />
     <meta property="og:url" content="https://www.carltravels.com/macbook-pro-m4-max-review.html" />
     <meta property="og:type" content="article" />
     <meta name="twitter:card" content="summary_large_image" />
@@ -79,6 +79,10 @@
 
     <main class="py-20 px-6">
         <div class="max-w-5xl mx-auto space-y-16">
+            <section class="overflow-hidden rounded-3xl shadow-2xl border border-white/10">
+                <img src="https://img.youtube.com/vi/aWhkZBogql8/maxresdefault.jpg"
+                    alt="MacBook Pro M4 Max review video thumbnail" class="w-full h-full object-cover">
+            </section>
             <!-- Summary Card -->
             <section class="info-card">
                 <h2 class="text-3xl font-bold text-white mb-6 heading-font tracking-wide">Quick Verdict</h2>
@@ -196,6 +200,16 @@
                     <a href="https://amzn.to/m4max-link"
                         class="px-8 py-3 border border-yellow-400 text-yellow-400 rounded-full font-bold hover:bg-yellow-400 hover:text-black transition-all">View
                         on Amazon</a>
+                </div>
+            </section>
+
+            <section class="space-y-6">
+                <h2 class="text-3xl font-bold text-white heading-font">Watch the Review</h2>
+                <div class="aspect-video rounded-3xl overflow-hidden shadow-2xl border border-white/10">
+                    <iframe class="w-full h-full" src="https://www.youtube.com/embed/aWhkZBogql8"
+                        title="MacBook Pro M4 Max Review" frameborder="0"
+                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                        allowfullscreen></iframe>
                 </div>
             </section>
 

--- a/sony-fx30-setup-guide.html
+++ b/sony-fx30-setup-guide.html
@@ -12,7 +12,7 @@
     <meta property="og:title" content="Sony FX30 Setup Guide: The Best Settings for Filmmakers (2025)" />
     <meta property="og:description"
         content="Stop guessing your settings. Here is my proven Sony FX30 setup for professional documentary and travel films." />
-    <meta property="og:image" content="https://www.carltravels.com/images/fx30-setup-guide.jpg" />
+    <meta property="og:image" content="https://img.youtube.com/vi/kNs-mxT_3eE/maxresdefault.jpg" />
     <meta property="og:url" content="https://www.carltravels.com/sony-fx30-setup-guide.html" />
     <meta property="og:type" content="article" />
     <script src="https://cdn.tailwindcss.com"></script>
@@ -104,6 +104,10 @@
 
             <!-- Content Area -->
             <div class="lg:col-span-3 prose prose-invert max-w-none">
+                <div class="mb-12 overflow-hidden rounded-3xl border border-white/10 shadow-2xl">
+                    <img src="https://img.youtube.com/vi/kNs-mxT_3eE/maxresdefault.jpg"
+                        alt="Sony FX30 setup guide video thumbnail" class="w-full h-full object-cover">
+                </div>
                 <section id="cine-ei" class="mb-16">
                     <h2 class="text-3xl mb-6">1. Mastering Cine EI Mode</h2>
                     <p>
@@ -213,6 +217,16 @@
                                     &rarr;</a>
                             </div>
                         </div>
+                    </div>
+                </section>
+
+                <section class="my-16">
+                    <h2 class="text-3xl mb-6">Watch the Full Setup Guide</h2>
+                    <div class="aspect-video rounded-3xl overflow-hidden shadow-2xl border border-white/10">
+                        <iframe class="w-full h-full" src="https://www.youtube.com/embed/kNs-mxT_3eE"
+                            title="Sony FX30 Setup Guide" frameborder="0"
+                            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                            allowfullscreen></iframe>
                     </div>
                 </section>
 

--- a/starting-over-at-40.html
+++ b/starting-over-at-40.html
@@ -18,7 +18,7 @@
     <meta property="og:title" content="I Wasted My 30s. Now I’m Starting Over at 40 - Carl Travels">
     <meta property="og:description"
         content="Is it too late to change? Carl shares his honest experience of hitting 40 and deciding to burn it all down to start something real.">
-    <meta property="og:image" content="https://www.carltravels.com/images/starting-over-40.jpg">
+    <meta property="og:image" content="https://img.youtube.com/vi/ttrBqi-LO2g/maxresdefault.jpg">
     <meta property="og:url" content="https://www.carltravels.com/starting-over-at-40.html">
     <meta property="og:type" content="article">
     <!-- Twitter Card Meta Tags -->
@@ -134,6 +134,10 @@
     <section id="article" class="py-24 bg-white">
         <div class="container mx-auto px-6 max-w-4xl">
             <div class="prose max-w-none text-gray-700 leading-relaxed">
+                <div class="mb-10">
+                    <img src="https://img.youtube.com/vi/ttrBqi-LO2g/maxresdefault.jpg"
+                        alt="Starting Over at 40 video thumbnail" class="w-full rounded-3xl shadow-xl">
+                </div>
                 <p class="text-xl font-medium text-gray-900 mb-8">
                     There is a specific kind of panic that hits you when the first digit of your age changes from a 3 to
                     a 4. It’s not just about the gray hairs or the slower recovery after a workout. It’s the sudden,
@@ -264,7 +268,7 @@
                 <div class="text-center mb-20">
                     <h3 class="text-2xl font-bold text-gray-900 mb-4 heading-font">Watch the Vlog</h3>
                     <div class="aspect-video rounded-3xl overflow-hidden shadow-2xl mb-6">
-                        <iframe class="w-full h-full" src="https://www.youtube.com/embed/Izha3ONStb4"
+                        <iframe class="w-full h-full" src="https://www.youtube.com/embed/ttrBqi-LO2g"
                             title="Starting Over at 40" frameborder="0"
                             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                             allowfullscreen></iframe>


### PR DESCRIPTION
### Motivation
- Correct several blog and gear pages that were embedding the wrong YouTube videos and using incorrect header/hero imagery/OG images.
- Ensure the new posts use their corresponding video thumbnails as hero/featured images in listings and social metadata so previews match the embedded videos.

### Description
- Updated the YouTube embed `src` URLs in `starting-over-at-40.html`, `grand-world-hanoi-guide.html`, and `living-in-bangkok.html` to the correct video IDs and replaced the old embeds pointing to `Izha3ONStb4` with the requested IDs.
- Replaced hero/background images and `og:image` meta tags with YouTube thumbnail URLs for `starting-over-at-40.html`, `grand-world-hanoi-guide.html`, `living-in-bangkok.html`, `macbook-pro-m4-max-review.html`, and `sony-fx30-setup-guide.html`.
- Added inline thumbnail image sections and new video embed sections to the MacBook and Sony review pages (`macbook-pro-m4-max-review.html` and `sony-fx30-setup-guide.html`) so the review pages show the video thumbnail and an embedded player.
- Swapped the listing/featured images on `blog.html` and `gear.html` to use the corresponding YouTube thumbnail images for the related posts and gear cards.

### Testing
- Served the site locally with `python -m http.server 8000` and ran a Playwright script to capture screenshots of the `gear.html` and `starting-over-at-40.html` pages; screenshots `artifacts/gear-page.png` and `artifacts/starting-over-at-40.png` were produced successfully after re-running the script following an initial timeout.
- Performed repository checks with `rg`/`nl` to verify updated `og:image` and `iframe` occurrences and confirmed the seven modified files (`blog.html`, `gear.html`, `grand-world-hanoi-guide.html`, `living-in-bangkok.html`, `macbook-pro-m4-max-review.html`, `sony-fx30-setup-guide.html`, `starting-over-at-40.html`) contain the intended changes.
- All automated verification steps completed and screenshots were generated successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698326a863388323aba7837dcff39fa2)