### PR TITLE
Restore Aiarty video enhancer article card on gear page

### DIFF
--- a/gear.html
+++ b/gear.html
@@ -372,7 +372,39 @@
                     </div>
                 </div>
 
-                <!-- Card 3: DaVinci Resolve -->
+                <!-- Card 3: AIARTY Video Enhancer -->
+                <div class="blog-card rounded-xl overflow-hidden shadow-lg">
+                    <div class="relative overflow-hidden h-64">
+                        <img src="https://img.youtube.com/vi/OC4M4wWQ6MY/maxresdefault.jpg"
+                            alt="Aiarty AI Video Enhancer Review"
+                            class="w-full h-full object-cover transform hover:scale-110 transition-transform duration-500">
+                        <div class="absolute inset-0 card-overlay"></div>
+                        <div class="absolute bottom-0 left-0 p-6 text-white">
+                            <h3 class="text-xl font-bold">Aiarty AI Video Enhancer</h3>
+                            <p class="text-sm">Upscaling & Frame Interpolation</p>
+                        </div>
+                    </div>
+                    <div class="p-6 bg-white">
+                        <div class="flex justify-between items-center mb-3">
+                            <span class="text-gray-500 text-sm"><i class="fas fa-film mr-1 text-yellow-500"></i> AI
+                                Tools</span>
+                            <div class="flex items-center">
+                                <i class="fas fa-star text-yellow-400 mr-1"></i>
+                                <span class="font-medium">4.6</span>
+                            </div>
+                        </div>
+                        <p class="text-gray-600 mb-4">
+                            Hands-on results from restoring soft footage, reducing noise, and improving playback with
+                            Aiarty’s AI-powered video workflow.
+                        </p>
+                        <a href="aiarty-video-enhancer-review.html"
+                            class="text-yellow-500 font-medium hover:text-yellow-500 inline-flex items-center">
+                            Read Review <i class="fas fa-arrow-right ml-2"></i>
+                        </a>
+                    </div>
+                </div>
+
+                <!-- Card 4: DaVinci Resolve -->
                 <div class="blog-card rounded-xl overflow-hidden shadow-lg">
                     <div class="relative overflow-hidden h-64">
                         <img src="https://img.youtube.com/vi/wUYUV_F4WQo/maxresdefault.jpg"


### PR DESCRIPTION
### Motivation
- The gear page was missing the Aiarty video enhancer article while the Aiarty image enhancer article remained, so both reviews need to be visible in the article grid.
- Restore the video enhancer entry to preserve content parity between Aiarty image and video reviews.

### Description
- Added a new `Aiarty AI Video Enhancer` card block to `gear.html` linking to `aiarty-video-enhancer-review.html` and including thumbnail, title, summary, and rating markup.
- Kept the existing `Aiarty AI Image Enhancer` card intact so both enhancer articles appear together in the grid.
- Updated the following section comment numbering so the subsequent `DaVinci Resolve` card comment reflects the new ordering.

### Testing
- Verified presence of the new entries with `rg -n "AIARTY|aiarty-video-enhancer-review|Card 4: DaVinci" gear.html` which returned expected matches (success).
- Served the site locally with `python3 -m http.server 4173` and performed a visual check using a Playwright script to capture a screenshot of `http://127.0.0.1:4173/gear.html` (screenshot captured successfully).
- Confirmed the modified file is `gear.html` and the inserted card renders as expected in the local preview (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac9421a25c8323bd499a0bcb5ff536)