### PR TITLE
Add CARL10 Saily discount line, remove Saily block from Yesim guide, standardize header/footer

### DIFF
--- a/7 ways to find cheap accomodation while traveling.html
+++ b/7 ways to find cheap accomodation while traveling.html
@@ -331,6 +331,7 @@ Curiosity-driven: The cheapest stays I found weren’t on booking sites
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/Berlin.html
+++ b/Berlin.html
@@ -384,6 +384,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/DJI-Flip-review.html
+++ b/DJI-Flip-review.html
@@ -321,6 +321,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/Hagiangloop.html
+++ b/Hagiangloop.html
@@ -446,6 +446,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/Hifuinhanoi.html
+++ b/Hifuinhanoi.html
@@ -445,6 +445,7 @@ Curiosity-driven: The moment I decided HIFU was worth trying
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/aiarty-image-enhancer-review.html
+++ b/aiarty-image-enhancer-review.html
@@ -151,6 +151,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/aiarty-video-enhancer-review.html
+++ b/aiarty-video-enhancer-review.html
@@ -490,6 +490,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/aiarty-vs-topaz-video-ai.html
+++ b/aiarty-vs-topaz-video-ai.html
@@ -182,6 +182,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/balitravelguide.html
+++ b/balitravelguide.html
@@ -634,6 +634,7 @@ Curiosity-driven: The Bali spot that still feels calm
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/becomingadigitalnomad.html
+++ b/becomingadigitalnomad.html
@@ -569,6 +569,7 @@ Curiosity-driven: The one country I didn’t expect to be so affordable
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/beginners-guide-davinci-resolve-2025.html
+++ b/beginners-guide-davinci-resolve-2025.html
@@ -448,6 +448,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/best-cafes-in-tay-ho-for-digital-nomads.html
+++ b/best-cafes-in-tay-ho-for-digital-nomads.html
@@ -422,6 +422,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/bose-s1pro-plus-vs-everse8-the-best-portable-speaker.html
+++ b/bose-s1pro-plus-vs-everse8-the-best-portable-speaker.html
@@ -519,6 +519,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/budvatravelguide.html
+++ b/budvatravelguide.html
@@ -540,6 +540,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/buskingguide.html
+++ b/buskingguide.html
@@ -457,6 +457,7 @@ Curiosity-driven: The busking tip that doubled my earnings
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/cairnstravelguide.html
+++ b/cairnstravelguide.html
@@ -471,6 +471,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/danangtravelguide.html
+++ b/danangtravelguide.html
@@ -579,6 +579,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/dating-in-vietnam.html
+++ b/dating-in-vietnam.html
@@ -106,23 +106,42 @@
                 <a href="/index.html" class="text-2xl font-bold">
                     <span class="heading-font" style="color: var(--primary);">CARL TOMICH</span>
                 </a>
+
                 <div class="hidden md:flex items-center space-x-8">
                     <a href="/index.html" class="nav-link font-medium">Films</a>
                     <a href="/portfolio.html" class="nav-link font-medium">Portfolio</a>
+                    <a href="/films/martial-arts-documentary.html" class="nav-link font-medium">Current Project</a>
                     <a href="/blog.html" class="nav-link font-medium">Blog</a>
                     <a href="/gear.html" class="nav-link font-medium">Gear</a>
                     <a href="/destinations.html" class="nav-link font-medium">Travel</a>
                     <a href="/about.html" class="nav-link font-medium">About</a>
                     <a href="/donate.html" class="nav-link font-medium" style="color: var(--primary);">Donate</a>
                 </div>
-                <button id="mobile-menu-button" class="md:hidden focus:outline-none" style="color: var(--secondary);">
+
+                <button id="mobile-menu-button" class="md:hidden focus:outline-none" style="color: var(--light);">
                     <i class="fas fa-bars text-2xl"></i>
                 </button>
+            </div>
+
+            <div id="mobile-menu" class="mobile-menu md:hidden">
+                <div class="pt-4 pb-2 space-y-2">
+                    <a href="/index.html" class="block px-3 py-2 rounded-md nav-link">Films</a>
+                    <a href="/portfolio.html" class="block px-3 py-2 rounded-md nav-link">Portfolio</a>
+                    <a href="/films/martial-arts-documentary.html" class="block px-3 py-2 rounded-md nav-link">Current
+                        Project</a>
+                    <a href="/blog.html" class="block px-3 py-2 rounded-md nav-link">Blog</a>
+                    <a href="/gear.html" class="block px-3 py-2 rounded-md nav-link">Gear</a>
+                    <a href="/destinations.html" class="block px-3 py-2 rounded-md nav-link">Travel</a>
+                    <a href="/about.html" class="block px-3 py-2 rounded-md nav-link">About</a>
+                    <a href="/donate.html" class="block px-3 py-2 rounded-md nav-link"
+                        style="color: var(--primary);">Donate</a>
+                </div>
             </div>
         </div>
     </nav>
 
     <!-- Hero Section -->
+
     <section class="hero-gradient relative overflow-hidden min-h-[60vh] flex items-center pt-20">
         <div class="wave-shape">
             <svg data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 120"
@@ -372,35 +391,107 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>
 
-    <footer class="py-12 bg-gray-900 text-gray-400 border-t border-gray-800">
-        <div class="container mx-auto px-6 text-center">
-            <h3 class="heading-font text-2xl mb-4 text-yellow-500">CARL TOMICH</h3>
-            <p class="text-sm mb-6">Documentary Filmmaker & Digital Nomad</p>
-            <div class="flex justify-center space-x-6 mb-8">
-                <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="hover:text-white"><i
-                        class="fab fa-youtube text-2xl"></i></a>
-                <a href="https://www.instagram.com/carlostomich" target="_blank" class="hover:text-white"><i
-                        class="fab fa-instagram text-2xl"></i></a>
+    <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
+        <div class="container mx-auto px-6">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
+                <div>
+                    <h3 class="heading-font text-2xl mb-4" style="color: var(--primary);">CARL TOMICH</h3>
+                    <p class="mb-4 text-sm" style="color: var(--light);">Documentary Filmmaker</p>
+                    <p class="text-sm" style="color: var(--muted);">Engineering extreme life projects and turning them
+                        into films since 2014.</p>
+                </div>
+                <div>
+                    <h3 class="font-semibold mb-4" style="color: var(--light);">Films</h3>
+                    <ul class="space-y-2 text-sm">
+                        <li><a href="https://www.youtube.com/watch?v=WjtMEQx34NE" target="_blank"
+                                class="nav-link">Busking for Berlin (2014)</a></li>
+                        <li><a href="https://www.youtube.com/watch?v=6iDgajITe6Q" target="_blank" class="nav-link">A
+                                Sail Untold (2022)</a></li>
+                        <li><a href="https://www.youtube.com/watch?v=S8L4Hmwkgiw" target="_blank" class="nav-link">Busk
+                                Life (2024)</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="font-semibold mb-4" style="color: var(--light);">Explore</h3>
+                    <ul class="space-y-2 text-sm">
+                        <li><a href="/about.html" class="nav-link">About</a></li>
+                        <li><a href="/blog.html" class="nav-link">Essays</a></li>
+                        <li><a href="/gear.html" class="nav-link">Gear</a></li>
+                        <li><a href="/destinations.html" class="nav-link">Travel Guides</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="font-semibold mb-4" style="color: var(--light);">Connect</h3>
+                    <div class="flex space-x-4 mb-4">
+                        <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="nav-link text-2xl"><i
+                                class="fab fa-youtube"></i></a>
+                        <a href="https://www.instagram.com/carlostomich" target="_blank" class="nav-link text-2xl"><i
+                                class="fab fa-instagram"></i></a>
+                    </div>
+                </div>
             </div>
