### PR TITLE
Add new blog post: Athens → Sarandë bus guide (maps, blog card, sitemap)

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -233,6 +233,36 @@
             </div>
 
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+                <!-- Blog Post: Athens to Sarande Bus Guide -->
+                <div class="blog-card rounded-xl overflow-hidden shadow-lg">
+                    <div class="relative overflow-hidden h-64">
+                        <img src="https://images.unsplash.com/photo-1526772662000-3f88f10405ff?auto=format&fit=crop&w=1200&q=80"
+                            alt="Bus journey through mountains"
+                            class="w-full h-full object-cover transform hover:scale-110 transition-transform duration-500">
+                        <div class="absolute inset-0 card-overlay"></div>
+                        <div class="absolute bottom-0 left-0 p-6 text-white">
+                            <h3 class="text-xl font-bold">How to Get to Sarandë from Athens by Bus</h3>
+                            <p class="text-sm">Direct Route with Ahmeti Travel</p>
+                        </div>
+                        <span
+                            class="absolute top-4 right-4 bg-yellow-900 text-white text-xs px-3 py-1 rounded-full">New</span>
+                    </div>
+                    <div class="p-6 bg-white">
+                        <div class="flex justify-between items-center mb-3">
+                            <span class="text-gray-500 text-sm"><i class="fas fa-bus mr-1 text-yellow-500"></i>
+                                Greece to Albania</span>
+                        </div>
+                        <p class="text-gray-600 mb-4 text-sm">
+                            Timings, ticket cost, border process, and practical steps for the easiest overland route
+                            from Athens to Sarandë.
+                        </p>
+                        <a href="how-to-get-to-sarande-from-athens-by-bus.html"
+                            class="text-yellow-500 font-medium hover:text-yellow-500 inline-flex items-center">
+                            Read the route guide <i class="fas fa-arrow-right ml-2"></i>
+                        </a>
+                    </div>
+                </div>
+
                 <!-- Blog Post: Living in Bangkok -->
                 <div class="blog-card rounded-xl overflow-hidden shadow-lg">
                     <div class="relative overflow-hidden h-64">

