### PR TITLE
Update AIARTY video card thumbnail on gear page

### DIFF
--- a/gear.html
+++ b/gear.html
@@ -375,7 +375,7 @@
                 <!-- Card 3: AIARTY Video Enhancer -->
                 <div class="blog-card rounded-xl overflow-hidden shadow-lg">
                     <div class="relative overflow-hidden h-64">
-                        <img src="https://img.youtube.com/vi/OC4M4wWQ6MY/maxresdefault.jpg"
+                        <img src="https://img.youtube.com/vi/fsYA84tjrTE/maxresdefault.jpg"
                             alt="Aiarty AI Video Enhancer Review"
                             class="w-full h-full object-cover transform hover:scale-110 transition-transform duration-500">
                         <div class="absolute inset-0 card-overlay"></div>


### PR DESCRIPTION
### Motivation
- Ensure the AIARTY Video Enhancer card on the gear page uses the same YouTube thumbnail as the linked review page so the link artwork matches the destination content.

### Description
- Replaced the AIARTY video card image `src` in `gear.html` with `https://img.youtube.com/vi/fsYA84tjrTE/maxresdefault.jpg` to match the review page thumbnail.

### Testing
- Ran `rg -n "fsYA84tjrTE|OC4M4wWQ6MY" gear.html` to confirm the updated thumbnail ID is present (success).
- Served the site with `python3 -m http.server 4173` and captured a Playwright screenshot of `http://127.0.0.1:4173/gear.html` to visually validate the updated card (success).
- Inspected the updated file to confirm only the thumbnail line was changed (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac9f9da434832380b0850eeaf13178)