### PR TITLE
Add Scoot Plus review post with YouTube-thumbnail hero

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -233,6 +233,35 @@
             </div>
 
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+            <div class="blog-card rounded-xl overflow-hidden shadow-lg">
+                    <div class="relative overflow-hidden h-64">
+                        <img src="https://img.youtube.com/vi/-jWYZg-gJ6U/maxresdefault.jpg"
+                            onerror="this.onerror=null;this.src='https://images.unsplash.com/photo-1436491865332-7a61a109cc05?auto=format&fit=crop&w=1200&q=80';"
+                            alt="Scoot Plus premium economy seat review"
+                            class="w-full h-full object-cover transform hover:scale-110 transition-transform duration-500">
+                        <div class="absolute inset-0 card-overlay"></div>
+                        <div class="absolute bottom-0 left-0 p-6 text-white">
+                            <h3 class="text-xl font-bold">Scoot Plus Review: Is It Worth It?</h3>
+                            <p class="text-sm">Budget Premium Economy Tested</p>
+                        </div>
+                        <span class="absolute top-4 right-4 bg-yellow-900 text-white text-xs px-3 py-1 rounded-full">New</span>
+                    </div>
+                    <div class="p-6 bg-white">
+                        <div class="flex justify-between items-center mb-3">
+                            <span class="text-gray-500 text-sm"><i class="fas fa-plane mr-1 text-yellow-500"></i>
+                                Airline Review</span>
+                        </div>
+                        <p class="text-gray-600 mb-4 text-sm">
+                            A full long-haul Scoot Plus breakdown from Perth to Athens, including seat comfort,
+                            baggage perks, and what you don’t get.
+                        </p>
+                        <a href="scoot-plus-review.html"
+                            class="inline-flex items-center gap-2 text-yellow-500 hover:text-yellow-400 font-medium">
+                            Read More <i class="fas fa-arrow-right text-xs"></i>
+                        </a>
+                    </div>
+                </div>
+
                 <!-- Blog Post: Athens to Sarande Bus Guide -->
                 <div class="blog-card rounded-xl overflow-hidden shadow-lg">
                     <div class="relative overflow-hidden h-64">

