### PR TITLE
Add Koh Samui Muay Thai blog post with video embed

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -233,6 +233,34 @@
             </div>
 
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+                <div class="blog-card rounded-xl overflow-hidden shadow-lg">
+                    <div class="relative overflow-hidden h-64">
+                        <img src="https://img.youtube.com/vi/F3CVHZBmYps/maxresdefault.jpg"
+                            onerror="this.onerror=null;this.src='https://img.youtube.com/vi/F3CVHZBmYps/hqdefault.jpg';"
+                            alt="Training Muay Thai in Thailand at 39"
+                            class="w-full h-full object-cover transform hover:scale-110 transition-transform duration-500">
+                        <div class="absolute inset-0 card-overlay"></div>
+                        <div class="absolute bottom-0 left-0 p-6 text-white">
+                            <h3 class="text-xl font-bold">Where to Train Muay Thai in Thailand</h3>
+                            <p class="text-sm">Koh Samui Beginner Experience at 39</p>
+                        </div>
+                        <span class="absolute top-4 right-4 bg-yellow-900 text-white text-xs px-3 py-1 rounded-full">New</span>
+                    </div>
+                    <div class="p-6 bg-white">
+                        <div class="flex justify-between items-center mb-3">
+                            <span class="text-gray-500 text-sm"><i class="fas fa-dumbbell mr-1 text-yellow-500"></i>
+                                Thailand Fitness Travel</span>
+                        </div>
+                        <p class="text-gray-600 mb-4 text-sm">
+                            An honest breakdown of what six weeks of Muay Thai training in Koh Samui feels like when
+                            you start with zero martial arts experience.
+                        </p>
+                        <a href="muay-thai-thailand-koh-samui-guide.html"
+                            class="inline-flex items-center gap-2 text-yellow-500 hover:text-yellow-400 font-medium">
+                            Read More <i class="fas fa-arrow-right text-xs"></i>
+                        </a>
+                    </div>
+                </div>
             <div class="blog-card rounded-xl overflow-hidden shadow-lg">
                     <div class="relative overflow-hidden h-64">
                         <img src="https://img.youtube.com/vi/-jWYZg-gJ6U/maxresdefault.jpg"

