### PR TITLE
Rewrite Bangkok article: debunk $1,000 myth and update living cost data

### DIFF
--- a/living-in-bangkok.html
+++ b/living-in-bangkok.html
@@ -4,13 +4,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Living in Bangkok: The Honest Expat & Nomad Guide (2025) - Carl Travels</title>
+    <title>The $1,000 "Live Like a King" Myth in Bangkok (What It Actually Costs to Live Here) - Carl Travels</title>
     <!-- Cookiebot for GDPR Compliance -->
     <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="e44b7cd2-126b-4f49-8aee-22495afe3ece"
         type="text/javascript" async></script>
     <!-- Meta Tags -->
     <meta name="description"
-        content="Is Bangkok still the king of digital nomad cities? An honest guide to the cost of living, neighborhoods, visas, and the reality of life in Thailand's capital." />
+        content="An honest, first-person reality check on the Bangkok cost of living, including bangkok rent prices, food, transport, and why the $1,000 myth doesn’t match living in Bangkok today." />
     <meta name="keywords"
         content="living in bangkok, digital nomad bangkok, bangkok cost of living 2025, expat guide bangkok, bangkok vs hanoi, thailand dtv visa" />
     <meta name="author" content="Carl Ostomich">
@@ -107,8 +107,8 @@
                 class="bg-yellow-500 text-black px-4 py-1 rounded-full text-xs font-bold uppercase mb-4 inline-block">City
                 Guide</span>
             <h1 class="text-5xl md:text-8xl font-bold heading-font mb-6 tracking-tight">Living in Bangkok</h1>
-            <p class="text-xl md:text-2xl opacity-90 font-light leading-relaxed">The city that never sleeps, never
-                stops, and never fails to surprise. My unfiltered guide to making the Big Mango your home.</p>
+            <p class="text-xl md:text-2xl opacity-90 font-light leading-relaxed">The $1,000 "live like a king" myth vs
+                the numbers I actually saw after ten trips and a fresh look in 2025.</p>
         </div>
     </header>
 
@@ -121,15 +121,15 @@
                     <ul class="space-y-4 text-sm">
                         <li class="flex justify-between border-b border-white/10 pb-2">
                             <span class="text-gray-400">Rent (Studio)</span>
-                            <span class="font-bold">$450 - $800</span>
+                            <span class="font-bold">$1,200 - $2,000</span>
                         </li>
                         <li class="flex justify-between border-b border-white/10 pb-2">
                             <span class="text-gray-400">Street Meal</span>
-                            <span class="font-bold">$1.50 - $3.00</span>
+                            <span class="font-bold">$3.00 - $6.00</span>
                         </li>
                         <li class="flex justify-between border-b border-white/10 pb-2">
                             <span class="text-gray-400">Coffee (Cafe)</span>
-                            <span class="font-bold">$2.50 - $4.00</span>
+                            <span class="font-bold">$4.00 - $6.50</span>
                         </li>
                         <li class="flex justify-between border-b border-white/10 pb-2">
                             <span class="text-gray-400">Internet Speed</span>
@@ -137,7 +137,7 @@
                         </li>
                         <li class="flex justify-between">
                             <span class="text-gray-400">Nomad Score</span>
-                            <span class="font-bold text-yellow-500">9.5/10</span>
+                            <span class="font-bold text-yellow-500">7.5/10</span>
                         </li>
                     </ul>
                 </div>
@@ -164,85 +164,78 @@
             <div class="lg:col-span-2">
                 <section class="prose prose-slate max-w-none">
                     <p class="text-xl leading-relaxed text-gray-600 mb-10">
-                        Bangkok is a sensory overload. It’s a city where 500-year-old temples sit in the shadow of
-                        neon-lit skyscrapers, and where you can buy a Michelin-star meal on a plastic stool for $2. For
-                        a digital nomad or expat, it remains one of the most compelling places on earth to call home.
+                        The $1,000 “live like a king in Bangkok” pitch still pops up in thumbnails, and I get why it
+                        sells. I’ve been coming to Thailand since 2014, probably ten trips now, and I just spent six
+                        weeks back in the city to reality-check the bangkok cost of living with fresh numbers. I’m not
+                        writing this as a quick tourist pass-through, I’m writing it as someone who has actually tried
+                        to live it. The myth feels neat and simple, but the real city is more expensive and more
+                        complicated than that.
                     </p>
-
-                    <h2 class="text-4xl font-bold text-gray-900 mb-6 heading-font">Why Bangkok in 2025?</h2>
                     <p class="mb-6">
-                        While other hubs have seen prices skyrocket and infrastructure lag, Bangkok has doubled down on
-                        its status as a creative capital. The introduction of the <strong>Destination Thailand Visa
-                            (DTV)</strong> has been a literal game-changer, allowing remote workers to stay for up to 5
-                        years with multiple entries.
+                        Rent is where the fantasy falls apart first. When I searched for whole apartments that felt
+                        livable, not just a tired room with a view of a wall, the bangkok rent prices that actually
+                        worked were in the $1,200 to $2,000 range per month. Anything cheaper was either far out, tiny,
+                        poorly rated, or the kind of place that makes you want to leave the apartment all day. If you’re
+                        moving to Bangkok and want a decent setup, that number is the reality I saw across Airbnb and
+                        Booking.
                     </p>
                     <p class="mb-10">
