### PR TITLE
Add Phu Quoc travel guide page and listing

### DIFF
--- a/destinations.html
+++ b/destinations.html
@@ -727,6 +727,38 @@
                         </div>
                     </div>
                 </div>
+                <!-- Destination 6ab: Phu Quoc -->
+                <div class="destination-card rounded-xl overflow-hidden shadow-lg" data-destination-id="phuquoc">
+                    <div class="destination-card-inner">
+                        <div class="relative overflow-hidden h-64">
+                            <img src="https://img.youtube.com/vi/Plen_Co5MPs/maxresdefault.jpg"
+                                alt="Phu Quoc Sunset Town at night"
+                                class="w-full h-full object-cover transform hover:scale-110 transition-transform duration-500">
+                            <div class="absolute inset-0 destination-overlay"></div>
+                            <div class="absolute bottom-0 left-0 p-6 text-white">
+                                <h3 class="text-xl font-bold">Phu Quoc</h3>
+                                <p class="text-sm">Sunset Town • Hon Thom</p>
+                            </div>
+                            <span
+                                class="absolute top-4 right-4 bg-yellow-500 text-black text-xs px-3 py-1 rounded-full">New</span>
+                        </div>
+                        <div class="p-6 bg-white">
+                            <div class="flex justify-between items-center mb-3">
+                                <span class="text-gray-500 text-sm"><i
+                                        class="fas fa-map-marker-alt mr-1 text-yellow-500"></i> Vietnam</span>
+                                <div class="flex items-center">
+                                    <i class="fas fa-star text-yellow-400 mr-1"></i>
+                                    <span class="font-medium">4.8</span>
+                                </div>
+                            </div>
+                            <p class="text-gray-600 mb-4">Where to stay, best season, Sunset Town at night, and whether the Hon Thom cable car + Sun World pass is actually worth it.</p>
+                            <a href="phuquoctravelguide.html"
+                                class="text-yellow-500 font-medium hover:text-yellow-500 inline-flex items-center">
+                                View Details <i class="fas fa-arrow-right ml-2"></i>
+                            </a>
+                        </div>
+                    </div>
+                </div>
                 <!-- Destination 6aa: Sapa -->
                 <div class="destination-card rounded-xl overflow-hidden shadow-lg" data-destination-id="sapa"
                     id="sapa-card">
@@ -1336,6 +1368,14 @@
                                         </button>
                                         <button
                                             class="map-destination-item w-full text-left px-4 py-3 rounded-xl bg-white"
+                                            data-country="Vietnam" data-map-destination="phuquoc">
+                                            <div class="flex items-center justify-between">
+                                                <p class="font-semibold text-gray-900">Phu Quoc</p>
+                                                <span class="text-yellow-500"><i class="fas fa-play"></i></span>
+                                            </div>
+                                        </button>
+                                        <button
+                                            class="map-destination-item w-full text-left px-4 py-3 rounded-xl bg-white"
                                             data-country="Vietnam" data-map-destination="sapa">
                                             <div class="flex items-center justify-between">
                                                 <p class="font-semibold text-gray-900">Sapa</p>
@@ -1774,6 +1814,13 @@
                             coords: [20.2506, 105.9745],
                             url: 'ninhbinhtravelguide.html',
                             video: 'https://www.youtube.com/embed/Hict_8lPMvw'