--- a/muay-thai-thailand-koh-samui-guide.html
+++ b/muay-thai-thailand-koh-samui-guide.html
@@ -1,0 +1,240 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Where to Train Muay Thai in Thailand: Koh Samui at 39 | Carl Travels</title>
+    <link rel="canonical" href="https://www.carltravels.com/muay-thai-thailand-koh-samui-guide.html">
+    <!-- Cookiebot for GDPR Compliance -->
+    <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="e44b7cd2-126b-4f49-8aee-22495afe3ece"
+        type="text/javascript" async></script>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-G72KT5ZW2J"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag() { dataLayer.push(arguments); }
+        gtag('js', new Date());
+        gtag('config', 'G-G72KT5ZW2J');
+    </script>
+    <meta name="description"
+        content="An honest guide to training Muay Thai in Thailand at 39, based on six weeks in Koh Samui. What beginner training is really like, what to expect, and how long to stay.">
+    <meta name="keywords"
+        content="train muay thai thailand, koh samui muay thai training, muay thai beginner thailand, muay thai camp thailand review, training muay thai at 40, fitness camp thailand, muay thai experience thailand, koh samui gym training">
+    <meta name="author" content="Carl Ostomich">
+    <meta property="og:title" content="Where to Train Muay Thai in Thailand: Koh Samui at 39">
+    <meta property="og:description"
+        content="What it actually feels like to start Muay Thai in Thailand at 39, with no fight background, and train consistently in Koh Samui.">
+    <meta property="og:image" content="https://img.youtube.com/vi/F3CVHZBmYps/maxresdefault.jpg">
+    <meta property="og:url" content="https://www.carltravels.com/muay-thai-thailand-koh-samui-guide.html">
+    <meta property="og:type" content="article">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Where to Train Muay Thai in Thailand: Koh Samui at 39">
+    <meta name="twitter:description"
+        content="A grounded, practical look at beginner Muay Thai training in Koh Samui, Thailand.">
+    <meta name="twitter:image" content="https://img.youtube.com/vi/F3CVHZBmYps/maxresdefault.jpg">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link rel="stylesheet" href="/assets/css/styles.css">
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700&family=Bebas+Neue&display=swap');
+
+        :root {
+            --primary: #f5c518;
+            --secondary: #2a2a2a;
+            --dark: #1a1a1a;
+            --light: #d4d4d4;
+        }
+
+        body {
+            font-family: 'Montserrat', sans-serif;
+            background-color: var(--dark);
+            color: var(--light);
+        }
+
+        .heading-font {
+            font-family: 'Bebas Neue', sans-serif;
+        }
+
+        .navbar {
+            backdrop-filter: blur(10px);
+            background-color: rgba(26, 26, 26, 0.9);
+            transition: all 0.3s ease;
+        }
+
+        .navbar.scrolled {
+            background-color: rgba(26, 26, 26, 0.98);
+            box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.3);
+        }
+
+        .hero {
+            background: linear-gradient(145deg, rgba(0, 0, 0, 0.72), rgba(0, 0, 0, 0.6)),
+                url('https://img.youtube.com/vi/F3CVHZBmYps/maxresdefault.jpg') center/cover no-repeat;
+        }
+
+        .section-card {
+            background: #101010;
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            border-radius: 1rem;
+        }
+
+        .mobile-menu {
+            max-height: 0;
+            overflow: hidden;
+            transition: max-height 0.5s ease-out;
+            background: rgba(12, 12, 12, 0.95);
+            border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+        }
+
+        .mobile-menu.open {
+            max-height: 500px;
+        }
+    </style>
+</head>
+
+<body>
+    <nav id="navbar" class="navbar fixed w-full z-50">
+        <div class="container mx-auto px-6 py-4">
+            <div class="flex justify-between items-center">
+                <a href="/index.html" class="text-2xl font-bold">
+                    <span class="heading-font" style="color: var(--primary);">CARL TOMICH</span>
+                </a>
+
+                <div class="hidden md:flex items-center space-x-8">
+                    <a href="/index.html" class="nav-link font-medium">Films</a>
+                    <a href="/portfolio.html" class="nav-link font-medium">Portfolio</a>
+                    <a href="/films/martial-arts-documentary.html" class="nav-link font-medium">Current Project</a>
+                    <a href="/blog.html" class="nav-link font-medium">Blog</a>
+                    <a href="/gear.html" class="nav-link font-medium">Gear</a>
+                    <a href="/destinations.html" class="nav-link font-medium">Travel</a>
+                    <a href="/about.html" class="nav-link font-medium">About</a>
+                    <a href="/donate.html" class="nav-link font-medium" style="color: var(--primary);">Donate</a>
+                </div>
+
+                <button id="mobile-menu-button" class="md:hidden focus:outline-none" style="color: var(--light);">
+                    <i class="fas fa-bars text-2xl"></i>
+                </button>
+            </div>
+
+            <div id="mobile-menu" class="mobile-menu md:hidden">
+                <div class="pt-4 pb-2 space-y-2">
+                    <a href="/index.html" class="block px-3 py-2 rounded-md nav-link">Films</a>
+                    <a href="/portfolio.html" class="block px-3 py-2 rounded-md nav-link">Portfolio</a>
+                    <a href="/films/martial-arts-documentary.html" class="block px-3 py-2 rounded-md nav-link">Current
+                        Project</a>
+                    <a href="/blog.html" class="block px-3 py-2 rounded-md nav-link">Blog</a>
+                    <a href="/gear.html" class="block px-3 py-2 rounded-md nav-link">Gear</a>
+                    <a href="/destinations.html" class="block px-3 py-2 rounded-md nav-link">Travel</a>
+                    <a href="/about.html" class="block px-3 py-2 rounded-md nav-link">About</a>
+                    <a href="/donate.html" class="block px-3 py-2 rounded-md nav-link"
+                        style="color: var(--primary);">Donate</a>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <header class="hero pt-32 pb-24">
+        <div class="container mx-auto px-6 max-w-5xl">
+            <span class="inline-block px-4 py-2 rounded-full bg-yellow-500/20 border border-yellow-300/30 text-yellow-200 text-xs uppercase tracking-widest">Thailand • Muay Thai • Koh Samui</span>
+            <h1 class="heading-font text-4xl md:text-6xl text-white mt-6 leading-tight">Where to Train Muay Thai in Thailand<br><span class="text-yellow-400">(What It’s Actually Like at 39)</span></h1>
+            <p class="text-lg text-gray-200 mt-6 max-w-3xl">A grounded, beginner-friendly account of six weeks training in Koh Samui with no martial arts background.</p>
+        </div>
+    </header>
+
+    <main class="py-16">
+        <article class="container mx-auto px-6 max-w-4xl space-y-8 leading-relaxed text-gray-200">
+            <section class="section-card p-8 space-y-6">
+                <p>I didn’t go to Thailand to become a fighter. I went because I was curious. At 39, with no background in Muay Thai or any real martial arts, I wanted to see what it would actually feel like to step into that world. Not for a day, not as a tourist experience, but properly. To live it, even if just for a short period of time.</p>
+                <p>I ended up spending six weeks training in Koh Samui, and by the end of it, I had a much clearer understanding of what this kind of experience really involves.</p>
+            </section>
+
+            <section class="section-card p-8 space-y-4">
+                <h2 class="heading-font text-3xl text-white">Why Koh Samui?</h2>
+                <p>Koh Samui sits in an unusual middle ground. On one hand, it’s a tropical island with beaches, cheap food, and a relaxed pace of life. On the other, it’s home to serious training environments where people come specifically to push themselves physically.</p>
+                <p>That contrast is what makes it work. You’re not isolated in a hardcore fight camp, but you’re also not just on holiday. You’re somewhere in between, and that balance helps people stay consistent.</p>
+            </section>
+
+            <section class="section-card p-8 space-y-4">
+                <h2 class="heading-font text-3xl text-white">Getting There and Settling In</h2>
+                <p>Getting to Koh Samui is straightforward. You can fly directly to the island, or connect through Bangkok. Once you land, most gyms and accommodation are around a 10 to 15 minute drive from the airport.</p>
+                <p>From there, life gets simple quickly. Most people stay close to their gym, and some stay at the camp itself. Either way, your day starts to revolve around training.</p>
+            </section>
+
+            <section class="section-card p-8 space-y-4">
+                <h2 class="heading-font text-3xl text-white">Walking Into Training for the First Time</h2>
+                <p>The first session is the hardest mentally. You walk in and everything is already moving. Pads are cracking, trainers are bouncing between students, and there’s no long introduction.</p>
+                <p>If you arrive with no experience, it can feel overwhelming for about ten minutes. Then it settles. A lot of people are in the same position: beginners, travelers, and people starting from zero.</p>
+            </section>
+
+            <section class="section-card p-8 space-y-4">
+                <h2 class="heading-font text-3xl text-white">The Daily Routine</h2>
+                <p>Most people train twice per day: once in the morning and once in the afternoon. In between, you recover, eat, hydrate, and try to keep your energy up.</p>
+                <p>Sessions are repetitive by design: skipping, pad work, bag work, conditioning, and small technical adjustments. It’s simple in theory, but difficult in practice because consistency is the hard part.</p>
+                <p>After a few days, fatigue sets in. Your legs are heavy, your hands are sore, and your body feels constantly used. But over time, you stop negotiating with yourself and just show up.</p>
+            </section>
+
+            <section class="section-card p-8 space-y-4">
+                <h2 class="heading-font text-3xl text-white">The Environment, Trainers, and Recovery</h2>
+                <p>The mix of people is one of the best parts. You’ll see people in their early 20s and people in their 40s, complete beginners and active fighters, all sharing the same training floor.</p>
+                <p>Good trainers make a huge difference. They correct details constantly, push your output, and scale expectations to your level. You’re not expected to be sharp immediately. You’re expected to keep turning up.</p>
+                <p>Outside the gym, life gets very minimal: eat, rest, train, repeat. Food is easy to find, gyms are close to accommodation, and that low-friction routine makes consistency possible.</p>
+            </section>
+
+            <section class="section-card p-8 space-y-4">
+                <h2 class="heading-font text-3xl text-white">How Long You Actually Need</h2>
+                <p>A day or two gives you a taste, not a real understanding. After a few days, you understand the structure. After a couple of weeks, your body starts adapting and your confidence improves.</p>
+                <p>If you want meaningful progress, plan at least two weeks. Longer stays make the biggest difference physically and mentally.</p>
+            </section>
+
+            <section class="section-card p-8 space-y-4">
+                <h2 class="heading-font text-3xl text-white">The Fighting Side</h2>
+                <p>If you want to go further, that path is there. Some people train specifically to fight, and you’ll see that progression around you. Watching local stadium fights, especially when someone from your gym is on the card, gives context to every drill you’re doing.</p>
+            </section>
+
+            <section class="section-card p-8 space-y-4">
+                <h2 class="heading-font text-3xl text-white">Final Thoughts</h2>
+                <p>The biggest takeaway isn’t perfect technique. It’s consistency. Showing up when you’re tired. Showing up when you’re sore. Showing up anyway.</p>
+                <p>At 39, starting from zero, Muay Thai training in Thailand was manageable. Not easy, but manageable. If you’re considering it, you don’t need to be in peak shape before you arrive. You just need to commit to the routine once you do.</p>
+            </section>
+
+            <section class="section-card p-8 space-y-4">
+                <h2 class="heading-font text-3xl text-white">Watch the Experience</h2>
+                <a href="https://youtu.be/F3CVHZBmYps" target="_blank" rel="noopener noreferrer" class="block rounded-xl overflow-hidden border border-white/10">
+                    <img src="https://img.youtube.com/vi/F3CVHZBmYps/maxresdefault.jpg"
+                        onerror="this.onerror=null;this.src='https://img.youtube.com/vi/F3CVHZBmYps/hqdefault.jpg';"
+                        alt="Training Muay Thai in Koh Samui video thumbnail" class="w-full h-auto">
+                </a>
+                <div class="aspect-video rounded-xl overflow-hidden border border-white/10">
+                    <iframe class="w-full h-full" src="https://www.youtube.com/embed/F3CVHZBmYps" title="Training Muay Thai in Thailand at 39"
+                        frameborder="0"
+                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                        referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+                </div>
+            </section>
+        </article>
+    </main>
+
+    <footer class="py-8 border-t border-white/10 text-center text-sm text-gray-400">
+        <p>&copy; 2026 Carl Travels. All rights reserved.</p>
+    </footer>
+
+    <script>
+        const navbar = document.getElementById('navbar');
+        const mobileMenuButton = document.getElementById('mobile-menu-button');
+        const mobileMenu = document.getElementById('mobile-menu');
+
+        window.addEventListener('scroll', () => {
+            if (window.scrollY > 50) {
+                navbar.classList.add('scrolled');
+            } else {
+                navbar.classList.remove('scrolled');
+            }
+        });
+
+        mobileMenuButton.addEventListener('click', () => {
+            mobileMenu.classList.toggle('open');
+        });
+    </script>
+</body>
+
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -63,4 +63,5 @@
   <url><loc>https://www.carltravels.com/living-in-bangkok.html</loc></url>
   <url><loc>https://www.carltravels.com/how-to-get-to-sarande-from-athens-by-bus.html</loc></url>
   <url><loc>https://www.carltravels.com/scoot-plus-review.html</loc></url>