--- a/how-to-get-to-sarande-from-athens-by-bus.html
+++ b/how-to-get-to-sarande-from-athens-by-bus.html
@@ -1,0 +1,291 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>How to Get to Sarandë from Athens by Bus - Carl Travels</title>
+    <link rel="canonical" href="https://www.carltravels.com/how-to-get-to-sarande-from-athens-by-bus.html">
+    <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="e44b7cd2-126b-4f49-8aee-22495afe3ece"
+        type="text/javascript" async></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-G72KT5ZW2J"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag() { dataLayer.push(arguments); }
+        gtag('js', new Date());
+        gtag('config', 'G-G72KT5ZW2J');
+    </script>
+
+    <meta name="description"
+        content="A practical guide to taking the Ahmeti Travel direct bus from Athens to Sarandë, including cost, duration, border process, and route maps.">
+    <meta name="keywords"
+        content="Athens to Sarande bus, Ahmeti Travel, how to get to Sarande, Greece to Albania bus, Sarande travel guide">
+    <meta name="author" content="Carl Ostomich">
+
+    <meta property="og:title" content="How to Get to Sarandë from Athens by Bus - Carl Travels">
+    <meta property="og:description"
+        content="Direct overland route from Athens to Sarandë with Ahmeti Travel: departure point, timing, cost, border crossing tips, and practical steps.">
+    <meta property="og:image" content="https://www.carltravels.com/korculalogo.jpg">
+    <meta property="og:url" content="https://www.carltravels.com/how-to-get-to-sarande-from-athens-by-bus.html">
+    <meta property="og:type" content="article">
+
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="How to Get to Sarandë from Athens by Bus - Carl Travels">
+    <meta name="twitter:description"
+        content="Direct bus route details from Athens to Sarandë with Ahmeti Travel, plus maps and step-by-step travel tips.">
+    <meta name="twitter:image" content="https://www.carltravels.com/korculalogo.jpg">
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700&family=Bebas+Neue&display=swap');
+
+        :root {
+            --primary: #f5c518;
+            --secondary: #2a2a2a;
+            --dark: #0b0b0b;
+            --light: #d4d4d4;
+        }
+
+        body {
+            font-family: 'Montserrat', sans-serif;
+            background-color: var(--dark);
+            color: var(--light);
+            scroll-behavior: smooth;
+        }
+
+        .hero-gradient {
+            background: linear-gradient(135deg, rgba(42, 42, 42, 0.92), rgba(10, 10, 10, 0.9));
+        }
+
+        .heading-font {
+            font-family: 'Bebas Neue', sans-serif;
+        }
+
+        .navbar {
+            backdrop-filter: blur(10px);
+            background-color: rgba(26, 26, 26, 0.92);
+            transition: all 0.3s ease;
+        }
+
+        .navbar.scrolled {
+            background-color: rgba(26, 26, 26, 0.98);
+            box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.35);
+        }
+
+        .mobile-menu {
+            max-height: 0;
+            overflow: hidden;
+            transition: max-height 0.5s ease-out;
+            background: rgba(12, 12, 12, 0.95);
+            border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+        }
+
+        .mobile-menu.open {
+            max-height: 500px;
+        }
+
+        .nav-link {
+            color: #d4d4d4;
+            transition: color 0.3s ease;
+        }
+
+        .nav-link:hover {
+            color: #f5c518;
+        }
+
+        .wave-shape {
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            width: 100%;
+            overflow: hidden;
+            line-height: 0;
+        }
+
+        .wave-shape svg {
+            position: relative;
+            display: block;
+            width: calc(100% + 1.3px);
+            height: 150px;
+        }
+
+        .wave-shape .shape-fill {
+            fill: #050505;
+        }
+
+        .glass-card {
+            background: rgba(20, 20, 20, 0.8);
+            border: 1px solid rgba(255, 255, 255, 0.06);
+            backdrop-filter: blur(14px);
+            box-shadow: 0 25px 55px -22px rgba(0, 0, 0, 0.55);
+        }
+
+        .content a {
+            color: #f5c518;
+        }
+
+        .content a:hover {
+            color: #fcd34d;
+        }
+
+        ul li {
+            margin-bottom: 0.5rem;
+        }
+
+        .map-wrap iframe {
+            width: 100%;
+            min-height: 280px;
+            border: 0;
+            border-radius: 0.75rem;
+        }
+    </style>
+</head>
+
+<body class="text-gray-200">
+    <nav id="navbar" class="navbar fixed w-full z-50">
+        <div class="container mx-auto px-6 py-4">
+            <div class="flex justify-between items-center">
+                <a href="/index.html" class="text-2xl font-bold">
+                    <span class="heading-font" style="color: var(--primary);">CARL TOMICH</span>
+                </a>
+
+                <div class="hidden md:flex items-center space-x-8">
+                    <a href="/index.html" class="nav-link font-medium">Films</a>
+                    <a href="/portfolio.html" class="nav-link font-medium">Portfolio</a>
+                    <a href="/films/martial-arts-documentary.html" class="nav-link font-medium">Current Project</a>
+                    <a href="/blog.html" class="nav-link font-medium">Blog</a>
+                    <a href="/gear.html" class="nav-link font-medium">Gear</a>
+                    <a href="/destinations.html" class="nav-link font-medium">Travel</a>
+                    <a href="/about.html" class="nav-link font-medium">About</a>
+                    <a href="/donate.html" class="nav-link font-medium" style="color: var(--primary);">Donate</a>
+                </div>
+
+                <button id="mobile-menu-button" class="md:hidden focus:outline-none" style="color: var(--light);">
+                    <i class="fas fa-bars text-2xl"></i>
+                </button>
+            </div>
+
+            <div id="mobile-menu" class="mobile-menu md:hidden">
+                <div class="pt-4 pb-2 space-y-2">
+                    <a href="/index.html" class="block px-3 py-2 rounded-md nav-link">Films</a>
+                    <a href="/portfolio.html" class="block px-3 py-2 rounded-md nav-link">Portfolio</a>
+                    <a href="/films/martial-arts-documentary.html" class="block px-3 py-2 rounded-md nav-link">Current
+                        Project</a>
+                    <a href="/blog.html" class="block px-3 py-2 rounded-md nav-link">Blog</a>
+                    <a href="/gear.html" class="block px-3 py-2 rounded-md nav-link">Gear</a>
+                    <a href="/destinations.html" class="block px-3 py-2 rounded-md nav-link">Travel</a>
+                    <a href="/about.html" class="block px-3 py-2 rounded-md nav-link">About</a>
+                    <a href="/donate.html" class="block px-3 py-2 rounded-md nav-link"
+                        style="color: var(--primary);">Donate</a>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <section class="hero-gradient relative overflow-hidden min-h-[50vh] flex items-center pt-32 pb-20"
+        style="background-image: url('https://images.unsplash.com/photo-1526772662000-3f88f10405ff?auto=format&fit=crop&w=1500&q=80'); background-size: cover; background-position: center;">
+        <div class="absolute inset-0 bg-black/70"></div>
+        <div class="container mx-auto px-6 relative z-10">
+            <div class="text-center max-w-4xl mx-auto">
+                <span class="inline-block px-4 py-1 rounded-full bg-yellow-500/20 text-yellow-300 text-sm tracking-wide mb-6">GREECE → ALBANIA</span>
+                <h1 class="heading-font text-4xl md:text-6xl text-white mb-4">How to Get to Sarandë from Athens by Bus</h1>
+                <p class="text-lg text-gray-200 max-w-3xl mx-auto">The direct Ahmeti Travel route is low-stress, affordable, and surprisingly scenic.</p>
+            </div>
+        </div>
+        <div class="wave-shape">
+            <svg data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 120" preserveAspectRatio="none">
+                <path d="M321.39,56.44C179.59,89.28,52.62,92.22,0,76V120H1200V0C1132.19,45.55,994.84,68.38,860,65.54,727.11,62.74,637.85,34.44,504.77,24.26,390.26,15.52,354.05,48.74,321.39,56.44Z" class="shape-fill"></path>
+            </svg>
+        </div>
+    </section>
+
+    <main class="py-16 bg-[#050505]">
+        <article class="container mx-auto px-6 max-w-4xl space-y-10 content">
+            <div class="glass-card rounded-2xl p-8">
+                <h2 class="heading-font text-3xl text-white mb-4">Ahmeti Travel: Direct Bus to Sarandë</h2>
+                <p>If you want the simplest overland route from Athens to Sarandë, the direct bus is the most straightforward option. No transfers. No border juggling. You get on in Athens and get off in southern Albania.</p>
+                <p>I took a bus with Ahmeti Travel. The departure point was <strong>Θεοδ. Δηλιγιάννη 21, Αθήνα</strong>. It is near central Athens and easy to reach by metro or taxi. To remove friction from the process, I booked a hotel about 50 metres from the pickup point. I flew into Athens the day before, stayed overnight, then walked to the bus in the morning. That made the whole experience low stress.</p>
+                <p>The ticket cost <strong>€35</strong>. For an international journey of nearly nine hours, that is reasonable.</p>
+            </div>
+
+            <div class="glass-card rounded-2xl p-8">
+                <h2 class="heading-font text-3xl text-white mb-4">Travel Day Details</h2>
+                <ul class="list-disc list-inside space-y-2">
+                    <li>The bus left at <strong>8:00 am</strong> and arrived in Sarandë at <strong>4:45 pm</strong>.</li>
+                    <li>There was one proper stop of around <strong>20 minutes</strong> for food and drinks.</li>
+                    <li>The driver also made a few very short stops along the way, usually around a minute.</li>
+                    <li>I stored two bags underneath in the luggage compartment without issue.</li>
+                </ul>
+                <p class="mt-4">Keep essentials in a small day bag with you, especially passport, wallet, and water.</p>
+            </div>
+
+            <div class="glass-card rounded-2xl p-8">
+                <h2 class="heading-font text-3xl text-white mb-4">What the Route Feels Like</h2>
+                <p>The drive itself is better than expected. After leaving Athens, the scenery shifts quickly: mountains, lakes, and small towns. Closer to the Albanian border, the landscape feels more rugged and less developed. At one point I noticed wild animals near the roadside. It does not feel like a generic highway transfer; there is real texture to the journey.</p>
+                <p>Border control is straightforward. Everyone gets off the bus with their passport, goes through checks, then gets back on. It was orderly and not overly slow, but it is smart to factor in delays during busy periods.</p>
+                <p>By the time you reach Sarandë, the terrain opens toward the coast. After hours of mountains and inland roads, seeing the Ionian Sea again feels earned.</p>
+            </div>
+
+            <div class="glass-card rounded-2xl p-8">
+                <h2 class="heading-font text-3xl text-white mb-6">Map: Key Points on the Trip</h2>
+                <div class="grid gap-6 md:grid-cols-2 map-wrap">
+                    <div>
+                        <h3 class="text-xl font-semibold text-white mb-3">Athens Pickup Point</h3>
+                        <iframe loading="lazy" allowfullscreen referrerpolicy="no-referrer-when-downgrade"
+                            src="https://www.google.com/maps?q=%CE%98%CE%B5%CE%BF%CE%B4.%20%CE%94%CE%B7%CE%BB%CE%B9%CE%B3%CE%B9%CE%AC%CE%BD%CE%BD%CE%B7%2021%2C%20Athens&output=embed"></iframe>
+                    </div>
+                    <div>
+                        <h3 class="text-xl font-semibold text-white mb-3">Arrival in Sarandë</h3>
+                        <iframe loading="lazy" allowfullscreen referrerpolicy="no-referrer-when-downgrade"
+                            src="https://www.google.com/maps?q=Sarande%2C%20Albania&output=embed"></iframe>
+                    </div>
+                </div>
+                <p class="mt-5 text-sm text-gray-300">Tip: Open both maps in Google Maps and save them offline before travel day.</p>
+            </div>
+
+            <div class="glass-card rounded-2xl p-8">
+                <h2 class="heading-font text-3xl text-white mb-4">Practical Steps</h2>
+                <ul class="list-disc list-inside space-y-2">
+                    <li>Fly into Athens at least one day before departure.</li>
+                    <li>Book a hotel near Θεοδ. Δηλιγιάννη 21 to avoid morning stress.</li>
+                    <li>Purchase your Ahmeti Travel ticket in advance.</li>
+                    <li>Arrive at least 20 to 30 minutes before the 8:00 am departure.</li>
+                    <li>Bring snacks and water, even though there is one main stop.</li>
+                    <li>Keep your passport easily accessible for the border crossing.</li>
+                </ul>
+                <p class="mt-5">For €35, it is an efficient and scenic way to move from Greece into southern Albania without the complexity of flights or multiple buses. It is not luxury travel, but it is practical, direct, and gets you where you need to go.</p>
+            </div>
+        </article>
+    </main>
+
+    <footer class="bg-[#030303] border-t border-white/10 py-10">
+        <div class="container mx-auto px-6 text-center text-gray-400">
+            <p>© <span id="year"></span> Carl Travels. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <script>
+        const navbar = document.getElementById('navbar');
+        window.addEventListener('scroll', function () {
+            if (window.scrollY > 50) {
+                navbar.classList.add('scrolled');
+            } else {
+                navbar.classList.remove('scrolled');
+            }
+        });
+
+        const mobileMenuButton = document.getElementById('mobile-menu-button');
+        const mobileMenu = document.getElementById('mobile-menu');
+        if (mobileMenuButton && mobileMenu) {
+            mobileMenuButton.addEventListener('click', () => {
+                mobileMenu.classList.toggle('open');
+            });
+        }
+
+        document.getElementById('year').textContent = new Date().getFullYear();
+    </script>
+</body>
+
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -61,4 +61,5 @@
   <url><loc>https://www.carltravels.com/macbook-pro-m4-max-review.html</loc></url>
   <url><loc>https://www.carltravels.com/sony-fx30-setup-guide.html</loc></url>
   <url><loc>https://www.carltravels.com/living-in-bangkok.html</loc></url>
