### PR TITLE
Add Sarandë bus guide post and local image with fallback

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -236,8 +236,9 @@
                 <!-- Blog Post: Athens to Sarande Bus Guide -->
                 <div class="blog-card rounded-xl overflow-hidden shadow-lg">
                     <div class="relative overflow-hidden h-64">
-                        <img src="https://images.unsplash.com/photo-1526772662000-3f88f10405ff?auto=format&fit=crop&w=1200&q=80"
-                            alt="Bus journey through mountains"
+                        <img src="sarandebus.jpg"
+                            onerror="this.onerror=null;this.src='https://images.unsplash.com/photo-1526772662000-3f88f10405ff?auto=format&fit=crop&w=1200&q=80';"
+                            alt="Athens to Sarandë bus route"
                             class="w-full h-full object-cover transform hover:scale-110 transition-transform duration-500">
                         <div class="absolute inset-0 card-overlay"></div>
                         <div class="absolute bottom-0 left-0 p-6 text-white">

--- a/index.html
+++ b/index.html
@@ -487,12 +487,12 @@
 
             <div class="grid md:grid-cols-3 gap-8">
                 <div class="film-card p-6">
-                    <h3 class="font-bold text-xl mb-4" style="color: var(--light);">Why I Left Australia</h3>
+                    <h3 class="font-bold text-xl mb-4" style="color: var(--light);">How to Get to Sarandë from Athens by Bus</h3>
                     <p class="mb-6" style="color: var(--muted);">
-                        The slow realization that the place you grew up in isn't the place you belong anymore. And what
-                        happens when you walk away.
+                        The direct Ahmeti Travel route explained with departure details, ticket pricing, and exactly
+                        what to expect at the Greece–Albania border.
                     </p>
-                    <a href="/whyileftaustralia.html" class="text-sm font-semibold" style="color: var(--primary);">Read
+                    <a href="/how-to-get-to-sarande-from-athens-by-bus.html" class="text-sm font-semibold" style="color: var(--primary);">Read
                         →</a>
                 </div>
 


### PR DESCRIPTION
### Motivation
- Promote a new travel guide for getting from Athens to Sarandë and surface it in the site’s blog and homepage feature list. 
- Prefer a local image asset with a remote fallback to improve resilience and reduce dependency on external CDN availability. 

### Description
- In `blog.html` replaced the hardcoded Unsplash `src` with `sarandebus.jpg`, added an `onerror` fallback to the original Unsplash URL, and updated the `alt` text to reference the Athens–Sarandë bus route. 
- In `index.html` updated the featured blog card title, summary, and `href` to point to `how-to-get-to-sarande-from-athens-by-bus.html`. 
- Added a trailing newline at end of `index.html` to normalize file ending.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7b4aa873c8323878aa3e3ced343ca)