### PR TITLE
Add Saily affiliate callout to blog and travel posts

### DIFF
--- a/7 ways to find cheap accomodation while traveling.html
+++ b/7 ways to find cheap accomodation while traveling.html
@@ -325,6 +325,16 @@ Curiosity-driven: The cheapest stays I found weren’t on booking sites
 
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/Berlin.html
+++ b/Berlin.html
@@ -378,6 +378,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/DJI-Flip-review.html
+++ b/DJI-Flip-review.html
@@ -315,6 +315,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/Hagiangloop.html
+++ b/Hagiangloop.html
@@ -440,6 +440,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/Hifuinhanoi.html
+++ b/Hifuinhanoi.html
@@ -439,6 +439,16 @@ Curiosity-driven: The moment I decided HIFU was worth trying
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/aiarty-image-enhancer-review.html
+++ b/aiarty-image-enhancer-review.html
@@ -144,5 +144,15 @@
             </section>
         </div>
     </main>
+
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
 </body>
 </html>

--- a/aiarty-video-enhancer-review.html
+++ b/aiarty-video-enhancer-review.html
@@ -484,6 +484,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/aiarty-vs-topaz-video-ai.html
+++ b/aiarty-vs-topaz-video-ai.html
@@ -175,5 +175,15 @@
             </section>
         </div>
     </main>
+
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
 </body>
 </html>

--- a/balitravelguide.html
+++ b/balitravelguide.html
@@ -628,6 +628,16 @@ Curiosity-driven: The Bali spot that still feels calm
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/becomingadigitalnomad.html
+++ b/becomingadigitalnomad.html
@@ -563,6 +563,16 @@ Curiosity-driven: The one country I didn’t expect to be so affordable
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/beginners-guide-davinci-resolve-2025.html
+++ b/beginners-guide-davinci-resolve-2025.html
@@ -442,6 +442,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/best-cafes-in-tay-ho-for-digital-nomads.html
+++ b/best-cafes-in-tay-ho-for-digital-nomads.html
@@ -416,6 +416,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/blog/horse-riding-near-hanoi-countryside-experience.html
+++ b/blog/horse-riding-near-hanoi-countryside-experience.html
@@ -244,5 +244,15 @@
             }
         });
     </script>
+
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
 </body>
 </html>

--- a/bose-s1pro-plus-vs-everse8-the-best-portable-speaker.html
+++ b/bose-s1pro-plus-vs-everse8-the-best-portable-speaker.html
@@ -513,6 +513,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/budvatravelguide.html
+++ b/budvatravelguide.html
@@ -534,6 +534,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/buskingguide.html
+++ b/buskingguide.html
@@ -451,6 +451,16 @@ Curiosity-driven: The busking tip that doubled my earnings
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/cairnstravelguide.html
+++ b/cairnstravelguide.html
@@ -465,6 +465,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/danangtravelguide.html
+++ b/danangtravelguide.html
@@ -573,6 +573,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/dating-in-vietnam.html
+++ b/dating-in-vietnam.html
@@ -347,6 +347,16 @@
     </section>
 
     <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12 bg-gray-900 text-gray-400 border-t border-gray-800">
         <div class="container mx-auto px-6 text-center">
             <h3 class="heading-font text-2xl mb-4 text-yellow-500">CARL TOMICH</h3>

--- a/dji-mini-3-pro-review.html
+++ b/dji-mini-3-pro-review.html
@@ -441,6 +441,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/electro-voice-everse-8-review.html
+++ b/electro-voice-everse-8-review.html
@@ -117,5 +117,15 @@
             </section>
         </div>
     </main>
+
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
 </body>
 </html>

--- a/farnorthqueenslandtravelguide.html
+++ b/farnorthqueenslandtravelguide.html
@@ -501,6 +501,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/finedininginhanoi.html
+++ b/finedininginhanoi.html
@@ -273,6 +273,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/grand-world-hanoi-guide.html
+++ b/grand-world-hanoi-guide.html
@@ -216,6 +216,16 @@
             </div>
         </section>
     </main>
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
 
     <footer class="bg-gray-900 py-16 text-white border-t border-gray-800 mt-20">
         <div class="container mx-auto px-6 text-center">

--- a/ha-long-bay-travel-guide/index.html
+++ b/ha-long-bay-travel-guide/index.html
@@ -511,6 +511,16 @@
 
     <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/hanoi-by-night.html