--- a/scoot-plus-review.html
+++ b/scoot-plus-review.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Scoot Plus Review: Is Scoot’s Budget Premium Economy Worth It? | Carl Travels</title>
+    <link rel="canonical" href="https://www.carltravels.com/scoot-plus-review.html">
+    <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="e44b7cd2-126b-4f49-8aee-22495afe3ece" type="text/javascript" async></script>
+    <meta name="description" content="A real-world Scoot Plus review from Perth to Athens via Singapore. See seat comfort, baggage perks, limitations, and whether the upgrade is worth the cost.">
+    <meta name="keywords" content="Scoot Plus review, Scoot premium economy, Scoot Plus seats, Scoot Plus worth it, Perth to Athens flight review">
+    <meta name="author" content="Carl Tomich">
+    <meta property="og:title" content="Scoot Plus Review: Is Scoot’s Budget Premium Economy Worth It?">
+    <meta property="og:description" content="I upgraded from economy to Scoot Plus on a long-haul route to test if the added comfort is worth the extra money.">
+    <meta property="og:image" content="https://img.youtube.com/vi/-jWYZg-gJ6U/maxresdefault.jpg">
+    <meta property="og:url" content="https://www.carltravels.com/scoot-plus-review.html">
+    <meta property="og:type" content="article">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Scoot Plus Review: Is Scoot’s Budget Premium Economy Worth It?">
+    <meta name="twitter:description" content="Scoot Plus seat comfort, baggage allowance, included perks, and whether the upgrade price makes sense.">
+    <meta name="twitter:image" content="https://img.youtube.com/vi/-jWYZg-gJ6U/maxresdefault.jpg">
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Review",
+      "itemReviewed": {
+        "@type": "Service",
+        "name": "Scoot Plus",
+        "provider": {
+          "@type": "Airline",
+          "name": "Scoot"
+        },
+        "description": "Scoot's budget premium economy cabin with wider seats, extra legroom, and added baggage allowance on select routes."
+      },
+      "author": {
+        "@type": "Person",
+        "name": "Carl Tomich"
+      },
+      "headline": "Scoot Plus Review: Is Scoot’s Budget Premium Economy Worth It?",
+      "reviewBody": "A practical long-haul review of Scoot Plus from Perth to Athens, covering seat comfort, baggage benefits, included perks, and overall value.",
+      "publisher": {
+        "@type": "Organization",
+        "name": "Carl Travels",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://www.carltravels.com/carlcircle.png"
+        }
+      },
+      "datePublished": "2026-03-14"
+    }
+    </script>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js?client=ca-pub-6483721386563068" crossorigin="anonymous"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-G72KT5ZW2J"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-G72KT5ZW2J');
+    </script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700&family=Bebas+Neue&display=swap" rel="stylesheet">
+    <style>
+      :root { --primary:#facc15; --secondary:#0f172a; --dark:#020617; --light:#e2e8f0; }
+      body { font-family:'Montserrat',sans-serif; background-color:var(--dark); color:var(--light); scroll-behavior:smooth; }
+      .hero { background: radial-gradient(circle at top left, rgba(250, 204, 21, 0.18), transparent 60%), radial-gradient(circle at bottom right, rgba(56, 189, 248, 0.12), transparent 55%), linear-gradient(135deg, rgba(15, 23, 42, 0.95), rgba(15, 23, 42, 0.75)); }
+      .heading-font { font-family:'Bebas Neue',sans-serif; }
+      .navbar { backdrop-filter:blur(12px); background-color:rgba(15, 23, 42, 0.82); transition:all .3s ease; }
+      .navbar.scrolled { background-color:rgba(2, 6, 23, 0.95); box-shadow:0 10px 30px -20px rgba(0,0,0,.6); }
+      .mobile-menu { max-height:0; overflow:hidden; transition:max-height .4s ease; }
+      .mobile-menu.open { max-height:500px; }
+      .badge { display:inline-flex; align-items:center; gap:.5rem; background:rgba(248, 250, 252, 0.08); border:1px solid rgba(148, 163, 184, 0.3); padding:.45rem 1rem; border-radius:9999px; font-size:.75rem; letter-spacing:.08em; text-transform:uppercase; }
+      .info-card { background:rgba(15,23,42,.82); border:1px solid rgba(148,163,184,.2); border-radius:1.25rem; padding:1.5rem; }
+      .responsive-video { position:relative; width:100%; padding-bottom:56.25%; border-radius:1rem; overflow:hidden; box-shadow:0 20px 45px -20px rgba(56,189,248,.35); }
+      .responsive-video iframe { position:absolute; inset:0; width:100%; height:100%; border:none; }
+      .article p { color:#cbd5e1; margin-bottom:1.15rem; line-height:1.8; }
+      .article h2 { font-family:'Bebas Neue',sans-serif; font-size:2rem; color:#fff; margin:2.2rem 0 1rem; letter-spacing:.03em; }
+      .article ul { margin:0 0 1.25rem 1.2rem; color:#cbd5e1; }
+      .article li { margin-bottom:.5rem; }
+      .cta-button { display:inline-flex; align-items:center; gap:.5rem; padding:.8rem 1.5rem; border-radius:9999px; background:linear-gradient(90deg,#facc15,#f59e0b); color:#111827; font-weight:600; }
+    </style>
+    <link rel="stylesheet" href="/assets/css/styles.css">
+</head>
+<body>
+    <nav id="navbar" class="navbar fixed w-full z-50">
+      <div class="container mx-auto px-6 py-4">
+        <div class="flex justify-between items-center">
+          <a href="/index.html" class="text-2xl font-bold"><span class="heading-font" style="color:var(--primary);">CARL TOMICH</span></a>
+          <div class="hidden md:flex items-center space-x-8">
+            <a href="/index.html" class="nav-link font-medium">Films</a><a href="/portfolio.html" class="nav-link font-medium">Portfolio</a><a href="/films/martial-arts-documentary.html" class="nav-link font-medium">Current Project</a><a href="/blog.html" class="nav-link font-medium">Blog</a><a href="/gear.html" class="nav-link font-medium">Gear</a><a href="/destinations.html" class="nav-link font-medium">Travel</a><a href="/about.html" class="nav-link font-medium">About</a><a href="/donate.html" class="nav-link font-medium" style="color:var(--primary);">Donate</a>
+          </div>
+          <button id="mobile-menu-button" class="md:hidden focus:outline-none" style="color:var(--light);"><i class="fas fa-bars text-2xl"></i></button>
+        </div>
+        <div id="mobile-menu" class="mobile-menu md:hidden"><div class="pt-4 pb-2 space-y-2">
+          <a href="/index.html" class="block px-3 py-2 rounded-md nav-link">Films</a><a href="/portfolio.html" class="block px-3 py-2 rounded-md nav-link">Portfolio</a><a href="/films/martial-arts-documentary.html" class="block px-3 py-2 rounded-md nav-link">Current Project</a><a href="/blog.html" class="block px-3 py-2 rounded-md nav-link">Blog</a><a href="/gear.html" class="block px-3 py-2 rounded-md nav-link">Gear</a><a href="/destinations.html" class="block px-3 py-2 rounded-md nav-link">Travel</a><a href="/about.html" class="block px-3 py-2 rounded-md nav-link">About</a><a href="/donate.html" class="block px-3 py-2 rounded-md nav-link" style="color:var(--primary);">Donate</a>
+        </div></div>
+      </div>
+    </nav>
+
+    <header class="hero pt-32 pb-16">
+      <div class="container mx-auto px-6">
+        <div class="grid lg:grid-cols-2 gap-12 items-center">
+          <div>
+            <span class="badge"><i class="fas fa-plane-departure text-yellow-400"></i> Long-Haul Flight Review</span>
+            <h1 class="heading-font text-4xl md:text-5xl text-white leading-tight mt-4">Scoot Plus Review</h1>
+            <p class="text-lg text-slate-200 leading-relaxed mt-4">Is Scoot’s budget premium economy actually worth paying for? I tested Scoot Plus on a Perth to Athens itinerary via Singapore and compared it against regular economy pricing and comfort.</p>
+            <div class="flex flex-wrap gap-4 mt-6">
+              <a href="#video-review" class="cta-button"><i class="fas fa-play"></i> Watch review</a>
+              <a href="#full-review" class="inline-flex items-center gap-2 px-6 py-3 border border-slate-500 text-slate-200 rounded-full hover:border-yellow-400 hover:text-yellow-400 transition-colors"><i class="fas fa-file-alt"></i> Read full breakdown</a>
+            </div>
+          </div>
+          <div class="info-card">
+            <img src="https://img.youtube.com/vi/-jWYZg-gJ6U/maxresdefault.jpg" alt="Scoot Plus review YouTube thumbnail" class="rounded-xl w-full h-auto">
+            <p class="text-sm text-slate-300 mt-4">Main image sourced from the YouTube thumbnail, matching the style used in recent review posts.</p>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <main class="pb-24">
+      <section id="full-review" class="container mx-auto px-6">
+        <div class="max-w-4xl mx-auto info-card article">
+          <p>Scoot is known as a low-cost airline, so when people hear the name they usually expect cramped seats and a very basic flying experience. But Scoot also offers Scoot Plus, which is their version of premium economy.</p>
+          <p>On a recent trip I flew from Perth to Athens with a stop in Singapore and decided to upgrade to Scoot Plus to see if it was actually worth the extra money. At the time, my economy ticket cost around 700 Australian dollars and the Scoot Plus upgrade was roughly another 300 dollars.</p>
+          <p>That price difference made this an interesting experiment. It is significantly cheaper than premium economy on traditional airlines, but does it actually deliver a better experience than standard economy?</p>
+
+          <h2>Scoot Plus Seat and Legroom</h2>
+          <p>The biggest difference between Scoot Plus and economy is the seat. Scoot Plus seats are wider and offer significantly more legroom.</p>
+          <p>On the Boeing 787 aircraft the seats are arranged in a 2-3-2 layout, which means fewer seats across the cabin compared with the 3-3-3 configuration in economy.</p>
+          <p>Seat pitch in Scoot Plus is about 38 inches compared with around 31 inches in economy. That extra space makes a noticeable difference on long flights. Seats also recline further, making it easier to rest.</p>
+
+          <h2>Scoot Plus Baggage Allowance</h2>
+          <p>Another advantage is the baggage allowance. Passengers typically receive around 30 kilograms of checked luggage and up to about 15 kilograms of carry-on baggage.</p>
+          <p>For travellers carrying camera gear or traveling long term, this extra allowance can be genuinely useful.</p>
+
+          <h2>Scoot Plus Perks</h2>
+          <ul>
+            <li>Priority boarding so you can settle in and claim overhead space earlier.</li>
+            <li>Meals included in the fare or upgrade package.</li>
+            <li>A noticeably quieter and less crowded cabin feel than economy.</li>
+          </ul>
+
+          <h2>What Scoot Plus Does Not Include</h2>
+          <p>While Scoot Plus is more comfortable than economy, it is still a budget airline product. Most Scoot aircraft do not have built-in seatback entertainment screens, so you need your own device for content.</p>
+          <p>Service is also simpler than what you would typically get on full-service carriers like Singapore Airlines or Emirates.</p>
+
+          <h2>Is Scoot Plus Worth It?</h2>
+          <p>For long flights, the extra seat space and comfort can make a significant difference. On my Perth to Athens trip, paying around 300 Australian dollars extra felt like very good value for the comfort and baggage boost.</p>
+          <p>Prices can vary by route and season, but Scoot Plus sits in a useful middle ground: more comfort than economy without the steep premium of major-airline premium cabins.</p>
+
+          <h2>Final Thoughts</h2>
+          <p>Scoot Plus will not replace true premium economy on full-service airlines, but it can be a practical upgrade if you want better comfort on long-haul flights without spending thousands.</p>
+          <p>If you are considering flying Scoot, the video below gives a clear look at the cabin layout, seat, and overall in-flight experience.</p>
+        </div>
+      </section>
+
+      <section id="video-review" class="container mx-auto px-6 mt-12">
+        <div class="max-w-4xl mx-auto">
+          <h2 class="heading-font text-4xl text-white mb-6 text-center">Watch the Full Scoot Plus Review</h2>
+          <div class="responsive-video">
+            <iframe src="https://www.youtube.com/embed/-jWYZg-gJ6U" title="Scoot Plus Review - Is Scoot Budget Premium Economy Worth It" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <script>
+      const navbar = document.getElementById('navbar');
+      const mobileMenuButton = document.getElementById('mobile-menu-button');
+      const mobileMenu = document.getElementById('mobile-menu');
+      window.addEventListener('scroll', () => { if (window.scrollY > 50) navbar.classList.add('scrolled'); else navbar.classList.remove('scrolled'); });
+      mobileMenuButton.addEventListener('click', () => mobileMenu.classList.toggle('open'));
+    </script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -62,4 +62,5 @@
   <url><loc>https://www.carltravels.com/sony-fx30-setup-guide.html</loc></url>
   <url><loc>https://www.carltravels.com/living-in-bangkok.html</loc></url>
   <url><loc>https://www.carltravels.com/how-to-get-to-sarande-from-athens-by-bus.html</loc></url>
+  <url><loc>https://www.carltravels.com/scoot-plus-review.html</loc></url>
 </urlset>


### PR DESCRIPTION
### Motivation
- Publish a new Scoot Plus long-haul review that matches the visual style of recent review posts and surfaces the YouTube review on the site. 
- Use the YouTube thumbnail as the main hero/OG image to provide a consistent thumbnail-first look for video-led reviews. 

### Description
- Added a new page `scoot-plus-review.html` containing SEO/meta tags, structured review schema, the article content (seat, baggage, perks, limitations, verdict), and an embedded YouTube player (`https://www.youtube.com/embed/-jWYZg-gJ6U`) with the thumbnail as the hero image (`https://img.youtube.com/vi/-jWYZg-gJ6U/maxresdefault.jpg`).
- Inserted a new blog card into `blog.html` so the post appears in the blog listing with matching card layout and a link to `scoot-plus-review.html`.
- Updated `sitemap.xml` to include the new page URL for indexing/discoverability.

### Testing
- Verified `sitemap.xml` parses successfully using Python's XML parser and confirmed the new page URL was inserted (test passed). 
- Asserted the presence of `scoot-plus-review.html` and the updated `blog.html` files programmatically (test passed). 
- Launched a local HTTP server and captured a full-page screenshot of the new post with Playwright for visual verification (screenshot generated successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b525f7baf883238e26826af98bb6b5)