+  <url><loc>https://www.carltravels.com/how-to-get-to-sarande-from-athens-by-bus.html</loc></url>
 </urlset>


### PR DESCRIPTION
### Motivation
- Add a new blog post matching the existing `blog.html` style describing how to get to Sarandë from Athens by bus, including practical steps, timings, and maps for readers.
- Surface the article in the site index and navigation by adding a blog card and updating the sitemap (`sitemap.xml`).
- No external skills were used; changes follow the existing site templates and assets.

### Description
- Created `how-to-get-to-sarande-from-athens-by-bus.html` containing the provided content, styled to match other posts and embedding two Google Maps iframes for the Athens pickup point and Sarandë arrival.
- Added a new blog card to `blog.html` that links to the new post and uses the same card layout as other posts.
- Appended the new URL entry to `sitemap.xml` for discoverability and added small CSS/JS tweaks (mobile menu / `.nav-link` styles and year script) inside the new article file.
- Committed the changes to the repository with the message "Add Sarandë bus guide post with maps and blog listing".

### Testing
- Parsed `sitemap.xml` with Python’s `xml.etree` successfully and asserted that `how-to-get-to-sarande-from-athens-by-bus.html` exists (test passed).
- Verified presence of the new page and links using `rg`/ripgrep checks (test passed).
- Attempted to capture visual screenshots with Playwright, but Chromium crashed in this environment (SIGSEGV), so no screenshot artifacts were produced (test failed due to environment issue).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6e41ad1d8832394eeef3a37b1523c)