### PR TITLE
Embed AIARTY hero video and update pricing CTA to affiliate link

### DIFF
--- a/aiarty-video-enhancer-review.html
+++ b/aiarty-video-enhancer-review.html
@@ -236,10 +236,6 @@
                     <h1 class="heading-font text-4xl md:text-5xl text-white leading-tight">AIARTY Video Enhancer Review (2026)</h1>
                     <p class="text-lg text-slate-200 leading-relaxed">I tested AIARTY Video Enhancer on travel footage, archival clips, and noisy night scenes to see if it’s actually a Topaz Video AI alternative in 2026. The quick take: AIARTY is faster and easier for day-to-day creator work, while Topaz still wins on extreme detail recovery. Here’s where AIARTY improves sharpness and motion, where it struggles, and how the exports hold up after YouTube compression.</p>
                     <div class="flex flex-wrap gap-4">
-                        <a href="#video-review" class="inline-flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-yellow-500 to-amber-600 text-black font-semibold rounded-full shadow-lg hover:shadow-xl transition-transform">
-                            <i class="fas fa-play"></i>
-                            Watch the video review
-                        </a>
                         <a href="#highlights" class="inline-flex items-center gap-2 px-6 py-3 border border-slate-500 text-slate-200 rounded-full hover:border-yellow-400 hover:text-yellow-400 transition-colors">
                             <i class="fas fa-sparkles"></i>
                             See the highlights
@@ -248,7 +244,9 @@
                 </div>
                 <div class="relative">
                     <div class="info-card">
-                        <img src="https://img.youtube.com/vi/fsYA84tjrTE/maxresdefault.jpg" alt="AIARTY Video Enhancer YouTube review thumbnail" class="rounded-xl w-full h-auto">
+                        <div class="responsive-video video-overlay" style="--video-thumb: url('https://img.youtube.com/vi/fsYA84tjrTE/maxresdefault.jpg');">
+                            <iframe src="https://www.youtube.com/embed/fsYA84tjrTE" title="AIARTY Video Enhancer Review" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                        </div>
                         <p class="text-slate-300 text-sm mt-4">Watch the full YouTube review of AIARTY Video Enhancer, featuring side-by-side tests and workflow tips.</p>
                     </div>
                 </div>
@@ -396,13 +394,9 @@
                 <div class="info-card lg:sticky lg:top-28">
                     <h3 class="text-2xl font-semibold text-white mb-4">Pricing &amp; Deals</h3>
                     <p class="text-gray-300 mb-4">AIARTY is a one-time $165 USD purchase, covering unlimited installs and updates. During this review, the developers offered Carl Tomich Tech Reviews viewers an extra discount.</p>
-                    <a href="https://tinyurl.com/2usf6cf4" target="_blank" rel="noopener" class="cta-button w-full justify-center mb-3">
+                    <a href="https://secure.2checkout.com/order/checkout.phpPRODS=50333861&QTY=1&AFFILIATE=246587&AFFSRC=image_enhancer_video&CART=1" target="_blank" rel="noopener" class="cta-button w-full justify-center mb-3">
                         <i class="fas fa-shopping-cart"></i>
-                        Buy AIARTY Video Enhancer
-                    </a>
-                    <a href="https://tinyurl.com/492a2tyk" target="_blank" rel="noopener" class="cta-button w-full justify-center bg-gradient-to-r from-amber-400 to-pink-500">
-                        <i class="fas fa-percentage"></i>
-                        Up to 36% OFF Lifetime License
+                        Buy it here to save 36% on AIARTY
                     </a>
                     <p class="text-gray-400 text-sm mt-4">Affiliate links help support the channel at no extra cost to you.</p>
                 </div>


### PR DESCRIPTION
### Motivation
- Improve the landing experience by embedding the AIARTY YouTube review directly into the hero so visitors can watch without extra clicks. 
- Remove the redundant "Watch the video review" button which pointed back to the same article. 
- Use the provided affiliate checkout URL and emphasize the 36% savings in the pricing CTA.

### Description
- Replaced the hero thumbnail `<img>` with a responsive video container and an embedded YouTube `<iframe>` for `fsYA84tjrTE` so the video plays on the main page. 
- Removed the hero "Watch the video review" CTA link to avoid duplication and keep the hero CTA focused on highlights. 
- Updated the Pricing & Deals CTA to point at the provided 2Checkout affiliate URL (`https://secure.2checkout.com/order/checkout.phpPRODS=50333861&QTY=1&AFFILIATE=246587&AFFSRC=image_enhancer_video&CART=1`) and changed the link text to "Buy it here to save 36% on AIARTY", removing the separate 36% button. 
- Changes applied to `aiarty-video-enhancer-review.html` and committed.

### Testing
- Started a local preview server with `python -m http.server 8000`, which launched successfully. 
- Attempted an automated visual capture with Playwright (`mcp__browser_tools__run_playwright_script`) but the Chromium process crashed (SIGSEGV), so a screenshot could not be captured. 
- Confirmed the HTML file was staged and committed with `git commit`, and the working tree shows the updated file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987b57202e88323a33b76d1498335f2)