### PR TITLE
Add Okinawa karate article card to blog listing

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -261,6 +261,34 @@
                         </a>
                     </div>
                 </div>
+                <div class="blog-card rounded-xl overflow-hidden shadow-lg">
+                    <div class="relative overflow-hidden h-64">
+                        <img src="https://img.youtube.com/vi/-SQdMh_km0Y/maxresdefault.jpg"
+                            onerror="this.onerror=null;this.src='https://img.youtube.com/vi/-SQdMh_km0Y/hqdefault.jpg';"
+                            alt="Where to train Karate in Okinawa"
+                            class="w-full h-full object-cover transform hover:scale-110 transition-transform duration-500">
+                        <div class="absolute inset-0 card-overlay"></div>
+                        <div class="absolute bottom-0 left-0 p-6 text-white">
+                            <h3 class="text-xl font-bold">Where to Train Karate in Okinawa</h3>
+                            <p class="text-sm">Beginner Guide to Shorin-ryu in Naha</p>
+                        </div>
+                        <span class="absolute top-4 right-4 bg-yellow-900 text-white text-xs px-3 py-1 rounded-full">New</span>
+                    </div>
+                    <div class="p-6 bg-white">
+                        <div class="flex justify-between items-center mb-3">
+                            <span class="text-gray-500 text-sm"><i class="fas fa-fist-raised mr-1 text-yellow-500"></i>
+                                Japan Martial Arts Travel</span>
+                        </div>
+                        <p class="text-gray-600 mb-4 text-sm">
+                            A beginner story from Okinawa: finding a dojo in Naha, training Shorin-ryu, and what it
+                            actually takes to start karate from zero.
+                        </p>
+                        <a href="blog/where-to-train-karate-in-okinawa.html"
+                            class="inline-flex items-center gap-2 text-yellow-500 hover:text-yellow-400 font-medium">
+                            Read More <i class="fas fa-arrow-right text-xs"></i>
+                        </a>
+                    </div>
+                </div>
             <div class="blog-card rounded-xl overflow-hidden shadow-lg">
                     <div class="relative overflow-hidden h-64">
                         <img src="https://img.youtube.com/vi/-jWYZg-gJ6U/maxresdefault.jpg"


### PR DESCRIPTION
### Motivation

- Ensure both martial-arts articles (Muay Thai and Karate) appear on the Blog page so the Karate post that hadn't been listed is visible from `blog.html`.

### Description

- Inserted a new blog card HTML block into `blog.html` linking to `blog/where-to-train-karate-in-okinawa.html` with matching thumbnail, title, category, and teaser text for visual consistency with other cards. 
- Kept the change scoped to the blog listing section and committed the update with message `Add Okinawa karate article card to blog listing`.

### Testing

- Verified both article links are present using `rg -n "where-to-train-karate-in-okinawa|muay-thai-thailand-koh-samui-guide" blog.html` which succeeded. 
- Reviewed the changes with `git diff -- blog.html` to confirm only the blog listing section was modified. 
- Committed the update with `git commit` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3f49fd2f083239a905e953fafda81)