### PR TITLE
Add Sarandë, Ksamil and Butrint destination travel guide page

### DIFF
--- a/destinations.html
+++ b/destinations.html
@@ -694,6 +694,38 @@
                         </div>
                     </div>
                 </div>
+                <!-- Destination: Sarandë, Ksamil & Butrint -->
+                <div class="destination-card rounded-xl overflow-hidden shadow-lg" data-destination-id="sarande-ksamil-butrint">
+                    <div class="destination-card-inner">
+                        <div class="relative overflow-hidden h-64">
+                            <img src="https://img.youtube.com/vi/b8LRRCgTn00/maxresdefault.jpg"
+                                alt="Sarandë waterfront and Ionian coast"
+                                class="w-full h-full object-cover transform hover:scale-110 transition-transform duration-500">
+                            <div class="absolute inset-0 destination-overlay"></div>
+                            <div class="absolute bottom-0 left-0 p-6 text-white">
+                                <h3 class="text-xl font-bold">Sarandë, Ksamil & Butrint</h3>
+                                <p class="text-sm">Beaches • UNESCO Ruins</p>
+                            </div>
+                            <span
+                                class="absolute top-4 right-4 bg-yellow-500 text-black text-xs px-3 py-1 rounded-full">New</span>
+                        </div>
+                        <div class="p-6 bg-white">
+                            <div class="flex justify-between items-center mb-3">
+                                <span class="text-gray-500 text-sm"><i
+                                        class="fas fa-map-marker-alt mr-1 text-yellow-500"></i> Europe</span>
+                                <div class="flex items-center">
+                                    <i class="fas fa-star text-yellow-400 mr-1"></i>
+                                    <span class="font-medium">4.8</span>
+                                </div>
+                            </div>
+                            <p class="text-gray-600 mb-4">Plan Sarandë as your base, beach days in Ksamil, and a half-day exploring Butrint National Park.</p>
+                            <a href="sarande-ksamil-butrint-travel-guide/"
+                                class="text-yellow-500 font-medium hover:text-yellow-500 inline-flex items-center">
+                                View Details <i class="fas fa-arrow-right ml-2"></i>
+                            </a>
+                        </div>
+                    </div>
+                </div>
                 <!-- Destination 6a: Ninh Bình -->
                 <div class="destination-card rounded-xl overflow-hidden shadow-lg">
                     <div class="destination-card-inner">
@@ -1807,6 +1839,13 @@
                             coords: [10.8231, 106.6297],
                             url: 'one-day-in-hcmc-guide.html',
                             video: 'https://www.youtube.com/embed/ULOM2GJDvak'