-            <p class="text-xs">© 2025 Carl Tomich. All rights reserved.</p>
+            <div class="border-t mt-12 pt-8 flex flex-col md:flex-row justify-between items-center"
+                style="border-color: var(--dark-3);">
+                <p class="text-sm mb-4 md:mb-0" style="color: var(--muted);">© 2025 Carl Tomich. All rights reserved.
+                </p>
+                <div class="flex space-x-6">
+                    <a href="/privacy-policy.html" class="text-sm nav-link">Privacy Policy</a>
+                    <a href="/terms-and-conditions.html" class="text-sm nav-link">Terms of Service</a>
+                </div>
+            </div>
         </div>
     </footer>
 
+    <!-- Back to Top Button -->
+    <button id="back-to-top"
+        class="fixed bottom-8 right-8 w-12 h-12 bg-gradient-to-r from-yellow-500 to-amber-600 text-white rounded-full shadow-lg flex items-center justify-center transition-all opacity-0 invisible">
+        <i class="fas fa-arrow-up"></i>
+    </button>
+
     <script>
-        // Simple Navbar Scroll Effect
-        window.addEventListener('scroll', function () {
+        document.addEventListener('DOMContentLoaded', function () {
+            const mobileMenuButton = document.getElementById('mobile-menu-button');
+            const mobileMenu = document.getElementById('mobile-menu');
+            if (mobileMenuButton && mobileMenu) {
+                mobileMenuButton.addEventListener('click', function () {
+                    mobileMenu.classList.toggle('open');
+                });
+            }
+
             const navbar = document.getElementById('navbar');
-            if (window.scrollY > 50) {
-                navbar.classList.add('scrolled');
-            } else {
-                navbar.classList.remove('scrolled');
+            if (navbar) {
+                window.addEventListener('scroll', function () {
+                    if (window.scrollY > 50) {
+                        navbar.classList.add('scrolled');
+                    } else {
+                        navbar.classList.remove('scrolled');
+                    }
+                });
+            }
+
+            const backToTopButton = document.getElementById('back-to-top');
+            if (backToTopButton) {
+                window.addEventListener('scroll', function () {
+                    if (window.scrollY > 300) {
+                        backToTopButton.classList.remove('opacity-0', 'invisible');
+                        backToTopButton.classList.add('opacity-100', 'visible');
+                    } else {
+                        backToTopButton.classList.remove('opacity-100', 'visible');
+                        backToTopButton.classList.add('opacity-0', 'invisible');
+                    }
+                });
+                backToTopButton.addEventListener('click', function () {
+                    window.scrollTo({ top: 0, behavior: 'smooth' });
+                });
             }
         });
     </script>
+    <script src="/assets/js/site.js" defer></script>
 </body>
 
 </html>

--- a/dji-mini-3-pro-review.html
+++ b/dji-mini-3-pro-review.html
@@ -447,6 +447,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/electro-voice-everse-8-review.html
+++ b/electro-voice-everse-8-review.html
@@ -124,6 +124,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/farnorthqueenslandtravelguide.html
+++ b/farnorthqueenslandtravelguide.html
@@ -507,6 +507,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/finedininginhanoi.html
+++ b/finedininginhanoi.html
@@ -279,6 +279,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/grand-world-hanoi-guide.html
+++ b/grand-world-hanoi-guide.html
@@ -222,6 +222,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/hanoi-by-night.html
+++ b/hanoi-by-night.html
@@ -259,6 +259,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/hanoitravelguide.html
+++ b/hanoitravelguide.html
@@ -648,6 +648,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/hiroshima-travel-guide.html
+++ b/hiroshima-travel-guide.html
@@ -435,6 +435,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/hon-chong-rocks-nha-trang.html
+++ b/hon-chong-rocks-nha-trang.html
@@ -267,6 +267,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/how-to-get-croatian-citizenship-by-descent.html
+++ b/how-to-get-croatian-citizenship-by-descent.html
@@ -488,6 +488,7 @@ Curiosity-driven: The document that slowed my Croatia application
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/how-to-get-croatian-citizenship-through-your-grandparent.html
+++ b/how-to-get-croatian-citizenship-through-your-grandparent.html
@@ -383,6 +383,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/how-to-make-your-videos-look-cinematic.html
+++ b/how-to-make-your-videos-look-cinematic.html
@@ -232,6 +232,7 @@ Curiosity-driven: The one tweak that made my footage feel less digital
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/howtofoldapopuptent.html
+++ b/howtofoldapopuptent.html
@@ -314,6 +314,7 @@ Curiosity-driven: The folding move that finally made the tent behave
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/howtomakemoneyonlinesellingstockfootage.html
+++ b/howtomakemoneyonlinesellingstockfootage.html
@@ -438,6 +438,7 @@ Curiosity-driven: The stock footage clip that keeps selling
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/japanonabudget.html
+++ b/japanonabudget.html
@@ -389,6 +389,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/korcula.html
+++ b/korcula.html
@@ -460,6 +460,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/kyototravelguide.html
+++ b/kyototravelguide.html
@@ -540,6 +540,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/living-in-bangkok.html
+++ b/living-in-bangkok.html
@@ -59,19 +59,48 @@
 
 <body>
     <!-- Navigation -->
-    <nav class="bg-white/90 backdrop-blur-md sticky top-0 z-50 border-b border-gray-100">
-        <div class="container mx-auto px-6 py-4 flex justify-between items-center">
-            <a href="/index.html" class="heading-font text-2xl font-bold text-gray-900">CARL TOMICH</a>
-            <div class="hidden md:flex space-x-8 text-xs font-bold uppercase tracking-widest">
-                <a href="/destinations.html" class="nav-link">Destinations</a>
-                <a href="/blog.html" class="nav-link">Blog</a>
-                <a href="/gear.html" class="nav-link">Gear</a>
-                <a href="/about.html" class="nav-link">About</a>
+    <nav id="navbar" class="navbar fixed w-full z-50">
+        <div class="container mx-auto px-6 py-4">
+            <div class="flex justify-between items-center">
+                <a href="/index.html" class="text-2xl font-bold">
+                    <span class="heading-font" style="color: var(--primary);">CARL TOMICH</span>
+                </a>
+
+                <div class="hidden md:flex items-center space-x-8">
+                    <a href="/index.html" class="nav-link font-medium">Films</a>
+                    <a href="/portfolio.html" class="nav-link font-medium">Portfolio</a>
+                    <a href="/films/martial-arts-documentary.html" class="nav-link font-medium">Current Project</a>
+                    <a href="/blog.html" class="nav-link font-medium">Blog</a>
+                    <a href="/gear.html" class="nav-link font-medium">Gear</a>
+                    <a href="/destinations.html" class="nav-link font-medium">Travel</a>
+                    <a href="/about.html" class="nav-link font-medium">About</a>
+                    <a href="/donate.html" class="nav-link font-medium" style="color: var(--primary);">Donate</a>
+                </div>
+
+                <button id="mobile-menu-button" class="md:hidden focus:outline-none" style="color: var(--light);">
+                    <i class="fas fa-bars text-2xl"></i>
+                </button>
+            </div>
+
+            <div id="mobile-menu" class="mobile-menu md:hidden">
+                <div class="pt-4 pb-2 space-y-2">
+                    <a href="/index.html" class="block px-3 py-2 rounded-md nav-link">Films</a>
+                    <a href="/portfolio.html" class="block px-3 py-2 rounded-md nav-link">Portfolio</a>
+                    <a href="/films/martial-arts-documentary.html" class="block px-3 py-2 rounded-md nav-link">Current
+                        Project</a>
+                    <a href="/blog.html" class="block px-3 py-2 rounded-md nav-link">Blog</a>
+                    <a href="/gear.html" class="block px-3 py-2 rounded-md nav-link">Gear</a>
+                    <a href="/destinations.html" class="block px-3 py-2 rounded-md nav-link">Travel</a>
+                    <a href="/about.html" class="block px-3 py-2 rounded-md nav-link">About</a>
+                    <a href="/donate.html" class="block px-3 py-2 rounded-md nav-link"
+                        style="color: var(--primary);">Donate</a>
+                </div>
             </div>
         </div>
     </nav>
 
     <!-- Hero Section -->
+
     <header class="hero-bg h-[70vh] flex items-center justify-center text-center text-white px-6">
         <div class="max-w-4xl">
             <span
@@ -225,24 +254,108 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>
 
 
-    <footer class="bg-gray-900 py-20 text-white border-t border-gray-800">
-        <div class="container mx-auto px-6 text-center">
-            <h3 class="heading-font text-4xl mb-4 text-yellow-500">CARL TOMICH</h3>
-            <p class="text-gray-500 mb-10 font-light">Documentary filmmaker and digital nomad living between the lines.
-            </p>
-            <div class="flex justify-center space-x-8">
-                <a href="https://www.youtube.com/@thecarltomich"
-                    class="text-2xl hover:text-yellow-500 transition-all"><i class="fab fa-youtube"></i></a>
-                <a href="https://www.instagram.com/carlostomich"
-                    class="text-2xl hover:text-yellow-500 transition-all"><i class="fab fa-instagram"></i></a>
+    <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
+        <div class="container mx-auto px-6">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
+                <div>
+                    <h3 class="heading-font text-2xl mb-4" style="color: var(--primary);">CARL TOMICH</h3>
+                    <p class="mb-4 text-sm" style="color: var(--light);">Documentary Filmmaker</p>
+                    <p class="text-sm" style="color: var(--muted);">Engineering extreme life projects and turning them
+                        into films since 2014.</p>
+                </div>
+                <div>
+                    <h3 class="font-semibold mb-4" style="color: var(--light);">Films</h3>
+                    <ul class="space-y-2 text-sm">
+                        <li><a href="https://www.youtube.com/watch?v=WjtMEQx34NE" target="_blank"
+                                class="nav-link">Busking for Berlin (2014)</a></li>
+                        <li><a href="https://www.youtube.com/watch?v=6iDgajITe6Q" target="_blank" class="nav-link">A
+                                Sail Untold (2022)</a></li>
+                        <li><a href="https://www.youtube.com/watch?v=S8L4Hmwkgiw" target="_blank" class="nav-link">Busk
+                                Life (2024)</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="font-semibold mb-4" style="color: var(--light);">Explore</h3>
+                    <ul class="space-y-2 text-sm">
+                        <li><a href="/about.html" class="nav-link">About</a></li>
+                        <li><a href="/blog.html" class="nav-link">Essays</a></li>
+                        <li><a href="/gear.html" class="nav-link">Gear</a></li>
+                        <li><a href="/destinations.html" class="nav-link">Travel Guides</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="font-semibold mb-4" style="color: var(--light);">Connect</h3>
+                    <div class="flex space-x-4 mb-4">
+                        <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="nav-link text-2xl"><i
+                                class="fab fa-youtube"></i></a>
+                        <a href="https://www.instagram.com/carlostomich" target="_blank" class="nav-link text-2xl"><i
+                                class="fab fa-instagram"></i></a>
+                    </div>
+                </div>
+            </div>
+            <div class="border-t mt-12 pt-8 flex flex-col md:flex-row justify-between items-center"
+                style="border-color: var(--dark-3);">
+                <p class="text-sm mb-4 md:mb-0" style="color: var(--muted);">© 2025 Carl Tomich. All rights reserved.
+                </p>
+                <div class="flex space-x-6">
+                    <a href="/privacy-policy.html" class="text-sm nav-link">Privacy Policy</a>
+                    <a href="/terms-and-conditions.html" class="text-sm nav-link">Terms of Service</a>
+                </div>
             </div>
         </div>
     </footer>
+
+    <!-- Back to Top Button -->
+    <button id="back-to-top"
+        class="fixed bottom-8 right-8 w-12 h-12 bg-gradient-to-r from-yellow-500 to-amber-600 text-white rounded-full shadow-lg flex items-center justify-center transition-all opacity-0 invisible">
+        <i class="fas fa-arrow-up"></i>
+    </button>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const mobileMenuButton = document.getElementById('mobile-menu-button');
+            const mobileMenu = document.getElementById('mobile-menu');
+            if (mobileMenuButton && mobileMenu) {
+                mobileMenuButton.addEventListener('click', function () {
+                    mobileMenu.classList.toggle('open');
+                });
+            }
+
+            const navbar = document.getElementById('navbar');
+            if (navbar) {
+                window.addEventListener('scroll', function () {
+                    if (window.scrollY > 50) {
+                        navbar.classList.add('scrolled');
+                    } else {
+                        navbar.classList.remove('scrolled');
+                    }
+                });
+            }
+
+            const backToTopButton = document.getElementById('back-to-top');
+            if (backToTopButton) {
+                window.addEventListener('scroll', function () {
+                    if (window.scrollY > 300) {
+                        backToTopButton.classList.remove('opacity-0', 'invisible');
+                        backToTopButton.classList.add('opacity-100', 'visible');
+                    } else {
+                        backToTopButton.classList.remove('opacity-100', 'visible');
+                        backToTopButton.classList.add('opacity-0', 'invisible');
+                    }
+                });
+                backToTopButton.addEventListener('click', function () {
+                    window.scrollTo({ top: 0, behavior: 'smooth' });
+                });
+            }
+        });
+    </script>
+    <script src="/assets/js/site.js" defer></script>
 </body>
 
 </html>

--- a/lotte-world-aquarium-hanoi.html
+++ b/lotte-world-aquarium-hanoi.html
@@ -318,6 +318,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/macbook-pro-m4-max-review.html
+++ b/macbook-pro-m4-max-review.html
@@ -52,16 +52,47 @@
 
 <body class="min-h-screen">
     <!-- Navigation -->
-    <nav class="glass-nav fixed w-full z-50">
-        <div class="container mx-auto px-6 py-4 flex justify-between items-center">
-            <a href="/index.html" class="heading-font text-2xl font-bold text-white tracking-widest">CARL TOMICH</a>
-            <div class="hidden md:flex space-x-8 text-xs font-bold uppercase tracking-widest">
-                <a href="/gear.html" class="text-yellow-400">Gear</a>
-                <a href="/blog.html">Blog</a>
-                <a href="/about.html">About</a>
+    <nav id="navbar" class="navbar fixed w-full z-50">
+        <div class="container mx-auto px-6 py-4">
+            <div class="flex justify-between items-center">
+                <a href="/index.html" class="text-2xl font-bold">
+                    <span class="heading-font" style="color: var(--primary);">CARL TOMICH</span>
+                </a>
+
+                <div class="hidden md:flex items-center space-x-8">
+                    <a href="/index.html" class="nav-link font-medium">Films</a>
+                    <a href="/portfolio.html" class="nav-link font-medium">Portfolio</a>
+                    <a href="/films/martial-arts-documentary.html" class="nav-link font-medium">Current Project</a>
+                    <a href="/blog.html" class="nav-link font-medium">Blog</a>
+                    <a href="/gear.html" class="nav-link font-medium">Gear</a>
+                    <a href="/destinations.html" class="nav-link font-medium">Travel</a>
+                    <a href="/about.html" class="nav-link font-medium">About</a>
+                    <a href="/donate.html" class="nav-link font-medium" style="color: var(--primary);">Donate</a>
+                </div>
+
+                <button id="mobile-menu-button" class="md:hidden focus:outline-none" style="color: var(--light);">
+                    <i class="fas fa-bars text-2xl"></i>
+                </button>
+            </div>
+
+            <div id="mobile-menu" class="mobile-menu md:hidden">
+                <div class="pt-4 pb-2 space-y-2">
+                    <a href="/index.html" class="block px-3 py-2 rounded-md nav-link">Films</a>
+                    <a href="/portfolio.html" class="block px-3 py-2 rounded-md nav-link">Portfolio</a>
+                    <a href="/films/martial-arts-documentary.html" class="block px-3 py-2 rounded-md nav-link">Current
+                        Project</a>
+                    <a href="/blog.html" class="block px-3 py-2 rounded-md nav-link">Blog</a>
+                    <a href="/gear.html" class="block px-3 py-2 rounded-md nav-link">Gear</a>
+                    <a href="/destinations.html" class="block px-3 py-2 rounded-md nav-link">Travel</a>
+                    <a href="/about.html" class="block px-3 py-2 rounded-md nav-link">About</a>
+                    <a href="/donate.html" class="block px-3 py-2 rounded-md nav-link"
+                        style="color: var(--primary);">Donate</a>
+                </div>
             </div>
         </div>
     </nav>
+
+    <!-- Hero Section -->
 
     <header class="pt-32 pb-16 px-6 bg-gradient-to-b from-slate-900 via-slate-950 to-slate-900 border-b border-white/5">
         <div class="max-w-5xl mx-auto text-center">
@@ -239,20 +270,108 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>
 
 
-    <footer class="py-12 bg-slate-950 border-t border-white/5 text-center">
-        <p class="text-xs text-slate-500 uppercase tracking-widest mb-4">© 2025 Carl Tomich | Travel & Tech</p>
-        <div class="flex justify-center space-x-6">
-            <a href="https://www.youtube.com/@thecarltomich" class="text-slate-400 hover:text-white transition-all"><i
-                    class="fab fa-youtube text-xl"></i></a>
-            <a href="https://www.instagram.com/carlostomich" class="text-slate-400 hover:text-white transition-all"><i
-                    class="fab fa-instagram text-xl"></i></a>
+    <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
+        <div class="container mx-auto px-6">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
+                <div>
+                    <h3 class="heading-font text-2xl mb-4" style="color: var(--primary);">CARL TOMICH</h3>
+                    <p class="mb-4 text-sm" style="color: var(--light);">Documentary Filmmaker</p>
+                    <p class="text-sm" style="color: var(--muted);">Engineering extreme life projects and turning them
+                        into films since 2014.</p>
+                </div>
+                <div>
+                    <h3 class="font-semibold mb-4" style="color: var(--light);">Films</h3>
+                    <ul class="space-y-2 text-sm">
+                        <li><a href="https://www.youtube.com/watch?v=WjtMEQx34NE" target="_blank"
+                                class="nav-link">Busking for Berlin (2014)</a></li>
+                        <li><a href="https://www.youtube.com/watch?v=6iDgajITe6Q" target="_blank" class="nav-link">A
+                                Sail Untold (2022)</a></li>
+                        <li><a href="https://www.youtube.com/watch?v=S8L4Hmwkgiw" target="_blank" class="nav-link">Busk
+                                Life (2024)</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="font-semibold mb-4" style="color: var(--light);">Explore</h3>
+                    <ul class="space-y-2 text-sm">
+                        <li><a href="/about.html" class="nav-link">About</a></li>
+                        <li><a href="/blog.html" class="nav-link">Essays</a></li>
+                        <li><a href="/gear.html" class="nav-link">Gear</a></li>
+                        <li><a href="/destinations.html" class="nav-link">Travel Guides</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="font-semibold mb-4" style="color: var(--light);">Connect</h3>
+                    <div class="flex space-x-4 mb-4">
+                        <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="nav-link text-2xl"><i
+                                class="fab fa-youtube"></i></a>
+                        <a href="https://www.instagram.com/carlostomich" target="_blank" class="nav-link text-2xl"><i
+                                class="fab fa-instagram"></i></a>
+                    </div>
+                </div>
+            </div>
+            <div class="border-t mt-12 pt-8 flex flex-col md:flex-row justify-between items-center"
+                style="border-color: var(--dark-3);">
+                <p class="text-sm mb-4 md:mb-0" style="color: var(--muted);">© 2025 Carl Tomich. All rights reserved.
+                </p>
+                <div class="flex space-x-6">
+                    <a href="/privacy-policy.html" class="text-sm nav-link">Privacy Policy</a>
+                    <a href="/terms-and-conditions.html" class="text-sm nav-link">Terms of Service</a>
+                </div>
+            </div>
         </div>
     </footer>
+
+    <!-- Back to Top Button -->
+    <button id="back-to-top"
+        class="fixed bottom-8 right-8 w-12 h-12 bg-gradient-to-r from-yellow-500 to-amber-600 text-white rounded-full shadow-lg flex items-center justify-center transition-all opacity-0 invisible">
+        <i class="fas fa-arrow-up"></i>
+    </button>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const mobileMenuButton = document.getElementById('mobile-menu-button');
+            const mobileMenu = document.getElementById('mobile-menu');
+            if (mobileMenuButton && mobileMenu) {
+                mobileMenuButton.addEventListener('click', function () {
+                    mobileMenu.classList.toggle('open');
+                });
+            }
+
+            const navbar = document.getElementById('navbar');
+            if (navbar) {
+                window.addEventListener('scroll', function () {
+                    if (window.scrollY > 50) {
+                        navbar.classList.add('scrolled');
+                    } else {
+                        navbar.classList.remove('scrolled');
+                    }
+                });
+            }
+
+            const backToTopButton = document.getElementById('back-to-top');
+            if (backToTopButton) {
+                window.addEventListener('scroll', function () {
+                    if (window.scrollY > 300) {
+                        backToTopButton.classList.remove('opacity-0', 'invisible');
+                        backToTopButton.classList.add('opacity-100', 'visible');
+                    } else {
+                        backToTopButton.classList.remove('opacity-100', 'visible');
+                        backToTopButton.classList.add('opacity-0', 'invisible');
+                    }
+                });
+                backToTopButton.addEventListener('click', function () {
+                    window.scrollTo({ top: 0, behavior: 'smooth' });
+                });
+            }
+        });
+    </script>
+    <script src="/assets/js/site.js" defer></script>
 </body>
 
 </html>

