### PR TITLE
Add Dating in Vietnam video embed and thumbnail

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -267,8 +267,8 @@
                 <!-- Blog Post: Dating in Vietnam -->
                 <div class="blog-card rounded-xl overflow-hidden shadow-lg">
                     <div class="relative overflow-hidden h-64">
-                        <img src="https://images.unsplash.com/photo-1528127269322-539801943592?auto=format&fit=crop&q=80&w=800"
-                            alt="Vietnam street scene"
+                        <img src="https://img.youtube.com/vi/HlHWvo1Yw14/maxresdefault.jpg"
+                            alt="Dating in Vietnam video thumbnail"
                             class="w-full h-full object-cover transform hover:scale-110 transition-transform duration-500">
                         <div class="absolute inset-0 card-overlay"></div>
                         <div class="absolute bottom-0 left-0 p-6 text-white">

--- a/dating-in-vietnam.html
+++ b/dating-in-vietnam.html
@@ -18,7 +18,7 @@
     <meta property="og:title" content="Dating in Vietnam: An Honest Guide for Expats & Nomads - Carl Travels">
     <meta property="og:description"
         content="What is dating in Vietnam actually like for a foreigner? Carl shares his honest experiences, the culture, the apps, and what to expect.">
-    <meta property="og:image" content="https://www.carltravels.com/images/dating-vietnam.jpg">
+    <meta property="og:image" content="https://img.youtube.com/vi/HlHWvo1Yw14/maxresdefault.jpg">
     <meta property="og:url" content="https://www.carltravels.com/dating-in-vietnam.html">
     <meta property="og:type" content="article">
     <!-- Twitter Card Meta Tags -->
@@ -165,6 +165,25 @@
                     </div>
 
                     <div class="prose max-w-none text-gray-600">
+                        <figure class="mb-10">
+                            <a href="https://youtu.be/HlHWvo1Yw14" target="_blank" rel="noopener noreferrer">
+                                <img src="https://img.youtube.com/vi/HlHWvo1Yw14/maxresdefault.jpg"
+                                    alt="Dating in Vietnam video thumbnail"
+                                    class="w-full rounded-xl shadow-lg">
+                            </a>
+                            <figcaption class="text-sm text-gray-500 mt-3 text-center">
+                                Watch: Dating in Vietnam — honest insights and real-world experiences.
+                            </figcaption>
+                        </figure>
+                        <div class="relative w-full overflow-hidden rounded-xl shadow-lg mb-10"
+                            style="padding-top: 56.25%;">
+                            <iframe class="absolute top-0 left-0 w-full h-full"
+                                src="https://www.youtube.com/embed/HlHWvo1Yw14"
+                                title="Dating in Vietnam"
+                                frameborder="0"
+                                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                                allowfullscreen></iframe>
+                        </div>
                         <p class="mb-6">
                             If you spend enough time as a digital nomad or expat in Vietnam, the question of dating
                             eventually comes up. Whether you're in the bustling streets of Saigon (HCMC) or the historic


### PR DESCRIPTION
### Motivation
- Improve engagement by embedding the YouTube video for the "Dating in Vietnam" article and using the video thumbnail as the article preview image and Open Graph image.
- Keep the blog listing visually consistent by replacing the blog-card image with the video's thumbnail so readers can immediately identify the video content.

### Description
- Updated the article Open Graph image meta to point to the YouTube thumbnail at `https://img.youtube.com/vi/HlHWvo1Yw14/maxresdefault.jpg` in `dating-in-vietnam.html`.
- Inserted a linked thumbnail figure and a responsive YouTube `iframe` embed for `HlHWvo1Yw14` at the top of the article in `dating-in-vietnam.html`.
- Replaced the Dating in Vietnam blog card image in `blog.html` with the same YouTube thumbnail and updated the `alt` text.
- Minor layout uses existing classes to keep the embed responsive and styled consistently with the site.

### Testing
- Started a local server with `python -m http.server 8000` and the site served successfully (manual automated run during validation).
- Ran a Playwright script to visit `http://127.0.0.1:8000/dating-in-vietnam.html` and captured a full-page screenshot which produced `artifacts/dating-in-vietnam-video.png`, indicating the embed and thumbnail render correctly.
- Performed `git` operations (`git status`, `git add`, `git commit`) and the changes were committed successfully; no unit tests exist for this static content change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69832b243d748323b80527186cdda6a7)