+++ b/hanoi-by-night.html
@@ -253,6 +253,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/hanoitravelguide.html
+++ b/hanoitravelguide.html
@@ -642,6 +642,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/hiroshima-travel-guide.html
+++ b/hiroshima-travel-guide.html
@@ -429,6 +429,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/hon-chong-rocks-nha-trang.html
+++ b/hon-chong-rocks-nha-trang.html
@@ -261,6 +261,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/how-to-get-croatian-citizenship-by-descent.html
+++ b/how-to-get-croatian-citizenship-by-descent.html
@@ -482,6 +482,16 @@ Curiosity-driven: The document that slowed my Croatia application
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/how-to-get-croatian-citizenship-through-your-grandparent.html
+++ b/how-to-get-croatian-citizenship-through-your-grandparent.html
@@ -377,6 +377,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/how-to-make-your-videos-look-cinematic.html
+++ b/how-to-make-your-videos-look-cinematic.html
@@ -226,6 +226,16 @@ Curiosity-driven: The one tweak that made my footage feel less digital
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/howtofoldapopuptent.html
+++ b/howtofoldapopuptent.html
@@ -308,6 +308,16 @@ Curiosity-driven: The folding move that finally made the tent behave
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/howtomakemoneyonlinesellingstockfootage.html
+++ b/howtomakemoneyonlinesellingstockfootage.html
@@ -432,6 +432,16 @@ Curiosity-driven: The stock footage clip that keeps selling
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/japanonabudget.html
+++ b/japanonabudget.html
@@ -383,6 +383,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/korcula.html
+++ b/korcula.html
@@ -454,6 +454,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/kyototravelguide.html
+++ b/kyototravelguide.html
@@ -534,6 +534,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/living-in-bangkok.html
+++ b/living-in-bangkok.html
@@ -219,6 +219,16 @@
             </div>
         </div>
     </main>
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
 
     <footer class="bg-gray-900 py-20 text-white border-t border-gray-800">
         <div class="container mx-auto px-6 text-center">

--- a/lotte-world-aquarium-hanoi.html
+++ b/lotte-world-aquarium-hanoi.html
@@ -312,6 +312,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/macbook-pro-m4-max-review.html
+++ b/macbook-pro-m4-max-review.html
@@ -233,6 +233,16 @@
             </section>
         </div>
     </main>
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
 
     <footer class="py-12 bg-slate-950 border-t border-white/5 text-center">
         <p class="text-xs text-slate-500 uppercase tracking-widest mb-4">© 2025 Carl Tomich | Travel & Tech</p>

--- a/make-money-online-while-traveling.html
+++ b/make-money-online-while-traveling.html
@@ -352,6 +352,16 @@ Curiosity-driven: The income stream I expected to work that didn’t
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/melbournetravelguide.html
+++ b/melbournetravelguide.html
@@ -432,6 +432,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/mytop10travelhacks.html
+++ b/mytop10travelhacks.html
@@ -417,6 +417,16 @@ Curiosity-driven: The travel hack that saved me the most last year
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/ninhbinhtravelguide.html
+++ b/ninhbinhtravelguide.html
@@ -431,6 +431,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/nusa-lembongan-travel-guide/index.html
+++ b/nusa-lembongan-travel-guide/index.html
@@ -545,6 +545,16 @@
 
     <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/nusalembongan.html
+++ b/nusalembongan.html
@@ -396,6 +396,16 @@
     <!-- Footer Section -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/old-quarter-scams-hanoi.html
+++ b/old-quarter-scams-hanoi.html
@@ -435,6 +435,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/one-day-in-hcmc-guide.html
+++ b/one-day-in-hcmc-guide.html
@@ -375,6 +375,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/osakatravelguide.html
+++ b/osakatravelguide.html
@@ -489,6 +489,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/phuketravelguide.html
+++ b/phuketravelguide.html
@@ -463,6 +463,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/port-douglas-travel-guide/index.html
+++ b/port-douglas-travel-guide/index.html
@@ -543,6 +543,16 @@
 
     <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/portdouglas.html
+++ b/portdouglas.html
@@ -545,6 +545,16 @@
                         "Port Douglas is a paradise! The marina is bustling with life, and the beaches are absolutely stunning."
                             <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/pros-and-cons-and-cost-of-living-in-hanoi.html
+++ b/pros-and-cons-and-cost-of-living-in-hanoi.html
@@ -488,6 +488,16 @@ Curiosity-driven: The Hanoi trade-off I didn’t expect at first
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/saily-e-simguide.html
+++ b/saily-e-simguide.html
@@ -154,6 +154,16 @@
 
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/sapa-travel-guide.html
+++ b/sapa-travel-guide.html
@@ -274,6 +274,16 @@
 
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/somnipods-3-review.html
+++ b/somnipods-3-review.html
@@ -422,6 +422,16 @@
     </section>
 
     <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/sony-a7cii-review.html
+++ b/sony-a7cii-review.html
@@ -423,6 +423,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/sony-a7iii-review-2025.html
+++ b/sony-a7iii-review-2025.html
@@ -117,5 +117,15 @@
             </section>
         </div>
     </main>
