### PR TITLE
Add SoundMarket review page and feature card on Gear page

### DIFF
--- a/gear.html
+++ b/gear.html
@@ -212,6 +212,41 @@
 
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
 
+                <!-- Card 0: SoundMarket Review -->
+                <div class="blog-card rounded-xl overflow-hidden shadow-lg">
+                    <div class="relative overflow-hidden h-64">
+                        <img src="https://img.youtube.com/vi/8eWZmmillt8/maxresdefault.jpg"
+                            alt="SoundMarket royalty free music review"
+                            class="w-full h-full object-cover transform hover:scale-110 transition-transform duration-500">
+                        <div class="absolute inset-0 card-overlay"></div>
+                        <div class="absolute bottom-0 left-0 p-6 text-white">
+                            <h3 class="text-xl font-bold">SoundMarket Review</h3>
+                            <p class="text-sm">Royalty Free Music for YouTube?</p>
+                        </div>
+                        <span
+                            class="absolute top-4 right-4 bg-yellow-500 text-black text-xs px-3 py-1 rounded-full font-bold">Music
+                            Tools</span>
+                    </div>
+                    <div class="p-6 bg-white">
+                        <div class="flex justify-between items-center mb-3">
+                            <span class="text-gray-500 text-sm"><i class="fas fa-music mr-1 text-yellow-500"></i>
+                                Audio</span>
+                            <div class="flex items-center">
+                                <i class="fas fa-star text-yellow-400 mr-1"></i>
+                                <span class="font-medium">4.8</span>
+                            </div>
+                        </div>
+                        <p class="text-gray-600 mb-4 text-sm">
+                            I tested SoundMarket to see if its curated catalog and pricing make it a practical
+                            alternative to Artlist and Epidemic Sound.
+                        </p>
+                        <a href="soundmarket.html"
+                            class="text-yellow-500 font-medium hover:text-yellow-500 inline-flex items-center">
+                            Read the review <i class="fas fa-arrow-right ml-2"></i>
+                        </a>
+                    </div>
+                </div>
+
 
                 <!-- Card 0: MacBook Pro M4 Max -->
                 <div class="blog-card rounded-xl overflow-hidden shadow-lg">