+                        },
+                        {
+                            id: 'phuquoc',
+                            name: 'Phu Quoc, Vietnam',
+                            coords: [10.2899, 103.9840],
+                            url: 'phuquoctravelguide.html',
+                            video: 'https://www.youtube.com/embed/Plen_Co5MPs'
                         },
                         {
                             id: 'sapa',

--- a/phuquoctravelguide.html
+++ b/phuquoctravelguide.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Phu Quoc Travel Guide 2026 – Sunset Town, Cable Car & Where to Stay | Carl Travels</title>
+    <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="e44b7cd2-126b-4f49-8aee-22495afe3ece" type="text/javascript" async></script>
+    <meta name="description" content="Phu Quoc travel guide: best areas to stay, when to visit, Sunset Town, Hon Thom cable car, Sun World tips, and two honest video walkthroughs.">
+    <meta name="keywords" content="Phu Quoc travel guide, Sunset Town, Hon Thom cable car, Sun World Nature Park, best time to visit Phu Quoc, where to stay in Phu Quoc">
+    <meta property="og:title" content="Phu Quoc Travel Guide 2026 – Sunset Town, Cable Car & Where to Stay">
+    <meta property="og:description" content="From first-night impressions in Sunset Town to the world’s longest over-sea cable car — here’s what Phu Quoc is actually like.">
+    <meta property="og:image" content="https://img.youtube.com/vi/Plen_Co5MPs/maxresdefault.jpg">
+    <meta property="og:url" content="https://www.carltravels.com/phuquoctravelguide.html">
+    <meta property="og:type" content="article">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Phu Quoc Travel Guide 2026 – Sunset Town, Cable Car & Where to Stay">
+    <meta name="twitter:description" content="What to expect in Phu Quoc, where to stay, best season, and whether Sun World is worth it.">
+    <meta name="twitter:image" content="https://img.youtube.com/vi/Plen_Co5MPs/maxresdefault.jpg">
+    <script async src="https://pagead2.googlesyndication.com/pagead/js?client=ca-pub-6483721386563068" crossorigin="anonymous"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-G72KT5ZW2J"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);} 
+        gtag('js', new Date());
+        gtag('config', 'G-G72KT5ZW2J');
+    </script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700&family=Bebas+Neue&display=swap" rel="stylesheet">
+    <style>
+        :root { --primary: #facc15; --dark: #0f172a; --light: #e2e8f0; --muted: #94a3b8; --dark-3: #1e293b; }
+        body { font-family: 'Montserrat', sans-serif; background-color: var(--dark); color: var(--light); }
+        .heading-font { font-family: 'Bebas Neue', sans-serif; letter-spacing: 0.08em; }
+        .hero { background: radial-gradient(circle at top left, rgba(250,204,21,0.16), transparent 60%), radial-gradient(circle at bottom right, rgba(59,130,246,0.12), transparent 55%), linear-gradient(135deg, rgba(15,23,42,0.95), rgba(15,23,42,0.78)); }
+        .navbar { backdrop-filter: blur(10px); background-color: rgba(26, 26, 26, 0.9); border-bottom: 1px solid rgba(255, 255, 255, 0.08); }
+        .navbar.scrolled { background-color: rgba(26, 26, 26, 0.98); box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35); }
+        .badge { display: inline-flex; align-items: center; gap: .5rem; background: rgba(248,250,252,.08); border: 1px solid rgba(148,163,184,.25); padding: .45rem 1rem; border-radius: 9999px; font-size: .75rem; letter-spacing: .08em; text-transform: uppercase; }
+        .info-card { background: rgba(30,41,59,.85); border: 1px solid rgba(148,163,184,.2); border-radius: 1.25rem; padding: 1.5rem; }
+        .responsive-video { position: relative; width: 100%; padding-bottom: 56.25%; border-radius: 1.5rem; overflow: hidden; box-shadow: 0 35px 65px -25px rgba(59,130,246,.35); }
+        .responsive-video iframe { position: absolute; inset: 0; width: 100%; height: 100%; border: none; }
+        .nav-link { color: #e5e7eb; }
+        .nav-link:hover { color: var(--primary); }
+        .mobile-menu { background-color: rgba(12, 12, 12, 0.95); border-bottom: 1px solid rgba(255, 255, 255, 0.08); }
+    </style>
+    <link rel="stylesheet" href="/assets/css/styles.css">
+</head>
+<body class="text-gray-100">
+    <nav id="navbar" class="navbar fixed w-full z-50">
+        <div class="container mx-auto px-6 py-4">
+            <div class="flex justify-between items-center">
+                <a href="/index.html" class="text-2xl font-bold"><span class="heading-font" style="color: var(--primary);">CARL TOMICH</span></a>
+                <div class="hidden md:flex items-center space-x-8">
+                    <a href="/index.html" class="nav-link font-medium">Films</a><a href="/portfolio.html" class="nav-link font-medium">Portfolio</a><a href="/films/martial-arts-documentary.html" class="nav-link font-medium">Current Project</a><a href="/blog.html" class="nav-link font-medium">Blog</a><a href="/gear.html" class="nav-link font-medium">Gear</a><a href="/destinations.html" class="nav-link font-medium">Travel</a><a href="/about.html" class="nav-link font-medium">About</a><a href="/donate.html" class="nav-link font-medium" style="color: var(--primary);">Donate</a>
+                </div>
+                <button id="mobile-menu-button" class="md:hidden focus:outline-none" style="color: var(--light);"><i class="fas fa-bars text-2xl"></i></button>
+            </div>
+            <div id="mobile-menu" class="mobile-menu md:hidden">
+                <div class="pt-4 pb-2 space-y-2">
+                    <a href="/index.html" class="block px-3 py-2 rounded-md nav-link">Films</a><a href="/portfolio.html" class="block px-3 py-2 rounded-md nav-link">Portfolio</a><a href="/films/martial-arts-documentary.html" class="block px-3 py-2 rounded-md nav-link">Current Project</a><a href="/blog.html" class="block px-3 py-2 rounded-md nav-link">Blog</a><a href="/gear.html" class="block px-3 py-2 rounded-md nav-link">Gear</a><a href="/destinations.html" class="block px-3 py-2 rounded-md nav-link">Travel</a><a href="/about.html" class="block px-3 py-2 rounded-md nav-link">About</a><a href="/donate.html" class="block px-3 py-2 rounded-md nav-link" style="color: var(--primary);">Donate</a>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <header class="hero pt-28 pb-16">
+        <div class="container mx-auto px-6 grid lg:grid-cols-2 gap-10 items-center">
+            <div class="space-y-6">
+                <div class="space-x-3"><span class="badge"><i class="fas fa-map-marker-alt text-yellow-400"></i> South Vietnam</span><span class="badge"><i class="fas fa-umbrella-beach text-yellow-400"></i> Island Guide</span></div>
+                <h1 class="heading-font text-4xl md:text-5xl font-bold leading-tight">Phu Quoc Travel Guide 2026<br>Where To Stay, When To Go & What To See</h1>
+                <p class="text-gray-300 leading-relaxed text-lg">I landed in Phu Quoc last minute with zero plan and started in Sunset Town at night. This page covers the key things most people ask first: best areas to stay, weather timing, top attractions, practical tips, and whether the island's big-ticket experiences are actually worth it.</p>
+                <div class="flex flex-wrap gap-4"><a href="#videos" class="px-6 py-3 bg-gradient-to-r from-yellow-500 to-amber-600 text-gray-900 font-semibold rounded-full">Watch both videos</a><a href="#stay" class="px-6 py-3 border border-yellow-400 text-yellow-400 font-semibold rounded-full hover:bg-yellow-500 hover:text-gray-900 transition">Plan your trip</a></div>
+            </div>
+            <div class="overflow-hidden rounded-2xl shadow-2xl border border-gray-700"><img src="https://img.youtube.com/vi/Plen_Co5MPs/maxresdefault.jpg" alt="Phu Quoc Sunset Town at night" class="w-full h-full object-cover"></div>
+        </div>
+    </header>
+
+    <section id="videos" class="py-16 bg-gray-900/60">
+        <div class="container mx-auto px-6 space-y-14">
+            <div class="grid lg:grid-cols-2 gap-10 items-center">
+                <div>
+                    <p class="badge mb-4"><i class="fas fa-moon text-yellow-400"></i> Video 1: First Night Walk</p>
+                    <h2 class="heading-font text-3xl md:text-4xl">Sunset Town: Vietnam's "Fake Italy"?</h2>
+                    <p class="text-gray-300 mt-4">A raw first impression walking tour through Sunset Town at night — canals, Roman-style columns, piazzas, fireworks, and the surreal feeling of a theme-park city by the sea. This is unscripted and real-time.</p>
+                </div>
+                <div class="responsive-video"><iframe src="https://www.youtube.com/embed/Plen_Co5MPs" title="Sunset Town first impressions" allowfullscreen loading="lazy"></iframe></div>
+            </div>
+            <div class="grid lg:grid-cols-2 gap-10 items-center">
+                <div>
+                    <p class="badge mb-4"><i class="fas fa-cable-car text-yellow-400"></i> Video 2: Value Test Day Trip</p>
+                    <h2 class="heading-font text-3xl md:text-4xl">Hon Thom Cable Car + Sun World for ~$40</h2>
+                    <p class="text-gray-300 mt-4">I tested the full package: the 8km over-sea cable car, Sun World Nature Park, rides, water park, beach time, and what your ticket includes. I expected cheesy — the value was honestly much better than expected.</p>
+                </div>
+                <div class="responsive-video"><iframe src="https://www.youtube.com/embed/H0scQqpIUS0" title="Hon Thom cable car and Sun World" allowfullscreen loading="lazy"></iframe></div>
+            </div>
+        </div>
+    </section>
+
+    <section id="stay" class="py-16">
+        <div class="container mx-auto px-6 grid lg:grid-cols-2 gap-8">
+            <div class="info-card">
+                <h3 class="heading-font text-2xl mb-3">Best Areas To Stay</h3>
+                <ul class="space-y-3 text-gray-300">
+                    <li><strong>Duong Dong / Long Beach:</strong> Best all-round base for first-timers, sunset bars, restaurants, and easy airport access.</li>
+                    <li><strong>Sunset Town (An Thoi):</strong> Great if you want cable car access, night shows, and dramatic architecture; quieter in daytime, livelier after dark.</li>
+                    <li><strong>Ong Lang:</strong> More relaxed and green; good for slower trips and boutique stays.</li>
+                    <li><strong>Northwest coast:</strong> Resort-heavy and calmer, ideal for couples or full resort days.</li>
+                </ul>
+            </div>
+            <div class="info-card">
+                <h3 class="heading-font text-2xl mb-3">Best Time Of Year</h3>
+                <ul class="space-y-3 text-gray-300">
+                    <li><strong>Nov-Apr:</strong> Best weather window (dry season), lower rain risk, clear sunsets and better island-hopping days.</li>
+                    <li><strong>May-Oct:</strong> Rainy season with short heavy showers; still possible to travel but keep plans flexible.</li>
+                    <li><strong>Shoulder months:</strong> Late Oct/early Nov and April can offer better prices with decent weather.</li>
+                </ul>
+            </div>
+            <div class="info-card">
+                <h3 class="heading-font text-2xl mb-3">Top Attractions</h3>
+                <ul class="space-y-3 text-gray-300">
+                    <li>Sunset Town night walk, bridge area, and evening shows.</li>
+                    <li>Hon Thom Cable Car (world's longest over-sea cable car).</li>
+                    <li>Sun World Nature Park rides + water park.</li>
+                    <li>Sao Beach and Khem Beach for calmer water and beach days.</li>
+                    <li>Night market seafood in Duong Dong.</li>
+                </ul>
+            </div>
+            <div class="info-card">
+                <h3 class="heading-font text-2xl mb-3">Practical Tips</h3>
+                <ul class="space-y-3 text-gray-300">
+                    <li>Use Grab where available, but consider a scooter if you're confident in traffic.</li>
+                    <li>For Sun World day trips, go early to avoid heat and peak queues.</li>
+                    <li>Bring reef-safe sunscreen, water shoes, and a dry bag for boat/cable car days.</li>
+                    <li>Mobile data helps a lot for transport and translation — Saily eSIM with code <strong>CARL10</strong> is included in the video notes.</li>
+                </ul>
+            </div>
+        </div>
+    </section>
+
+    <footer class="py-12" style="background: var(--dark); border-top: 1px solid var(--dark-3);">
+        <div class="container mx-auto px-6 text-sm text-center text-gray-400">© 2025 Carl Tomich · <a href="/destinations.html" class="nav-link">More destinations</a></div>
+    </footer>
+
+    <script>
+        const navbar = document.getElementById('navbar');
+        const menuButton = document.getElementById('mobile-menu-button');
+        const mobileMenu = document.getElementById('mobile-menu');
+        if (mobileMenu) mobileMenu.style.display = 'none';
+        menuButton.addEventListener('click', () => {
+            mobileMenu.style.display = mobileMenu.style.display === 'none' ? 'block' : 'none';
+        });
+        window.addEventListener('scroll', () => navbar.classList.toggle('scrolled', window.scrollY > 40));
+    </script>
+    <script src="/assets/js/site.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a new destination guide for Phu Quoc that matches the site’s existing travel guide style and includes the two requested video walkthroughs. 
- Surface Phu Quoc in the main `destinations.html` grid and interactive map so visitors can discover and access the guide easily.

### Description
- Added a new full guide page at `phuquoctravelguide.html` with sections for where to stay, best time to visit, top attractions, and practical tips, and embedded the two requested videos (`https://youtu.be/Plen_Co5MPs` and `https://youtu.be/H0scQqpIUS0`).
- Inserted a Phu Quoc destination card into `destinations.html` that matches the existing card layout and links to the new guide page.
- Added a Phu Quoc entry to the destinations map sidebar and to the JavaScript destination dataset (map coordinates, URL, and `video` embed) so map interactions work with the new page.

### Testing
- Ran `rg -n "phuquoc|Phu Quoc" destinations.html phuquoctravelguide.html` to confirm the new page and references are present, which succeeded. 
- Served the site locally with `python3 -m http.server 4173` and visually verified `/phuquoctravelguide.html` and `/destinations.html`, which loaded and rendered correctly. 
- Captured automated screenshots via a Playwright script to validate rendering of the new guide page and the destinations page with the Phu Quoc card, which completed successfully. 
- Checked local status with `git status --short` as part of verification steps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b4b3ae3848323a1635d4ee622aebf)