--- a/make-money-online-while-traveling.html
+++ b/make-money-online-while-traveling.html
@@ -358,6 +358,7 @@ Curiosity-driven: The income stream I expected to work that didn’t
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/melbournetravelguide.html
+++ b/melbournetravelguide.html
@@ -438,6 +438,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/mytop10travelhacks.html
+++ b/mytop10travelhacks.html
@@ -423,6 +423,7 @@ Curiosity-driven: The travel hack that saved me the most last year
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/ninhbinhtravelguide.html
+++ b/ninhbinhtravelguide.html
@@ -437,6 +437,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/nusalembongan.html
+++ b/nusalembongan.html
@@ -402,6 +402,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/old-quarter-scams-hanoi.html
+++ b/old-quarter-scams-hanoi.html
@@ -441,6 +441,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/one-day-in-hcmc-guide.html
+++ b/one-day-in-hcmc-guide.html
@@ -381,6 +381,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/osakatravelguide.html
+++ b/osakatravelguide.html
@@ -495,6 +495,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/phuketravelguide.html
+++ b/phuketravelguide.html
@@ -469,6 +469,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/portdouglas.html
+++ b/portdouglas.html
@@ -551,6 +551,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/pros-and-cons-and-cost-of-living-in-hanoi.html
+++ b/pros-and-cons-and-cost-of-living-in-hanoi.html
@@ -494,6 +494,7 @@ Curiosity-driven: The Hanoi trade-off I didn’t expect at first
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/saily-e-simguide.html
+++ b/saily-e-simguide.html
@@ -160,6 +160,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/sapa-travel-guide.html
+++ b/sapa-travel-guide.html
@@ -280,6 +280,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/somnipods-3-review.html
+++ b/somnipods-3-review.html
@@ -428,6 +428,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/sony-a7cii-review.html
+++ b/sony-a7cii-review.html
@@ -429,6 +429,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/sony-a7iii-review-2025.html
+++ b/sony-a7iii-review-2025.html
@@ -124,6 +124,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/sony-fx30-setup-guide.html
+++ b/sony-fx30-setup-guide.html
@@ -63,18 +63,48 @@
 
 <body class="selection:bg-yellow-500/30">
     <!-- Navigation -->