+                        },
+                        {
+                            id: 'sarande-ksamil-butrint',
+                            name: 'Sarandë, Ksamil & Butrint, Albania',
+                            coords: [39.7615, 20.0077],
+                            url: 'sarande-ksamil-butrint-travel-guide/',
+                            video: 'https://www.youtube.com/embed/b8LRRCgTn00'
                         },
                         {
                             id: 'ninhbinh',

--- a/sarande-ksamil-butrint-travel-guide/index.html
+++ b/sarande-ksamil-butrint-travel-guide/index.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sarandë, Ksamil and Butrint Travel Guide: How to Visit Southern Albania</title>
+    <link rel="canonical" href="https://www.carltravels.com/sarande-ksamil-butrint-travel-guide/">
+    <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="e44b7cd2-126b-4f49-8aee-22495afe3ece" type="text/javascript" async></script>
+    <meta name="description" content="A practical guide to visiting Sarandë, Ksamil and Butrint in southern Albania, including how to get there, best time to visit, things to do, and local travel tips. Sarandë, Ksamil and Butrint sit in the far south of Albania along the Ionian Sea. Together they form one of the most popular areas of the Albanian Riviera. Within a short distance you can experience a lively coastal town, some of the clearest beaches in the country, and one of the most important archaeological sites in the Balkans. If you are planning a trip to southern Albania, this region is usually the best place to start.">
+    <meta name="keywords" content="Sarande travel guide, Ksamil travel guide, Butrint National Park, Southern Albania itinerary, Albania Riviera travel, Sarande Ksamil Butrint">
+    <meta property="og:title" content="Sarandë, Ksamil and Butrint Travel Guide | Southern Albania">
+    <meta property="og:description" content="A practical guide to visiting Sarandë, Ksamil and Butrint with transport options, beaches, ruins, seasonal advice, and local tips.">
+    <meta property="og:image" content="https://img.youtube.com/vi/b8LRRCgTn00/maxresdefault.jpg">
+    <meta property="og:url" content="https://www.carltravels.com/sarande-ksamil-butrint-travel-guide/">
+    <meta property="og:type" content="article">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Sarandë, Ksamil and Butrint Travel Guide | Southern Albania">
+    <meta name="twitter:description" content="How to visit Sarandë, Ksamil and Butrint with practical transport advice, timing tips, beach planning, and archaeological highlights.">
+    <meta name="twitter:image" content="https://img.youtube.com/vi/b8LRRCgTn00/maxresdefault.jpg">
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "TravelArticle",
+        "headline": "Sarandë, Ksamil and Butrint Travel Guide: How to Visit Southern Albania",
+        "description": "A practical guide to visiting Sarandë, Ksamil and Butrint in southern Albania, including how to get there, best time to visit, things to do, and local travel tips.",
+        "image": "https://img.youtube.com/vi/b8LRRCgTn00/maxresdefault.jpg",
+        "author": { "@type": "Person", "name": "Carl Tomich" },
+        "publisher": {
+            "@type": "Organization",
+            "name": "Carl Travels",
+            "logo": { "@type": "ImageObject", "url": "https://www.carltravels.com/carlcircle.png" }
+        },
+        "mainEntityOfPage": { "@type": "WebPage", "@id": "https://www.carltravels.com/sarande-ksamil-butrint-travel-guide/" }
+    }
+    </script>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js?client=ca-pub-6483721386563068" crossorigin="anonymous"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-G72KT5ZW2J"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);} 
+        gtag('js', new Date());
+        gtag('config', 'G-G72KT5ZW2J');
+    </script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700&family=Bebas+Neue&display=swap" rel="stylesheet">
+    <style>
+        :root { --primary: #f5c518; --secondary: #2a2a2a; --dark: #1a1a1a; --light: #d4d4d4; }
+        body { font-family: 'Montserrat', sans-serif; background-color: var(--dark); color: var(--light); scroll-behavior: smooth; }
+        .heading-font { font-family: 'Bebas Neue', sans-serif; letter-spacing: 2px; }
+        .navbar { backdrop-filter: blur(10px); background-color: rgba(26, 26, 26, 0.9); transition: all 0.3s ease; }
+        .navbar.scrolled { background-color: rgba(26, 26, 26, 0.98); box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.3); }
+        .mobile-menu { max-height: 0; overflow: hidden; transition: max-height 0.5s ease-out; }
+        .mobile-menu.open { max-height: 500px; }
+        .hero-overlay { background: linear-gradient(180deg, rgba(0,0,0,0.35) 0%, rgba(0,0,0,0.78) 75%, rgba(0,0,0,0.95) 100%); }
+        .glass-card { background: rgba(26, 26, 26, 0.7); border: 1px solid rgba(255, 255, 255, 0.08); backdrop-filter: blur(12px); }
+        .highlight-card { background: rgba(15, 15, 15, 0.65); border: 1px solid rgba(255, 255, 255, 0.06); }
+        .responsive-video { position: relative; width: 100%; padding-bottom: 56.25%; border-radius: 1rem; overflow: hidden; border: 1px solid rgba(255, 255, 255, 0.08); }
+        .responsive-video iframe, .map-frame iframe { position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0; }
+        .map-frame { position: relative; width: 100%; min-height: 320px; border-radius: 1rem; overflow: hidden; border: 1px solid rgba(255, 255, 255, 0.08); }
+    </style>
+</head>
+<body class="text-gray-200">
+    <nav id="navbar" class="navbar fixed w-full z-50">
+        <div class="container mx-auto px-6 py-4">
+            <div class="flex justify-between items-center">
+                <a href="/index.html" class="text-2xl font-bold"><span class="heading-font" style="color: var(--primary);">CARL TOMICH</span></a>
+                <div class="hidden md:flex items-center space-x-8">
+                    <a href="/index.html" class="nav-link font-medium">Films</a><a href="/portfolio.html" class="nav-link font-medium">Portfolio</a><a href="/films/martial-arts-documentary.html" class="nav-link font-medium">Current Project</a><a href="/blog.html" class="nav-link font-medium">Blog</a><a href="/gear.html" class="nav-link font-medium">Gear</a><a href="/destinations.html" class="nav-link font-medium">Travel</a><a href="/about.html" class="nav-link font-medium">About</a><a href="/donate.html" class="nav-link font-medium" style="color: var(--primary);">Donate</a>
+                </div>
+                <button id="mobile-menu-button" class="md:hidden focus:outline-none" style="color: var(--light);"><i class="fas fa-bars text-2xl"></i></button>
+            </div>
+            <div id="mobile-menu" class="mobile-menu md:hidden"><div class="pt-4 pb-2 space-y-2"><a href="/index.html" class="block px-3 py-2 rounded-md nav-link">Films</a><a href="/portfolio.html" class="block px-3 py-2 rounded-md nav-link">Portfolio</a><a href="/films/martial-arts-documentary.html" class="block px-3 py-2 rounded-md nav-link">Current Project</a><a href="/blog.html" class="block px-3 py-2 rounded-md nav-link">Blog</a><a href="/gear.html" class="block px-3 py-2 rounded-md nav-link">Gear</a><a href="/destinations.html" class="block px-3 py-2 rounded-md nav-link">Travel</a><a href="/about.html" class="block px-3 py-2 rounded-md nav-link">About</a><a href="/donate.html" class="block px-3 py-2 rounded-md nav-link" style="color: var(--primary);">Donate</a></div></div>
+        </div>
+    </nav>
+
+    <header class="relative min-h-[75vh] flex items-center" style="background: url('https://img.youtube.com/vi/b8LRRCgTn00/maxresdefault.jpg') center/cover no-repeat;">
+        <div class="absolute inset-0 hero-overlay"></div>
+        <div class="container mx-auto px-6 relative z-10 py-32">
+            <span class="inline-block mb-4 px-4 py-2 rounded-full bg-yellow-500/20 text-yellow-400 text-xs uppercase tracking-[0.2em]">Southern Albania Guide</span>
+            <h1 class="heading-font text-4xl md:text-6xl text-white max-w-4xl">Sarandë, Ksamil and Butrint Travel Guide: How to Visit Southern Albania</h1>
+            <p class="mt-6 text-lg text-gray-300 max-w-3xl">A practical, easy-to-follow route for beaches, archaeology, and coastal town life along Albania's Ionian coast.</p>
+        </div>
+    </header>
+
+    <main>
+        <section class="py-16 bg-[#171717]">
+            <div class="container mx-auto px-6 grid lg:grid-cols-3 gap-8">
+                <div class="glass-card rounded-3xl p-6"><h2 class="heading-font text-2xl text-white mb-3">Why this region works</h2><p>Sarandë gives you transport and nightlife, Ksamil gives you clear shallow water, and Butrint gives you one of the Balkans' most important archaeological sites. All three are close enough to visit in a short stay.</p></div>
+                <div class="glass-card rounded-3xl p-6"><h2 class="heading-font text-2xl text-white mb-3">Suggested stay</h2><p>Plan 3 to 4 nights for a balanced trip: one day in Sarandë, one beach day in Ksamil, one half or full day in Butrint, and one flexible day for viewpoints or weather changes.</p></div>
+                <div class="glass-card rounded-3xl p-6"><h2 class="heading-font text-2xl text-white mb-3">Quick logistics</h2><ul class="space-y-2"><li><i class="fas fa-car text-yellow-500 mr-2"></i>Tirana to Sarandë: around 4 to 5 hours.</li><li><i class="fas fa-ferry text-yellow-500 mr-2"></i>Corfu to Sarandë ferry: around 30 to 60 minutes.</li><li><i class="fas fa-bus text-yellow-500 mr-2"></i>Sarandë to Ksamil: around 20 minutes.</li><li><i class="fas fa-landmark text-yellow-500 mr-2"></i>Butrint entry: around 1000 ALL.</li></ul></div>
+            </div>
+        </section>
+
+        <section class="py-16 bg-[#1a1a1a]">
+            <div class="container mx-auto px-6 grid lg:grid-cols-2 gap-10 items-center">
+                <div>
+                    <h2 class="heading-font text-4xl text-white mb-4">How to get to Sarandë</h2>
+                    <p class="text-gray-300 mb-4">Sarandë is the gateway to southern Albania and the main base for visiting both Ksamil and Butrint. From Tirana, buses and cars typically take around four to five hours depending on traffic. The coastal route via the Llogara Pass is one of the most scenic drives in the Balkans.</p>
+                    <p class="text-gray-300 mb-4">From Greece, the easiest route is by ferry from Corfu. Crossings run daily and usually take 30 to 60 minutes. It is one of the fastest international entries into Albania.</p>
+                    <p class="text-gray-300">You can also reach Sarandë by long-distance bus from Athens, but the ride can take 10 to 12 hours depending on border crossing times.</p>
+                </div>
+                <div class="map-frame">
+                    <iframe src="https://www.google.com/maps?q=Sarande+Albania&output=embed" loading="lazy" referrerpolicy="no-referrer-when-downgrade" title="Map of Sarande"></iframe>
+                </div>
+            </div>
+        </section>
+
+        <section class="py-16 bg-[#171717]">
+            <div class="container mx-auto px-6 grid lg:grid-cols-2 gap-10 items-start">
+                <div class="space-y-4">
+                    <h2 class="heading-font text-4xl text-white">Sarandë: Base town and waterfront life</h2>
+                    <p>Sarandë sits directly opposite Corfu and works as the transport and accommodation hub for the southern coast. The promenade is active in the evenings with seafood restaurants, cafés, and sea views.</p>
+                    <p>It is not the quietest stop in the region, but it is practical. You get frequent buses, easy taxi access, and a wide range of hotels and apartments for different budgets.</p>
+                    <p>A short drive uphill to Lëkurësi Castle gives you panoramic views over the bay and back toward Corfu.</p>
+                </div>
+                <div class="responsive-video"><iframe src="https://www.youtube.com/embed/b8LRRCgTn00" title="Sarande travel video" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>
+            </div>
+        </section>
+
+        <section class="py-16 bg-[#1a1a1a]">
+            <div class="container mx-auto px-6 grid lg:grid-cols-2 gap-10 items-start">
+                <div class="responsive-video lg:order-2"><iframe src="https://www.youtube.com/embed/YNO8wWjcyqU" title="Ksamil travel video" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>
+                <div class="space-y-4 lg:order-1">
+                    <h2 class="heading-font text-4xl text-white">Ksamil: Beaches, islands and clear water</h2>
+                    <p>About 14 km south of Sarandë, Ksamil is known for shallow turquoise water and small offshore islands that you can often swim or kayak to on calm days.</p>
+                    <p>During July and August, beach clubs and restaurants are at full capacity and the village gets crowded. For a calmer experience, May, June, September, and October are usually better choices.</p>
+                    <p>If you are staying in Sarandë, this is an easy day trip. But if beaches are your top priority, staying one or two nights in Ksamil makes sunrise and early morning swims much easier.</p>
+                </div>
+            </div>
+            <div class="container mx-auto px-6 mt-10">
+                <div class="map-frame"><iframe src="https://www.google.com/maps?q=Ksamil+Albania&output=embed" loading="lazy" referrerpolicy="no-referrer-when-downgrade" title="Map of Ksamil"></iframe></div>
+            </div>
+        </section>
+
+        <section class="py-16 bg-[#171717]">
+            <div class="container mx-auto px-6 grid lg:grid-cols-2 gap-10 items-start">
+                <div class="space-y-4">
+                    <h2 class="heading-font text-4xl text-white">Butrint National Park: UNESCO ruins in nature</h2>
+                    <p>Just beyond Ksamil, Butrint is one of Albania's most important archaeological sites. The ancient city was first settled by Greeks, expanded under Romans, and later shaped by Byzantine and Venetian periods.</p>
+                    <p>You can walk through a 3rd-century BC theatre, Roman baths, basilicas, city walls, and gates in one circuit. The setting feels unique because ruins are surrounded by wetland and forest landscapes.</p>
+                    <p>Entry is approximately 1000 Albanian Lek. Most visitors spend 2 to 4 hours exploring.</p>
+                </div>
+                <div class="responsive-video"><iframe src="https://www.youtube.com/embed/Re8xO-VQUog" title="Butrint travel video" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>
+            </div>
+            <div class="container mx-auto px-6 mt-10">
+                <div class="map-frame"><iframe src="https://www.google.com/maps?q=Butrint+National+Park&output=embed" loading="lazy" referrerpolicy="no-referrer-when-downgrade" title="Map of Butrint"></iframe></div>
+            </div>
+        </section>
+
+        <section class="py-16 bg-[#1a1a1a]">
+            <div class="container mx-auto px-6 grid lg:grid-cols-2 gap-8">
+                <div class="highlight-card rounded-3xl p-8">
+                    <h3 class="heading-font text-3xl text-white mb-4">Best time to visit</h3>
+                    <ul class="space-y-3 text-gray-300">
+                        <li><strong>June to September:</strong> hottest weather, busiest beaches, liveliest atmosphere.</li>
+                        <li><strong>May and October:</strong> warm conditions with fewer crowds and better accommodation prices.</li>
+                        <li><strong>Winter:</strong> Sarandë stays active, but many Ksamil businesses close seasonally.</li>
+                    </ul>
+                </div>
+                <div class="highlight-card rounded-3xl p-8">
+                    <h3 class="heading-font text-3xl text-white mb-4">Easy 3-day itinerary</h3>
+                    <ul class="space-y-3 text-gray-300">
+                        <li><strong>Day 1:</strong> Arrive in Sarandë, sunset walk on the promenade, dinner by the waterfront.</li>
+                        <li><strong>Day 2:</strong> Morning in Ksamil, beach time, island swim or kayak, return to Sarandë.</li>
+                        <li><strong>Day 3:</strong> Visit Butrint early, then stop at Lëkurësi Castle before evening departure.</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="bg-black text-gray-400 py-12">
+        <div class="container mx-auto px-6 text-center">
+            <p class="mb-2">© 2026 Carl Travels. All rights reserved.</p>
+            <p class="text-sm">Travel guides based on first-hand research, practical route planning, and realistic expectations.</p>
+        </div>
+    </footer>
+
+    <script>
+        const mobileMenuButton = document.getElementById('mobile-menu-button');
+        const mobileMenu = document.getElementById('mobile-menu');
+        if (mobileMenuButton && mobileMenu) {
+            mobileMenuButton.addEventListener('click', () => mobileMenu.classList.toggle('open'));
+        }
+        const navbar = document.getElementById('navbar');
+        window.addEventListener('scroll', () => {
+            if (!navbar) return;
+            if (window.scrollY > 50) navbar.classList.add('scrolled');
+            else navbar.classList.remove('scrolled');
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a new, SEO-optimized destination guide for Sarandë, Ksamil and Butrint that matches the visual style, layout, and editorial structure used across existing destination pages. 
- Make the region easy to plan with practical sections (getting there, things to do, maps, itinerary) and embedded media for richer context. 
- Ensure the new guide is discoverable from the site-wide destinations list and interactive map.

### Description
- Added a new guide at `sarande-ksamil-butrint-travel-guide/index.html` that reuses the site’s dark editorial styles, fonts, spacing, card components, responsive video treatment, and SEO/JSON-LD structure. 
- Embedded the requested YouTube videos for Sarandë (`b8LRRCgTn00`), Ksamil (`YNO8wWjcyqU`), and Butrint (`Re8xO-VQUog`) and included Google Maps embeds for Sarandë, Ksamil, and Butrint. 
- Updated `destinations.html` to add a matching destination card linking to the new guide and inserted a new entry in the interactive destinations dataset so the map marker and video preview work consistently.

### Testing
- Verified references and presence with `rg -n "sarande-ksamil-butrint" destinations.html sarande-ksamil-butrint-travel-guide/index.html`, which returned the expected matches. 
- Served the site locally with `python3 -m http.server 8000 --directory /workspace/Carltravels` and confirmed the new page responded successfully (HTTP 200) at `/sarande-ksamil-butrint-travel-guide/`. 
- Captured a full-page screenshot using Playwright to validate layout and responsive rendering, and confirmed the embedded videos and maps load in the rendered output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b19ded5044832394e4549f8c86962e)