-                        But beyond the visas, it’s the ease of life. You can decide you want a world-class pizza at 3 AM
-                        and have it delivered by a Grab driver in 20 minutes. You can join a community of thousands of
-                        creators at any one of the hundreds of co-working spaces.
+                        Food is the next myth people lean on, and yes, street food exists and it’s still good. But it’s
+                        not the bargain people keep quoting from 2010, especially anywhere near the areas foreigners
+                        actually live. The really cheap meals are often away from the action, and the tourist zones have
+                        crept up closer to Western prices. The thailand cost of living is still lower than Australia,
+                        but it’s not magic anymore.
                     </p>
-
-                    <h2 class="text-4xl font-bold text-gray-900 mb-6 heading-font">The Neighborhood Breakdown</h2>
-                    <div class="space-y-8 mb-12">
-                        <div class="card p-6 border-l-4 border-yellow-500">
-                            <h4 class="font-bold text-xl mb-2">Sukhumvit (Asok / Phrom Phong / Thong Lo)</h4>
-                            <p class="text-sm text-gray-600">The expat heart. High-end condos, international bars, and
-                                incredible nightlife. It's expensive by Thai standards but very convenient.</p>
-                        </div>
-                        <div class="card p-6 border-l-4 border-gray-300">
-                            <h4 class="font-bold text-xl mb-2">Ari</h4>
-                            <p class="text-sm text-gray-600">The "hipster" neighborhood. Residential, leafy, and filled
-                                with boutique cafes. It feels more "local" than Sukhumvit while still being connected
-                                via the BTS.</p>
-                        </div>
-                        <div class="card p-6 border-l-4 border-gray-300">
-                            <h4 class="font-bold text-xl mb-2">Sathorn / Silom</h4>
-                            <p class="text-sm text-gray-600">The financial district. Great for those who want a mix of
-                                high-end bars, green spaces (Lumphini Park), and a professional atmosphere.</p>
-                        </div>
-                    </div>
-
-                    <h2 class="text-4xl font-bold text-gray-900 mb-6 heading-font">Cost of Living: The Reality</h2>
                     <p class="mb-6">
-                        Is it still cheap? Yes and no. If you want to live exactly like you do in London or Sydney,
-                        you'll pay Western prices. But if you embrace the local systems, your money goes incredibly far.
+                        Transport is another thing people underestimate. Bangkok is massive, so if you choose cheaper
+                        rent on the edge you pay for it in commute time and energy. Trains get packed, traffic drags,
+                        and the humidity makes every extra minute feel longer. Living in Bangkok means accepting that
+                        getting around is a real cost, even when the ride itself is cheap.
                     </p>