-    <nav class="nav-blur fixed w-full z-50 border-b border-white/5">
-        <div class="container mx-auto px-6 py-4 flex justify-between items-center">
-            <a href="/index.html" class="heading-font text-2xl font-bold text-white tracking-widest">CARL TOMICH</a>
-            <div class="hidden md:flex space-x-8 text-xs font-bold uppercase tracking-widest">
-                <a href="/gear.html" class="text-yellow-400">Gear Reviews</a>
-                <a href="/blog.html" class="hover:text-white transition-colors">Blog</a>
-                <a href="/portfolio.html" class="hover:text-white transition-colors">Portfolio</a>
+    <nav id="navbar" class="navbar fixed w-full z-50">
+        <div class="container mx-auto px-6 py-4">
+            <div class="flex justify-between items-center">
+                <a href="/index.html" class="text-2xl font-bold">
+                    <span class="heading-font" style="color: var(--primary);">CARL TOMICH</span>
+                </a>
+
+                <div class="hidden md:flex items-center space-x-8">
+                    <a href="/index.html" class="nav-link font-medium">Films</a>
+                    <a href="/portfolio.html" class="nav-link font-medium">Portfolio</a>
+                    <a href="/films/martial-arts-documentary.html" class="nav-link font-medium">Current Project</a>
+                    <a href="/blog.html" class="nav-link font-medium">Blog</a>
+                    <a href="/gear.html" class="nav-link font-medium">Gear</a>
+                    <a href="/destinations.html" class="nav-link font-medium">Travel</a>
+                    <a href="/about.html" class="nav-link font-medium">About</a>
+                    <a href="/donate.html" class="nav-link font-medium" style="color: var(--primary);">Donate</a>
+                </div>
+
+                <button id="mobile-menu-button" class="md:hidden focus:outline-none" style="color: var(--light);">
+                    <i class="fas fa-bars text-2xl"></i>
+                </button>
+            </div>
+
+            <div id="mobile-menu" class="mobile-menu md:hidden">
+                <div class="pt-4 pb-2 space-y-2">
+                    <a href="/index.html" class="block px-3 py-2 rounded-md nav-link">Films</a>
+                    <a href="/portfolio.html" class="block px-3 py-2 rounded-md nav-link">Portfolio</a>
+                    <a href="/films/martial-arts-documentary.html" class="block px-3 py-2 rounded-md nav-link">Current
+                        Project</a>
+                    <a href="/blog.html" class="block px-3 py-2 rounded-md nav-link">Blog</a>
+                    <a href="/gear.html" class="block px-3 py-2 rounded-md nav-link">Gear</a>
+                    <a href="/destinations.html" class="block px-3 py-2 rounded-md nav-link">Travel</a>
+                    <a href="/about.html" class="block px-3 py-2 rounded-md nav-link">About</a>
+                    <a href="/donate.html" class="block px-3 py-2 rounded-md nav-link"
+                        style="color: var(--primary);">Donate</a>
+                </div>
             </div>
         </div>
     </nav>
 