--- a/soundmarket.html
+++ b/soundmarket.html
@@ -1,0 +1,241 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SoundMarket Review (2026): Royalty Free Music for YouTube Creators | Carl Travels</title>
+    <meta name="description" content="Hands-on SoundMarket review for YouTube creators: pricing, licensing, catalog quality, and whether it is a strong alternative to Artlist and Epidemic Sound." />
+    <meta name="keywords" content="SoundMarket review, royalty free music for YouTube, YouTube music licensing, Artlist alternative, Epidemic Sound alternative" />
+    <meta name="author" content="Carl Tomich" />
+    <meta property="og:title" content="SoundMarket Review (2026): Royalty Free Music for YouTube Creators" />
+    <meta property="og:description" content="I tested SoundMarket for YouTube and travel video edits. Here is what stands out on licensing, quality, and value." />
+    <meta property="og:image" content="https://img.youtube.com/vi/8eWZmmillt8/maxresdefault.jpg" />
+    <meta property="og:url" content="https://www.carltravels.com/soundmarket.html" />
+    <meta property="og:type" content="article" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="SoundMarket Review (2026): Royalty Free Music for YouTube Creators" />
+    <meta name="twitter:description" content="SoundMarket tested for YouTube creators: claims safety, catalog depth, free tier, and pricing." />
+    <meta name="twitter:image" content="https://img.youtube.com/vi/8eWZmmillt8/maxresdefault.jpg" />
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700&family=Bebas+Neue&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/assets/css/styles.css">
+    <style>
+        :root {
+            --primary: #facc15;
+            --secondary: #0f172a;
+            --dark: #020617;
+            --light: #e2e8f0;
+        }
+        body {
+            font-family: 'Montserrat', sans-serif;
+            background-color: var(--dark);
+            color: var(--light);
+            scroll-behavior: smooth;
+        }
+        .hero {
+            background: radial-gradient(circle at top left, rgba(250, 204, 21, 0.2), transparent 58%),
+                        radial-gradient(circle at bottom right, rgba(56, 189, 248, 0.15), transparent 60%),
+                        linear-gradient(135deg, rgba(15, 23, 42, 0.95), rgba(2, 6, 23, 0.96));
+        }
+        .heading-font { font-family: 'Bebas Neue', sans-serif; }
+        .info-card {
+            background: rgba(15, 23, 42, 0.82);
+            border: 1px solid rgba(148, 163, 184, 0.24);
+            border-radius: 1.25rem;
+            padding: 1.75rem;
+        }
+        .responsive-video {
+            position: relative;
+            width: 100%;
+            padding-bottom: 56.25%;
+            border-radius: 1rem;
+            overflow: hidden;
+            box-shadow: 0 35px 65px -25px rgba(59, 130, 246, 0.45);
+        }
+        .responsive-video iframe {
+            position: absolute;
+            inset: 0;
+            width: 100%;
+            height: 100%;
+            border: none;
+        }
+        .navbar {
+            backdrop-filter: blur(12px);
+            background-color: rgba(2, 6, 23, 0.85);
+            transition: all 0.3s ease;
+        }
+        .navbar.scrolled {
+            background-color: rgba(2, 6, 23, 0.96);
+            box-shadow: 0 10px 30px -20px rgba(0, 0, 0, 0.6);
+        }
+        .mobile-menu { max-height: 0; overflow: hidden; transition: max-height 0.4s ease; }
+        .mobile-menu.open { max-height: 500px; }
+    </style>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-G72KT5ZW2J"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-G72KT5ZW2J');
+    </script>
+</head>
+<body class="min-h-screen">
+    <nav id="navbar" class="navbar fixed w-full z-50">
+        <div class="container mx-auto px-6 py-4">
+            <div class="flex justify-between items-center">
+                <a href="/index.html" class="text-2xl font-bold">
+                    <span class="heading-font" style="color: var(--primary);">CARL TOMICH</span>
+                </a>
+
+                <div class="hidden md:flex items-center space-x-8">
+                    <a href="/index.html" class="nav-link font-medium">Films</a>
+                    <a href="/portfolio.html" class="nav-link font-medium">Portfolio</a>
+                    <a href="/films/martial-arts-documentary.html" class="nav-link font-medium">Current Project</a>
+                    <a href="/blog.html" class="nav-link font-medium">Blog</a>
+                    <a href="/gear.html" class="nav-link font-medium">Gear</a>
+                    <a href="/destinations.html" class="nav-link font-medium">Travel</a>
+                    <a href="/about.html" class="nav-link font-medium">About</a>
+                    <a href="/donate.html" class="nav-link font-medium" style="color: var(--primary);">Donate</a>
+                </div>
+
+                <button id="mobile-menu-button" class="md:hidden focus:outline-none" style="color: var(--light);">
+                    <i class="fas fa-bars text-2xl"></i>
+                </button>
+            </div>
+
+            <div id="mobile-menu" class="mobile-menu md:hidden">
+                <div class="pt-4 pb-2 space-y-2">
+                    <a href="/index.html" class="block px-3 py-2 rounded-md nav-link">Films</a>
+                    <a href="/portfolio.html" class="block px-3 py-2 rounded-md nav-link">Portfolio</a>
+                    <a href="/films/martial-arts-documentary.html" class="block px-3 py-2 rounded-md nav-link">Current Project</a>
+                    <a href="/blog.html" class="block px-3 py-2 rounded-md nav-link">Blog</a>
+                    <a href="/gear.html" class="block px-3 py-2 rounded-md nav-link">Gear</a>
+                    <a href="/destinations.html" class="block px-3 py-2 rounded-md nav-link">Travel</a>
+                    <a href="/about.html" class="block px-3 py-2 rounded-md nav-link">About</a>
+                    <a href="/donate.html" class="block px-3 py-2 rounded-md nav-link" style="color: var(--primary);">Donate</a>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <header class="hero pt-32 pb-16">
+        <div class="container mx-auto px-6">
+            <div class="grid lg:grid-cols-2 gap-12 items-center">
+                <div class="space-y-6">
+                    <span class="inline-flex items-center gap-2 rounded-full border border-yellow-400/40 px-4 py-2 text-yellow-300 text-sm uppercase tracking-[0.12em]">
+                        <i class="fas fa-music"></i> Music Licensing Review
+                    </span>
+                    <h1 class="heading-font text-4xl md:text-5xl text-white leading-tight">Best Royalty Free Music for YouTube Creators? SoundMarket Review</h1>
+                    <p class="text-lg text-slate-200 leading-relaxed">If you make videos for YouTube, travel content, documentaries, or social media, you eventually run into the same problem: music licensing. I tested SoundMarket in a real edit workflow to see how it compares with larger platforms like Artlist and Epidemic Sound.</p>
+                    <div class="flex flex-wrap gap-4">
+                        <a href="#review" class="inline-flex items-center gap-2 px-6 py-3 rounded-full bg-yellow-400 text-black font-semibold hover:bg-yellow-300 transition-colors">Read the full review</a>
+                        <a href="https://soundmarket.io/?ref=CarlTravels" target="_blank" rel="noopener" class="inline-flex items-center gap-2 px-6 py-3 rounded-full border border-slate-500 text-slate-200 hover:border-yellow-400 hover:text-yellow-300 transition-colors">Visit SoundMarket</a>
+                    </div>
+                </div>
+                <div class="info-card">
+                    <div class="responsive-video" style="background-image: url('https://img.youtube.com/vi/8eWZmmillt8/maxresdefault.jpg'); background-size: cover; background-position: center;">
+                        <iframe src="https://www.youtube.com/embed/8eWZmmillt8" title="Best Royalty Free Music for YouTube Creators? SoundMarket Review" loading="lazy" referrerpolicy="strict-origin-when-cross-origin" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+                    </div>
+                    <p class="text-slate-300 text-sm mt-4">Watch the full video review and hear sample track selections in a travel/documentary editing context.</p>
+                </div>
+            </div>
+        </div>
+    </header>
+
+    <main id="review" class="py-16 px-6">
+        <div class="max-w-5xl mx-auto space-y-8">
+            <section class="info-card space-y-5">
+                <p>If you upload a video with the wrong music, the outcome is predictable: YouTube flags the content, ad revenue disappears, and sometimes the audio gets muted entirely. That is exactly why music licensing platforms for YouTube creators have become essential.</p>
+                <h2 class="text-2xl font-semibold text-white">How to Find Royalty Free Music for YouTube Videos</h2>
+                <p>If you upload videos to YouTube regularly, you must have proper usage rights for your music. Most creators end up using one of these options:</p>
+                <ul class="list-disc list-inside space-y-2 text-slate-200">
+                    <li>The YouTube Audio Library</li>
+                    <li>Paid platforms like Artlist or Epidemic Sound</li>
+                    <li>Curated royalty free libraries like SoundMarket</li>
+                </ul>
+                <p>While YouTube’s free library is useful, many creators move to dedicated platforms for better track quality and clearer monetization licensing.</p>
+            </section>
+
+            <section class="info-card space-y-5">
+                <h2 class="text-2xl font-semibold text-white">What Makes SoundMarket Different</h2>
+                <p>SoundMarket is a royalty free music library for creators, but the catalog sourcing is different from many traditional stock libraries. A lot of music comes from professional composers who work in film, television, advertising, and games.</p>
+                <p>Many tracks were originally created for real productions and later added to SoundMarket when they were not used in final edits. That gives the platform a less "generic stock" sound. The current library has around 18,000 tracks and is curated, which can reduce how often you hear the same songs reused across YouTube.</p>
+            </section>
+
+            <section class="info-card space-y-5">
+                <h2 class="text-2xl font-semibold text-white">Features Designed for Video Creators</h2>
+                <p>SoundMarket includes practical tools for editing workflows. Many songs provide ALT mixes that remove lead instruments so tracks sit better under narration or dialogue.</p>
+                <p>Higher subscription plans also include:</p>
+                <ul class="list-disc list-inside space-y-2 text-slate-200">
+                    <li>Music stems for adjusting drums, bass, and individual layers</li>
+                    <li>Cut-down durations in 15, 30, and 60 second versions</li>
+                    <li>Versions prepared for social and short-form content</li>
+                </ul>
+            </section>
+
+            <section class="info-card space-y-5">
+                <h2 class="text-2xl font-semibold text-white">Free Tier for Non-Monetized Channels</h2>
+                <p>If your YouTube channel is not monetized, SoundMarket allows you to use tracks for free. This lowers the barrier for new creators who are still building toward monetization.</p>
+                <p>Once monetization starts, you can move to a paid plan and whitelist your channel for continued licensing coverage.</p>
+            </section>
+
+            <section class="info-card space-y-5">
+                <h2 class="text-2xl font-semibold text-white">SoundMarket Pricing vs Competitors</h2>
+                <p>Paid plans begin around $12.99/month, which is usually lower than common alternatives that often begin around $20 to $30/month. For creators publishing often, this can make SoundMarket easier to justify.</p>
+            </section>
+
+            <section class="info-card space-y-5">
+                <h2 class="text-2xl font-semibold text-white">Testing the Music in a Real Video Edit</h2>
+                <p>I tested multiple SoundMarket tracks inside a travel edit. The production quality is strong and worked well for cinematic travel sequences, documentary pacing, and voiceover-heavy scenes.</p>
+                <p>The catalog is smaller than some major competitors, but many tracks felt less overused, which helps if you want a fresher soundtrack identity.</p>
+            </section>
+
+            <section class="info-card space-y-5">
+                <h2 class="text-2xl font-semibold text-white">SoundMarket vs Other Royalty Free Music Libraries</h2>
+                <div class="grid md:grid-cols-3 gap-4 text-slate-200">
+                    <div class="rounded-xl border border-slate-700 p-4">
+                        <h3 class="font-semibold text-white mb-2">Artlist</h3>
+                        <p>Large catalog with strong cinematic music used by filmmakers.</p>
+                    </div>
+                    <div class="rounded-xl border border-slate-700 p-4">
+                        <h3 class="font-semibold text-white mb-2">Epidemic Sound</h3>
+                        <p>Huge library with strong YouTube integration and creator tools.</p>
+                    </div>
+                    <div class="rounded-xl border border-slate-700 p-4">
+                        <h3 class="font-semibold text-white mb-2">SoundMarket</h3>
+                        <p>Curated catalog from professional composers with less overused tracks.</p>
+                    </div>
+                </div>
+            </section>
+
+            <section class="info-card space-y-5">
+                <h2 class="text-2xl font-semibold text-white">Frequently Asked Questions</h2>
+                <div class="space-y-4 text-slate-200">
+                    <div>
+                        <h3 class="font-semibold text-white">Is SoundMarket safe to use on YouTube?</h3>
+                        <p>Yes. SoundMarket provides licensed music intended for creators publishing on YouTube and social platforms.</p>
+                    </div>
+                    <div>
+                        <h3 class="font-semibold text-white">Can you use SoundMarket if your channel is not monetized?</h3>
+                        <p>Yes. There is a free tier for non-monetized channels.</p>
+                    </div>
+                    <div>
+                        <h3 class="font-semibold text-white">Do you need a subscription to use SoundMarket?</h3>
+                        <p>A paid plan is required once your channel is monetized and you want to whitelist your channel.</p>
+                    </div>
+                </div>
+            </section>
+
+            <section class="info-card space-y-5">
+                <h2 class="text-2xl font-semibold text-white">Final Thoughts</h2>
+                <p>Music is one of the fastest ways to raise perceived production quality. Visuals matter, but the soundtrack controls pacing and emotion.</p>
+                <p>SoundMarket is newer than some of the dominant licensing platforms, but the curated catalog and free entry point for non-monetized channels make it a strong option for creators who want licensed music without immediately committing to high monthly costs.</p>
+                <p>If you want royalty free music for YouTube videos, SoundMarket is worth exploring: <a class="text-yellow-300 hover:text-yellow-200" href="https://soundmarket.io/?ref=CarlTravels" target="_blank" rel="noopener">soundmarket.io</a>.</p>
+            </section>
+        </div>
+    </main>
+
+    <script src="/assets/js/site.js"></script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a dedicated review of SoundMarket targeted at YouTube creators and surface it on the site as a new long-form article and video resource.
- Promote the new review from the Gear section so visitors discovering reviews can easily access the SoundMarket writeup.

### Description
- Add a new review page `soundmarket.html` containing full page metadata, responsive YouTube embed, styled content sections, FAQ, and an external affiliate link to SoundMarket. 
- Add a new review card to the `gear.html` blog grid that links to `soundmarket.html` with thumbnail, short excerpt, category tag, and rating UI.
- Include page-level assets and scripts such as Tailwind inclusion, Google Analytics `gtag`, font and Font Awesome references, and reuse of site CSS/JS paths (`/assets/css/styles.css`, `/assets/js/site.js`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adfb1801fc8323b3a19c5696c9f668)