### PR TITLE
Fix percent-escaping in CSS, harden YouTube iframes, and update affiliate checkout link

### DIFF
--- a/aiarty-video-enhancer-review.html
+++ b/aiarty-video-enhancer-review.html
@@ -107,8 +107,8 @@
         }
         .responsive-video {
             position: relative;
-            width: 100%%;
-            padding-bottom: 56.25%%;
+            width: 100%;
+            padding-bottom: 56.25%;
             border-radius: 1.5rem;
             overflow: hidden;
             box-shadow: 0 35px 65px -25px rgba(59, 130, 246, 0.45);
@@ -117,8 +117,8 @@
             position: absolute;
             top: 0;
             left: 0;
-            width: 100%%;
-            height: 100%%;
+            width: 100%;
+            height: 100%;
             border: none;
             z-index: 0;
         }
@@ -245,7 +245,7 @@
                 <div class="relative">
                     <div class="info-card">
                         <div class="responsive-video video-overlay" style="--video-thumb: url('https://img.youtube.com/vi/fsYA84tjrTE/maxresdefault.jpg');">
-                            <iframe src="https://www.youtube.com/embed/fsYA84tjrTE" title="AIARTY Video Enhancer Review" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                            <iframe width="560" height="315" src="https://www.youtube.com/embed/fsYA84tjrTE" title="AIARTY Video Enhancer Review" loading="lazy" referrerpolicy="strict-origin-when-cross-origin" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
                         </div>
                         <p class="text-slate-300 text-sm mt-4">Watch the full YouTube review of AIARTY Video Enhancer, featuring side-by-side tests and workflow tips.</p>
                     </div>
@@ -304,7 +304,7 @@
                     <p class="text-slate-200 max-w-2xl">This video covers the same clips mentioned in the article, including the MoDetail model, denoise settings, and export speed comparisons against Topaz Video AI.</p>
                 </div>
                 <div class="responsive-video video-overlay" style="--video-thumb: url('https://img.youtube.com/vi/fsYA84tjrTE/maxresdefault.jpg');">
-                    <iframe src="https://www.youtube.com/embed/fsYA84tjrTE" title="AIARTY Video Enhancer Review" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                    <iframe width="560" height="315" src="https://www.youtube.com/embed/fsYA84tjrTE" title="AIARTY Video Enhancer Review" loading="lazy" referrerpolicy="strict-origin-when-cross-origin" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
                 </div>
             </div>
         </div>
@@ -394,7 +394,7 @@
                 <div class="info-card lg:sticky lg:top-28">
                     <h3 class="text-2xl font-semibold text-white mb-4">Pricing &amp; Deals</h3>
                     <p class="text-gray-300 mb-4">AIARTY is a one-time $165 USD purchase, covering unlimited installs and updates. During this review, the developers offered Carl Tomich Tech Reviews viewers an extra discount.</p>
-                    <a href="https://secure.2checkout.com/order/checkout.phpPRODS=50333861&QTY=1&AFFILIATE=246587&AFFSRC=image_enhancer_video&CART=1" target="_blank" rel="noopener" class="cta-button w-full justify-center mb-3">
+                    <a href="https://secure.2checkout.com/order/checkout.php?PRODS=50334856&QTY=1&AFFILIATE=246587&AFFSRC=image_enhancer_video&CART=1" target="_blank" rel="noopener" class="cta-button w-full justify-center mb-3">
                         <i class="fas fa-shopping-cart"></i>
                         Buy it here to save 36% on AIARTY
                     </a>


### PR DESCRIPTION
### Motivation
- Correct malformed percent-escapes in the responsive video CSS so styles render as intended.
- Improve embedded YouTube iframe markup for performance, privacy, and modern browser features.
- Point the affiliate CTA to the correct 2Checkout product and query format so the buy link is valid.

### Description
- Replace accidental double-percent tokens (`%%`) with single percent signs (`%`) in the responsive video CSS rules.
- Add explicit `width`/`height` attributes and include `loading="lazy"`, `referrerpolicy="strict-origin-when-cross-origin"`, and `web-share` in the `allow` list on YouTube `iframe`s.
- Correct the affiliate checkout URL by adding the `?` query delimiter and updating the `PRODS` value to `50334856`.

### Testing
- No automated tests were run for this static HTML change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac8db3babc83238bacfea90b12ec89)