-    <!-- Hero -->
+    <!-- Hero Section -->
+
     <header class="pt-32 pb-20 px-6 text-center bg-gradient-to-b from-black to-[#0a0a0a]">
         <div class="max-w-4xl mx-auto">
             <span class="status-badge mb-4 inline-block">2025 UPDATED</span>
@@ -258,25 +288,108 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>
 
 
-    <footer class="py-20 bg-black border-t border-white/5">
-        <div class="container mx-auto px-6 text-center">
-            <h4 class="heading-font text-3xl mb-4 text-white">Carl Tomich</h4>
-            <div class="flex justify-center space-x-10 mb-8">
-                <a href="#" class="text-gray-500 hover:text-white transition-all"><i
-                        class="fab fa-youtube text-2xl"></i></a>
-                <a href="#" class="text-gray-500 hover:text-white transition-all"><i
-                        class="fab fa-instagram text-2xl"></i></a>
-                <a href="#" class="text-gray-500 hover:text-white transition-all"><i
-                        class="fab fa-twitter text-2xl"></i></a>
+    <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
+        <div class="container mx-auto px-6">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
+                <div>
+                    <h3 class="heading-font text-2xl mb-4" style="color: var(--primary);">CARL TOMICH</h3>
+                    <p class="mb-4 text-sm" style="color: var(--light);">Documentary Filmmaker</p>
+                    <p class="text-sm" style="color: var(--muted);">Engineering extreme life projects and turning them
+                        into films since 2014.</p>
+                </div>
+                <div>
+                    <h3 class="font-semibold mb-4" style="color: var(--light);">Films</h3>
+                    <ul class="space-y-2 text-sm">
+                        <li><a href="https://www.youtube.com/watch?v=WjtMEQx34NE" target="_blank"
+                                class="nav-link">Busking for Berlin (2014)</a></li>
+                        <li><a href="https://www.youtube.com/watch?v=6iDgajITe6Q" target="_blank" class="nav-link">A
+                                Sail Untold (2022)</a></li>
+                        <li><a href="https://www.youtube.com/watch?v=S8L4Hmwkgiw" target="_blank" class="nav-link">Busk
+                                Life (2024)</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="font-semibold mb-4" style="color: var(--light);">Explore</h3>
+                    <ul class="space-y-2 text-sm">
+                        <li><a href="/about.html" class="nav-link">About</a></li>
+                        <li><a href="/blog.html" class="nav-link">Essays</a></li>
+                        <li><a href="/gear.html" class="nav-link">Gear</a></li>
+                        <li><a href="/destinations.html" class="nav-link">Travel Guides</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="font-semibold mb-4" style="color: var(--light);">Connect</h3>
+                    <div class="flex space-x-4 mb-4">
+                        <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="nav-link text-2xl"><i
+                                class="fab fa-youtube"></i></a>
+                        <a href="https://www.instagram.com/carlostomich" target="_blank" class="nav-link text-2xl"><i
+                                class="fab fa-instagram"></i></a>
+                    </div>
+                </div>
             </div>