-                    <ul class="list-disc pl-6 mb-10 space-y-3">
-                        <li><strong>Housing:</strong> $500 gets you a clean, modern studio with a pool and gym near the
-                            BTS. $1200 gets you luxury.</li>
-                        <li><strong>Food:</strong> $300 a month is plenty if you eat Thai food. $800 if you want western
-                            brunch and craft beer every night.</li>
-                        <li><strong>Transport:</strong> The BTS/MRT (trains) are world-class and cheap ($1-$2 per trip).
-                            Use Grab or Bolt for taxis.</li>
-                    </ul>
-
-                    <div class="bg-yellow-50 p-10 rounded-2xl border-l-8 border-yellow-500 my-16">
-                        <h4 class="text-2xl font-bold mb-4">Carl's Verdict: Bangkok vs Hanoi</h4>
-                        <p class="italic text-gray-800 leading-relaxed">
-                            "I love Hanoi for its grit, its history, and its coffee culture. But Bangkok wins on pure
-                            efficiency. If you need to scale a business, if you need fast internet, and if you want a
-                            city that actually *works*, Bangkok is the place. It's less 'authentic' than Hanoi in parts,
-                            but it's far easier to live in long-term."
-                        </p>
-                        <a href="pros-and-cons-and-cost-of-living-in-hanoi.html"
-                            class="text-yellow-600 font-bold block mt-6 hover:underline">Read my Hanoi guide &rarr;</a>
-                    </div>
-
-                    <h2 class="text-4xl font-bold text-gray-900 mb-6 heading-font">Final Advice: Get a Scooter?</h2>
+                    <p class="mb-6">
+                        The city vibe has shifted too, and I felt it immediately. Bangkok is more commercial now, more
+                        mall-heavy, more polished, and that changes the soul of the place. It’s still a wild mix of
+                        chaos and convenience, but the edge is softer than it used to be. That’s not good or bad, it’s
+                        just a different version of the city.
+                    </p>
+                    <p class="mb-6">
+                        I’m not bashing Thailand, and I still like being there. Expat life Thailand can be genuinely
+                        enjoyable if you value convenience, variety, and easy social scenes. I just don’t want people
+                        falling for a cheap-luxury story that doesn’t exist anymore. Digital nomad Bangkok is real, but
+                        it’s not the bargain it once was.
+                    </p>
+                    <p class="mb-6">
+                        I’m currently based in Vietnam because the costs are lower and the daily rhythm suits me more.
+                        It’s not a perfect comparison, but it does highlight how far Bangkok has moved up the price
+                        ladder. If you want to compare, I’ve written about the cost of living in Hanoi and the broader
+                        reality of living overseas on Carltravels.com, and those pieces give some context. Bangkok still
+                        offers a lot, but the bangkok cost of living has caught up to the hype.
+                    </p>
+                    <p class="mb-6">
+                        If you’re considering moving to Bangkok, my advice is to test it properly. Come for a month,
+                        pay real rent, buy normal groceries, and commute like you would if you actually lived there.
+                        That kind of trial run makes the math clear, and it saves you from learning expensive lessons
+                        later. If the numbers still work, you’ll have the confidence to commit.
+                    </p>
+                    <p class="mb-6">
+                        I made a full video with the listings I used and the actual costs I saw, so if you want the
+                        receipts and the visuals, give it a watch. It’s a soft reality check, not a rant, and I think it
+                        helps cut through the noise. If you want extra reading after, take a look at my guide on
+                        <a href="things-to-know-before-moving-to-vietnam.html">things to know before moving to Vietnam</a>,
+                        my <a href="pros-and-cons-and-cost-of-living-in-hanoi.html">Hanoi cost of living breakdown</a>,
+                        and my take on <a href="the-reality-of-living-overseas.html">the reality of living overseas</a>.
+                        Those are all part of the same bigger conversation.
+                    </p>
                     <p class="mb-10">
-                        Unless you are extremely confident on two wheels, <strong>don't.</strong> Bangkok traffic is
-                        some of the most congested and unpredictable in the world. Stick to the trains and the
-                        occasional "Win" (motorcycle taxi) for short distances when you're in a rush.
+                        I’ll keep visiting Bangkok, and I still recommend people see it for themselves. The city has
+                        plenty of energy and plenty of upside, but it won’t live up to a fantasy budget. If you’ve lived
+                        there recently, did your numbers line up with the myth or did reality hit harder?
                     </p>
-
-                    <div class="border-t border-gray-200 pt-16 mt-20">
-                        <h3 class="text-2xl font-bold mb-6">Watch the Vlog: My First Month in Bangkok</h3>
-                        <div class="aspect-video rounded-3xl overflow-hidden shadow-2xl mb-12 bg-black">
-                            <iframe class="w-full h-full" src="https://www.youtube.com/embed/U41rV5x6p-Y"
-                                title="Living in Bangkok Guide" frameborder="0"
-                                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                                allowfullscreen></iframe>
-                        </div>
+                    <div class="aspect-video rounded-3xl overflow-hidden shadow-2xl mb-12 bg-black">
+                        <iframe class="w-full h-full" src="https://www.youtube.com/embed/U41rV5x6p-Y"
+                            title="Living in Bangkok Guide" frameborder="0"
+                            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                            allowfullscreen></iframe>
                     </div>
                 </section>
             </div>


### PR DESCRIPTION
### Motivation
- Replace an outdated, promotional tone with an honest, first-person reality check on the $1,000 “live like a king in Bangkok” claim based on recent visits and fresh pricing data. 
- Correct quick-reference pricing and context so readers searching for terms like `bangkok cost of living`, `bangkok rent prices`, and `digital nomad bangkok` get accurate information. 
- Link the article into existing site content that compares Bangkok with Vietnam and Hanoi to provide readers practical alternatives and next steps.

### Description
- Rewrote the main long-form article in `living-in-bangkok.html` to a conversational first-person narrative that debunks the $1,000 myth and covers rent, food, transport, city vibe, and practical advice. 
- Updated page metadata and the hero subtitle to reflect the new angle and SEO targets, and adjusted sidebar Quick Stats to show realistic ranges for rent, street meals, and coffee. 
- Added internal links to related pages (`things-to-know-before-moving-to-vietnam.html`, `pros-and-cons-and-cost-of-living-in-hanoi.html`, `the-reality-of-living-overseas.html`) and retained the embedded YouTube video as a soft CTA. 
- Cleaned up content blocks to remove outdated lists and neighborhood breakdowns that conflicted with the new first-person narrative and tone.

### Testing
- No automated tests were run because these are content-only changes and no code paths were modified. 
- File changes were verified by inspecting the updated `living-in-bangkok.html` to confirm the new title, meta description, sidebar stats, article body, and internal links were applied.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698359dd9ac883238a6b186dea244b62)