### PR TITLE
Update AIARTY coupon checkout link and confirm YouTube embed

### DIFF
--- a/aiarty-video-enhancer-review.html
+++ b/aiarty-video-enhancer-review.html
@@ -394,7 +394,7 @@
                 <div class="info-card lg:sticky lg:top-28">
                     <h3 class="text-2xl font-semibold text-white mb-4">Pricing &amp; Deals</h3>
                     <p class="text-gray-300 mb-4">AIARTY is a one-time $165 USD purchase, covering unlimited installs and updates. During this review, the developers offered Carl Tomich Tech Reviews viewers an extra discount.</p>
-                    <a href="https://secure.2checkout.com/order/checkout.phpPRODS=50333861&QTY=1&AFFILIATE=246587&AFFSRC=image_enhancer_video&CART=1" target="_blank" rel="noopener" class="cta-button w-full justify-center mb-3">
+                    <a href="https://secure.2checkout.com/order/checkout.php?PRODS=50334856&QTY=1&AFFILIATE=246587&AFFSRC=image_enhancer_video&CART=1" target="_blank" rel="noopener" class="cta-button w-full justify-center mb-3">
                         <i class="fas fa-shopping-cart"></i>
                         Buy it here to save 36% on AIARTY
                     </a>


### PR DESCRIPTION
### Motivation
- The 2Checkout coupon CTA URL on the AIARTY Video Enhancer review page was broken and needed to be replaced with the working URL provided so visitors can complete purchases. 
- The article should also explicitly include the requested YouTube review video embed to ensure readers can watch the walkthrough from the page.

### Description
- Replaced the outdated 2Checkout link in `aiarty-video-enhancer-review.html` (Pricing & Deals) with the provided working URL: `https://secure.2checkout.com/order/checkout.php?PRODS=50334856&QTY=1&AFFILIATE=246587&AFFSRC=image_enhancer_video&CART=1`.
- Verified the requested YouTube video (`fsYA84tjrTE`) is embedded in the article in both the hero and the dedicated video walkthrough sections.
- No AGENTS.md skills were used because this was a straightforward HTML content update.
- Committed the HTML change to the branch.

### Testing
- Ran a content search with `rg -n '2checkout|AFFSRC|coupon|secure\.2checkout|youtube|youtu|iframe|Aiarty|Ai Airty|video enhancer' aiarty-video-enhancer-review.html` to locate and verify the link and embeds, and it succeeded. 
- Produced a diff with `git diff -- aiarty-video-enhancer-review.html | cat` to confirm the URL change, and it succeeded. 
- Confirmed the file was staged and committed with `git status --short` and `git commit`, and the commit succeeded. 
- Inspected the file lines with `nl -ba aiarty-video-enhancer-review.html | sed -n '236,320p'` and `sed -n '388,408p'` to verify the `iframe` embeds and updated link, and the inspection showed the expected changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac8db3babc83238bacfea90b12ec89)