+
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
 </body>
 </html>

--- a/sony-fx30-setup-guide.html
+++ b/sony-fx30-setup-guide.html
@@ -252,6 +252,16 @@
             </div>
         </div>
     </main>
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
 
     <footer class="py-20 bg-black border-t border-white/5">
         <div class="container mx-auto px-6 text-center">

--- a/starting-over-at-40.html
+++ b/starting-over-at-40.html
@@ -279,6 +279,16 @@
     </section>
 
     <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-20 bg-gray-900 text-white">
         <div class="container mx-auto px-6 text-center">
             <h2 class="heading-font text-4xl mb-6 text-yellow-500">CARL TOMICH</h2>

--- a/tech-review-dji-mavic3.html
+++ b/tech-review-dji-mavic3.html
@@ -408,6 +408,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/tech-review-sony-a7siii.html
+++ b/tech-review-sony-a7siii.html
@@ -414,6 +414,16 @@
 
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/tech-review-zhiyun-weebill2.html
+++ b/tech-review-zhiyun-weebill2.html
@@ -320,6 +320,16 @@
 
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/the-reality-of-living-overseas.html
+++ b/the-reality-of-living-overseas.html
@@ -292,6 +292,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/thebesttemplesinhanoi.html
+++ b/thebesttemplesinhanoi.html
@@ -379,6 +379,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/things-to-know-before-moving-to-vietnam.html
+++ b/things-to-know-before-moving-to-vietnam.html
@@ -362,6 +362,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/tokyotravelguide.html
+++ b/tokyotravelguide.html
@@ -546,6 +546,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/tolifo-100w-rgb-light-review.html
+++ b/tolifo-100w-rgb-light-review.html
@@ -383,6 +383,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/top-10-things-to-do-in-hanoi.html
+++ b/top-10-things-to-do-in-hanoi.html
@@ -360,6 +360,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/travel-gear-2025.html
+++ b/travel-gear-2025.html
@@ -273,6 +273,16 @@ Curiosity-driven: The small piece of gear that saves my shoots
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/vietnam-e-visa-2026-guide.html
+++ b/vietnam-e-visa-2026-guide.html
@@ -396,6 +396,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/vinwonders-nha-trang.html
+++ b/vinwonders-nha-trang.html
@@ -393,6 +393,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/what-i-learned-after-returning-to-australia-and-why-i-LEFT-again.html
+++ b/what-i-learned-after-returning-to-australia-and-why-i-LEFT-again.html
@@ -309,6 +309,16 @@
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/whyileftaustralia.html
+++ b/whyileftaustralia.html
@@ -333,6 +333,16 @@ Curiosity-driven: The moment I knew I had to leave Australia
     <!-- Footer -->
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">

--- a/yesim-guide.html
+++ b/yesim-guide.html
@@ -360,6 +360,16 @@ Curiosity-driven: The small eSIM detail that made travel days easier
 
         <!-- Footer -->
         <!-- Footer -->
+    <!-- Saily Affiliate -->
+    <section class="max-w-4xl mx-auto px-6 py-10">
+        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
+            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
+            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
+        </div>
+    </section>
+
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">


### PR DESCRIPTION
### Motivation
- Add a short, styled affiliate callout for Saily eSIM across article and travel-guide pages so readers see a clear CTA before each page footer.
- Target blog posts, travel guides and representative index pages (including travel-guide `index.html` variants) to maximize visibility.

### Description
- Inserted a reusable HTML affiliate block (heading, short description and CTA link to `https://go.saily.site/aff_c?offer_id=101&aff_id=12234`) immediately before the site footer on article and guide pages.  
- Applied the snippet to the site HTML files (script-run update across the site updated 72 files).  
- Excluded core non-article pages from insertion via an exclusion list in the insertion script (e.g. `index.html`, `about.html`, `contact.html`, `blog.html`, etc.).  
- Committed the changes with a message: `Add Saily affiliate callout to posts`.

### Testing
- Ran the insertion script which reported `Updated 72 files`, and verified presence of the marker `<!-- Saily Affiliate -->` in sample pages such as `hanoitravelguide.html`, `ha-long-bay-travel-guide/index.html`, and `blog/horse-riding-near-hanoi-countryside-experience.html`. (search/grep checks succeeded).  
- Started a local HTTP server with `python -m http.server 8000` and used Playwright to open `http://127.0.0.1:8000/hanoitravelguide.html` and capture a full-page screenshot to validate rendering; the screenshot artifact was produced successfully.  
- Committed the changes to the repository; the commit completed successfully. All automated checks above completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983292d86188323895a787780a32c8e)