-            <p class="text-[10px] text-gray-700 uppercase tracking-[0.3em]">Hanoi | Berlin | Melbourne</p>
+            <div class="border-t mt-12 pt-8 flex flex-col md:flex-row justify-between items-center"
+                style="border-color: var(--dark-3);">
+                <p class="text-sm mb-4 md:mb-0" style="color: var(--muted);">© 2025 Carl Tomich. All rights reserved.
+                </p>
+                <div class="flex space-x-6">
+                    <a href="/privacy-policy.html" class="text-sm nav-link">Privacy Policy</a>
+                    <a href="/terms-and-conditions.html" class="text-sm nav-link">Terms of Service</a>
+                </div>
+            </div>
         </div>
     </footer>
+
+    <!-- Back to Top Button -->
+    <button id="back-to-top"
+        class="fixed bottom-8 right-8 w-12 h-12 bg-gradient-to-r from-yellow-500 to-amber-600 text-white rounded-full shadow-lg flex items-center justify-center transition-all opacity-0 invisible">
+        <i class="fas fa-arrow-up"></i>
+    </button>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const mobileMenuButton = document.getElementById('mobile-menu-button');
+            const mobileMenu = document.getElementById('mobile-menu');
+            if (mobileMenuButton && mobileMenu) {
+                mobileMenuButton.addEventListener('click', function () {
+                    mobileMenu.classList.toggle('open');
+                });
+            }
+
+            const navbar = document.getElementById('navbar');
+            if (navbar) {
+                window.addEventListener('scroll', function () {
+                    if (window.scrollY > 50) {
+                        navbar.classList.add('scrolled');
+                    } else {
+                        navbar.classList.remove('scrolled');
+                    }
+                });
+            }
+
+            const backToTopButton = document.getElementById('back-to-top');
+            if (backToTopButton) {
+                window.addEventListener('scroll', function () {
+                    if (window.scrollY > 300) {
+                        backToTopButton.classList.remove('opacity-0', 'invisible');
+                        backToTopButton.classList.add('opacity-100', 'visible');
+                    } else {
+                        backToTopButton.classList.remove('opacity-100', 'visible');
+                        backToTopButton.classList.add('opacity-0', 'invisible');
+                    }
+                });
+                backToTopButton.addEventListener('click', function () {
+                    window.scrollTo({ top: 0, behavior: 'smooth' });
+                });
+            }
+        });
+    </script>
+    <script src="/assets/js/site.js" defer></script>
 </body>
 
 </html>

--- a/starting-over-at-40.html
+++ b/starting-over-at-40.html
@@ -88,24 +88,47 @@
 <body class="text-gray-800">
     <!-- Navigation -->
     <nav id="navbar" class="navbar fixed w-full z-50">