+  <url><loc>https://www.carltravels.com/muay-thai-thailand-koh-samui-guide.html</loc></url>
 </urlset>


### PR DESCRIPTION
### Motivation
- Add a polished, paragraph-driven blog article about training Muay Thai in Koh Samui that reads like a first-person experience for older beginners and improves site content and SEO. 
- Surface the related video content directly in the article by using the provided YouTube thumbnail as the hero image and embedding the player to increase engagement. 
- Make the new article discoverable by listing it on the blog index and including it in the sitemap for search indexing.

### Description
- Added a new article file `muay-thai-thailand-koh-samui-guide.html` containing the full copy, SEO meta tags (description, keywords, OG/Twitter), hero image using the YouTube thumbnail, and an embedded YouTube player for `F3CVHZBmYps`.
- Inserted a new blog card at the top of the grid in `blog.html` that uses the same video thumbnail, title, excerpt, and links to the new article.
- Appended the article URL to `sitemap.xml` to expose the new page to search engines.
- Reused existing site styling and small JavaScript hooks (mobile menu and navbar scroll) to keep the new page consistent with the site layout.

### Testing
- Confirmed references to the new slug exist in the listing and sitemap using `rg -n "muay-thai-thailand-koh-samui-guide" blog.html sitemap.xml`, which succeeded.
- Verified the new article file was created and has content using `wc -l muay-thai-thailand-koh-samui-guide.html`, which returned a nonzero line count.
- Validated the embedded YouTube URL and thumbnail references appear in both the article head and body, which succeeded.
- All automated checks included above passed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3c97709ac83238998cad477fdd7a4)