-        <div class="container mx-auto px-6 py-4 flex justify-between items-center">
-            <a href="/index.html" class="text-2xl font-bold">
-                <span class="heading-font" style="color: var(--primary);">CARL TOMICH</span>
-            </a>
-            <div class="hidden md:flex items-center space-x-8">
-                <a href="/index.html" class="nav-link font-medium">Films</a>
-                <a href="/portfolio.html" class="nav-link font-medium">Portfolio</a>
-                <a href="/blog.html" class="nav-link font-medium">Blog</a>
-                <a href="/gear.html" class="nav-link font-medium">Gear</a>
-                <a href="/destinations.html" class="nav-link font-medium">Travel</a>
-                <a href="/about.html" class="nav-link font-medium">About</a>
+        <div class="container mx-auto px-6 py-4">
+            <div class="flex justify-between items-center">
+                <a href="/index.html" class="text-2xl font-bold">
+                    <span class="heading-font" style="color: var(--primary);">CARL TOMICH</span>
+                </a>
+
+                <div class="hidden md:flex items-center space-x-8">
+                    <a href="/index.html" class="nav-link font-medium">Films</a>
+                    <a href="/portfolio.html" class="nav-link font-medium">Portfolio</a>
+                    <a href="/films/martial-arts-documentary.html" class="nav-link font-medium">Current Project</a>
+                    <a href="/blog.html" class="nav-link font-medium">Blog</a>
+                    <a href="/gear.html" class="nav-link font-medium">Gear</a>
+                    <a href="/destinations.html" class="nav-link font-medium">Travel</a>
+                    <a href="/about.html" class="nav-link font-medium">About</a>
+                    <a href="/donate.html" class="nav-link font-medium" style="color: var(--primary);">Donate</a>
+                </div>
+
+                <button id="mobile-menu-button" class="md:hidden focus:outline-none" style="color: var(--light);">
+                    <i class="fas fa-bars text-2xl"></i>
+                </button>
             </div>
-            <a href="/donate.html"
-                class="px-6 py-2 bg-yellow-500 text-white rounded-full font-bold hover:bg-yellow-600 transition-all">Support</a>
+
+            <div id="mobile-menu" class="mobile-menu md:hidden">
+                <div class="pt-4 pb-2 space-y-2">
+                    <a href="/index.html" class="block px-3 py-2 rounded-md nav-link">Films</a>
+                    <a href="/portfolio.html" class="block px-3 py-2 rounded-md nav-link">Portfolio</a>
+                    <a href="/films/martial-arts-documentary.html" class="block px-3 py-2 rounded-md nav-link">Current
+                        Project</a>
+                    <a href="/blog.html" class="block px-3 py-2 rounded-md nav-link">Blog</a>
+                    <a href="/gear.html" class="block px-3 py-2 rounded-md nav-link">Gear</a>
+                    <a href="/destinations.html" class="block px-3 py-2 rounded-md nav-link">Travel</a>
+                    <a href="/about.html" class="block px-3 py-2 rounded-md nav-link">About</a>
+                    <a href="/donate.html" class="block px-3 py-2 rounded-md nav-link"
+                        style="color: var(--primary);">Donate</a>
+                </div>
+            </div>
         </div>
     </nav>
 
     <!-- Hero Section -->
+
     <section class="hero-gradient relative min-h-[70vh] flex items-center pt-20 overflow-hidden">
         <div class="wave-shape">
             <svg data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 120"
@@ -285,22 +308,107 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>
 
-    <footer class="py-20 bg-gray-900 text-white">
-        <div class="container mx-auto px-6 text-center">
-            <h2 class="heading-font text-4xl mb-6 text-yellow-500">CARL TOMICH</h2>
-            <div class="flex justify-center space-x-8 mb-10">
-                <a href="https://www.youtube.com/@thecarltomich"
-                    class="text-gray-400 hover:text-white transition-all text-2xl"><i class="fab fa-youtube"></i></a>
-                <a href="https://www.instagram.com/carlostomich"
-                    class="text-gray-400 hover:text-white transition-all text-2xl"><i class="fab fa-instagram"></i></a>
+    <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
+        <div class="container mx-auto px-6">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
+                <div>
+                    <h3 class="heading-font text-2xl mb-4" style="color: var(--primary);">CARL TOMICH</h3>
+                    <p class="mb-4 text-sm" style="color: var(--light);">Documentary Filmmaker</p>
+                    <p class="text-sm" style="color: var(--muted);">Engineering extreme life projects and turning them
+                        into films since 2014.</p>
+                </div>
+                <div>
+                    <h3 class="font-semibold mb-4" style="color: var(--light);">Films</h3>
+                    <ul class="space-y-2 text-sm">
+                        <li><a href="https://www.youtube.com/watch?v=WjtMEQx34NE" target="_blank"
+                                class="nav-link">Busking for Berlin (2014)</a></li>
+                        <li><a href="https://www.youtube.com/watch?v=6iDgajITe6Q" target="_blank" class="nav-link">A
+                                Sail Untold (2022)</a></li>
+                        <li><a href="https://www.youtube.com/watch?v=S8L4Hmwkgiw" target="_blank" class="nav-link">Busk
+                                Life (2024)</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="font-semibold mb-4" style="color: var(--light);">Explore</h3>
+                    <ul class="space-y-2 text-sm">
+                        <li><a href="/about.html" class="nav-link">About</a></li>
+                        <li><a href="/blog.html" class="nav-link">Essays</a></li>
+                        <li><a href="/gear.html" class="nav-link">Gear</a></li>
+                        <li><a href="/destinations.html" class="nav-link">Travel Guides</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3 class="font-semibold mb-4" style="color: var(--light);">Connect</h3>
+                    <div class="flex space-x-4 mb-4">
+                        <a href="https://www.youtube.com/@thecarltomich" target="_blank" class="nav-link text-2xl"><i
+                                class="fab fa-youtube"></i></a>
+                        <a href="https://www.instagram.com/carlostomich" target="_blank" class="nav-link text-2xl"><i
+                                class="fab fa-instagram"></i></a>
+                    </div>
+                </div>
             </div>
-            <p class="text-gray-500 text-sm">© 2025 Carl Tomich. Built for the journey.</p>
+            <div class="border-t mt-12 pt-8 flex flex-col md:flex-row justify-between items-center"
+                style="border-color: var(--dark-3);">
+                <p class="text-sm mb-4 md:mb-0" style="color: var(--muted);">© 2025 Carl Tomich. All rights reserved.
+                </p>
+                <div class="flex space-x-6">
+                    <a href="/privacy-policy.html" class="text-sm nav-link">Privacy Policy</a>
+                    <a href="/terms-and-conditions.html" class="text-sm nav-link">Terms of Service</a>
+                </div>
+            </div>
         </div>
     </footer>
+
+    <!-- Back to Top Button -->
+    <button id="back-to-top"
+        class="fixed bottom-8 right-8 w-12 h-12 bg-gradient-to-r from-yellow-500 to-amber-600 text-white rounded-full shadow-lg flex items-center justify-center transition-all opacity-0 invisible">
+        <i class="fas fa-arrow-up"></i>
+    </button>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const mobileMenuButton = document.getElementById('mobile-menu-button');
+            const mobileMenu = document.getElementById('mobile-menu');
+            if (mobileMenuButton && mobileMenu) {
+                mobileMenuButton.addEventListener('click', function () {
+                    mobileMenu.classList.toggle('open');
+                });
+            }
+
+            const navbar = document.getElementById('navbar');
+            if (navbar) {
+                window.addEventListener('scroll', function () {
+                    if (window.scrollY > 50) {
+                        navbar.classList.add('scrolled');
+                    } else {
+                        navbar.classList.remove('scrolled');
+                    }
+                });
+            }
+
+            const backToTopButton = document.getElementById('back-to-top');
+            if (backToTopButton) {
+                window.addEventListener('scroll', function () {
+                    if (window.scrollY > 300) {
+                        backToTopButton.classList.remove('opacity-0', 'invisible');
+                        backToTopButton.classList.add('opacity-100', 'visible');
+                    } else {
+                        backToTopButton.classList.remove('opacity-100', 'visible');
+                        backToTopButton.classList.add('opacity-0', 'invisible');
+                    }
+                });
+                backToTopButton.addEventListener('click', function () {
+                    window.scrollTo({ top: 0, behavior: 'smooth' });
+                });
+            }
+        });
+    </script>
+    <script src="/assets/js/site.js" defer></script>
 </body>
 
 </html>

--- a/tech-review-dji-mavic3.html
+++ b/tech-review-dji-mavic3.html
@@ -414,6 +414,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/tech-review-sony-a7siii.html
+++ b/tech-review-sony-a7siii.html
@@ -420,6 +420,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/tech-review-zhiyun-weebill2.html
+++ b/tech-review-zhiyun-weebill2.html
@@ -326,6 +326,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/the-reality-of-living-overseas.html
+++ b/the-reality-of-living-overseas.html
@@ -298,6 +298,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/thebesttemplesinhanoi.html
+++ b/thebesttemplesinhanoi.html
@@ -385,6 +385,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/things-to-know-before-moving-to-vietnam.html
+++ b/things-to-know-before-moving-to-vietnam.html
@@ -368,6 +368,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/tokyotravelguide.html
+++ b/tokyotravelguide.html
@@ -552,6 +552,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/tolifo-100w-rgb-light-review.html
+++ b/tolifo-100w-rgb-light-review.html
@@ -389,6 +389,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/top-10-things-to-do-in-hanoi.html
+++ b/top-10-things-to-do-in-hanoi.html
@@ -366,6 +366,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/travel-gear-2025.html
+++ b/travel-gear-2025.html
@@ -279,6 +279,7 @@ Curiosity-driven: The small piece of gear that saves my shoots
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/vietnam-e-visa-2026-guide.html
+++ b/vietnam-e-visa-2026-guide.html
@@ -402,6 +402,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/vinwonders-nha-trang.html
+++ b/vinwonders-nha-trang.html
@@ -399,6 +399,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/what-i-learned-after-returning-to-australia-and-why-i-LEFT-again.html
+++ b/what-i-learned-after-returning-to-australia-and-why-i-LEFT-again.html
@@ -315,6 +315,7 @@
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/whyileftaustralia.html
+++ b/whyileftaustralia.html
@@ -339,6 +339,7 @@ Curiosity-driven: The moment I knew I had to leave Australia
             <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
             <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
             <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
+            <p style="margin-bottom: 16px; color: #cfd0d3;">🎟 Use code CARL10 for a discount</p>
             <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
         </div>
     </section>

--- a/yesim-guide.html
+++ b/yesim-guide.html
@@ -359,16 +359,6 @@ Curiosity-driven: The small eSIM detail that made travel days easier
     </section>
 
         <!-- Footer -->
-        <!-- Footer -->
-    <!-- Saily Affiliate -->
-    <section class="max-w-4xl mx-auto px-6 py-10">
-        <div class="affiliate-card" style="background: rgba(15, 15, 15, 0.78); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 20px; padding: 24px; box-shadow: 0 18px 40px -26px rgba(0, 0, 0, 0.7);">
-            <p style="text-transform: uppercase; letter-spacing: 0.2em; font-size: 0.75rem; color: #f5c518; font-weight: 600; margin-bottom: 8px;">Travel Essential</p>
-            <h2 style="font-size: 1.6rem; font-weight: 600; color: #ffffff; margin-bottom: 12px;">Saily - Travel stress-free with data in 100+ countries!</h2>
-            <p style="margin-bottom: 16px; color: #cfd0d3;">Skip the SIM cards ✈️ — grab a Saily eSIM before your next trip and stay online from day one.</p>
-            <a href="https://go.saily.site/aff_c?offer_id=101&aff_id=12234" target="_blank" rel="noopener" style="display: inline-block; background: #f5c518; color: #0f0f0f; font-weight: 700; padding: 12px 20px; border-radius: 999px; text-decoration: none;">👉 Activate your eSIM now</a>
-        </div>
-    </section>
 
     <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
         <div class="container mx-auto px-6">


### PR DESCRIPTION
### Motivation
- Ensure every page that includes the Saily affiliate callout also displays the short discount line `🎟 Use code CARL10 for a discount` for consistent messaging. 
- Remove the Saily affiliate block from the `yesim-guide.html` page to avoid duplicate or conflicting eSIM callouts on that guide. 
- Standardize the header/navigation and footer layout on a set of pages so they follow the same structure and UX as `somnipods-3-review.html` (consistent nav, mobile menu, back-to-top button, and footer grid). 

### Description
- Inserted the line `🎟 Use code CARL10 for a discount` directly beneath the existing Saily description in the Saily affiliate block across pages that include the `<!-- Saily Affiliate -->` section, while skipping `yesim-guide.html`. 
- Removed the Saily affiliate block from `yesim-guide.html` so its CTA/footer now flows from the Yesim CTA to the site footer. 
- Replaced and aligned header/navigation and footer sections on the specified pages (`dating-in-vietnam.html`, `living-in-bangkok.html`, `macbook-pro-m4-max-review.html`, `sony-fx30-setup-guide.html`, `starting-over-at-40.html`) to match the `somnipods-3-review.html` layout, including adding the mobile menu markup, `id=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69832d97986c83239ce53035a45f9e21)