### PR TITLE
Add comprehensive Sarandë / Albania travel guide page

### DIFF
--- a/guide-to-sarande.html
+++ b/guide-to-sarande.html
@@ -1,0 +1,316 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Guide to Sarandë, Albania: Ksamil, Butrint, Corfu & Tirana - Carl Travels</title>
+    <link rel="canonical" href="https://www.carltravels.com/guide-to-sarande.html">
+    <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="e44b7cd2-126b-4f49-8aee-22495afe3ece"
+        type="text/javascript" async></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-G72KT5ZW2J"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag() { dataLayer.push(arguments); }
+        gtag('js', new Date());
+        gtag('config', 'G-G72KT5ZW2J');
+    </script>
+
+    <meta name="description"
+        content="A full travel guide to Sarandë, Albania, including Ksamil, Butrint National Park, Corfu day trips, Tirana context, and practical transport + budget tips.">
+    <meta name="keywords"
+        content="Sarande guide, Albania travel guide, Ksamil bus, Butrint National Park, Corfu day trip from Sarande, Tirana travel tips">
+    <meta name="author" content="Carl Ostomich">
+
+    <meta property="og:title" content="Guide to Sarandë, Albania: Ksamil, Butrint, Corfu & Tirana - Carl Travels">
+    <meta property="og:description"
+        content="Everything you need to plan a Sarandë base: local buses to Ksamil and Butrint, Corfu ferry options, budget breakdown, and what to do in town.">
+    <meta property="og:image" content="https://img.youtube.com/vi/b8LRRCgTn00/maxresdefault.jpg">
+    <meta property="og:url" content="https://www.carltravels.com/guide-to-sarande.html">
+    <meta property="og:type" content="article">
+
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Guide to Sarandë, Albania: Ksamil, Butrint, Corfu & Tirana">
+    <meta name="twitter:description"
+        content="The practical Sarandë base guide: buses, beaches, ruins, ferry day trip ideas, and realistic monthly cost expectations.">
+    <meta name="twitter:image" content="https://img.youtube.com/vi/b8LRRCgTn00/maxresdefault.jpg">
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700&family=Bebas+Neue&display=swap');
+
+        :root {
+            --primary: #f5c518;
+            --secondary: #2a2a2a;
+            --dark: #0b0b0b;
+            --light: #d4d4d4;
+        }
+
+        body {
+            font-family: 'Montserrat', sans-serif;
+            background-color: var(--dark);
+            color: var(--light);
+            scroll-behavior: smooth;
+        }
+
+        .hero-gradient {
+            background: linear-gradient(135deg, rgba(42, 42, 42, 0.88), rgba(10, 10, 10, 0.9));
+        }
+
+        .heading-font {
+            font-family: 'Bebas Neue', sans-serif;
+        }
+
+        .navbar {
+            backdrop-filter: blur(10px);
+            background-color: rgba(26, 26, 26, 0.92);
+            transition: all 0.3s ease;
+        }
+
+        .navbar.scrolled {
+            background-color: rgba(26, 26, 26, 0.98);
+            box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.35);
+        }
+
+        .mobile-menu {
+            max-height: 0;
+            overflow: hidden;
+            transition: max-height 0.5s ease-out;
+            background: rgba(12, 12, 12, 0.95);
+            border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+        }
+
+        .mobile-menu.open {
+            max-height: 500px;
+        }
+
+        .nav-link {
+            color: #d4d4d4;
+            transition: color 0.3s ease;
+        }
+
+        .nav-link:hover {
+            color: #f5c518;
+        }
+
+        .wave-shape {
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            width: 100%;
+            overflow: hidden;
+            line-height: 0;
+        }
+
+        .wave-shape svg {
+            position: relative;
+            display: block;
+            width: calc(100% + 1.3px);
+            height: 130px;
+        }
+
+        .wave-shape .shape-fill {
+            fill: #050505;
+        }
+
+        .glass-card {
+            background: rgba(20, 20, 20, 0.82);
+            border: 1px solid rgba(255, 255, 255, 0.06);
+            backdrop-filter: blur(14px);
+            box-shadow: 0 20px 45px -25px rgba(0, 0, 0, 0.65);
+        }
+
+        .content a {
+            color: #f5c518;
+        }
+
+        .content a:hover {
+            color: #fcd34d;
+        }
+
+        .video-wrap iframe {
+            width: 100%;
+            min-height: 320px;
+            border: 0;
+            border-radius: 0.75rem;
+        }
+    </style>
+</head>
+
+<body class="text-gray-200">
+    <nav id="navbar" class="navbar fixed w-full z-50">
+        <div class="container mx-auto px-6 py-4">
+            <div class="flex justify-between items-center">
+                <a href="/index.html" class="text-2xl font-bold">
+                    <span class="heading-font" style="color: var(--primary);">CARL TOMICH</span>
+                </a>
+
+                <div class="hidden md:flex items-center space-x-8">
+                    <a href="/index.html" class="nav-link font-medium">Films</a>
+                    <a href="/portfolio.html" class="nav-link font-medium">Portfolio</a>
+                    <a href="/films/martial-arts-documentary.html" class="nav-link font-medium">Current Project</a>
+                    <a href="/blog.html" class="nav-link font-medium">Blog</a>
+                    <a href="/gear.html" class="nav-link font-medium">Gear</a>
+                    <a href="/destinations.html" class="nav-link font-medium">Travel</a>
+                    <a href="/about.html" class="nav-link font-medium">About</a>
+                    <a href="/donate.html" class="nav-link font-medium" style="color: var(--primary);">Donate</a>
+                </div>
+
+                <button id="mobile-menu-button" class="md:hidden focus:outline-none" style="color: var(--light);">
+                    <i class="fas fa-bars text-2xl"></i>
+                </button>
+            </div>
+
+            <div id="mobile-menu" class="mobile-menu md:hidden">
+                <div class="pt-4 pb-2 space-y-2">
+                    <a href="/index.html" class="block px-3 py-2 rounded-md nav-link">Films</a>
+                    <a href="/portfolio.html" class="block px-3 py-2 rounded-md nav-link">Portfolio</a>
+                    <a href="/films/martial-arts-documentary.html" class="block px-3 py-2 rounded-md nav-link">Current
+                        Project</a>
+                    <a href="/blog.html" class="block px-3 py-2 rounded-md nav-link">Blog</a>
+                    <a href="/gear.html" class="block px-3 py-2 rounded-md nav-link">Gear</a>
+                    <a href="/destinations.html" class="block px-3 py-2 rounded-md nav-link">Travel</a>
+                    <a href="/about.html" class="block px-3 py-2 rounded-md nav-link">About</a>
+                    <a href="/donate.html" class="block px-3 py-2 rounded-md nav-link"
+                        style="color: var(--primary);">Donate</a>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <section class="hero-gradient relative overflow-hidden min-h-[65vh] flex items-end pt-24 pb-16"
+        style="background-image: url('https://img.youtube.com/vi/b8LRRCgTn00/maxresdefault.jpg'); background-size: cover; background-position: center;">
+        <div class="absolute inset-0 bg-black/65"></div>
+        <div class="container mx-auto px-6 relative z-10">
+            <div class="max-w-4xl">
+                <span class="inline-block px-4 py-1 rounded-full bg-yellow-500/20 text-yellow-300 text-sm tracking-wide mb-5">ALBANIA TRAVEL GUIDE</span>
+                <h1 class="heading-font text-4xl md:text-6xl text-white mb-4">Guide to Sarandë: Ksamil, Butrint, Corfu & Tirana</h1>
+                <p class="text-lg text-gray-200 max-w-3xl">Sarandë is the easiest base in southern Albania: cheap local buses, clear-water beach days, ancient ruins, and simple day trips that actually work.</p>
+            </div>
+        </div>
+        <div class="wave-shape">
+            <svg data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 120" preserveAspectRatio="none">
+                <path d="M321.39,56.44C179.59,89.28,52.62,92.22,0,76V120H1200V0C1132.19,45.55,994.84,68.38,860,65.54,727.11,62.74,637.85,34.44,504.77,24.26,390.26,15.52,354.05,48.74,321.39,56.44Z" class="shape-fill"></path>
+            </svg>
+        </div>
+    </section>
+
+    <main class="py-16 bg-[#050505]">
+        <article class="container mx-auto px-6 max-w-4xl space-y-10 content">
+            <div class="glass-card rounded-2xl p-8">
+                <h2 class="heading-font text-3xl text-white mb-4">Why Sarandë Works as a Base</h2>
+                <p>Albania has rough edges in a good way. It feels lived in, not polished for tourists. If you stay in Sarandë, everything gets simple: you can go beach, history, and even international day trip mode without heavy planning.</p>
+                <p>You settle into a rhythm fast: slow morning coffee on the promenade, local bus for a half-day mission, back before sunset, then dinner by the water. It doesn’t feel like checklist travel. It feels like you actually lived somewhere.</p>
+            </div>
+
+            <div class="glass-card rounded-2xl p-8 video-wrap">
+                <h2 class="heading-font text-3xl text-white mb-4">Watch: Sarandë Video</h2>
+                <iframe src="https://www.youtube.com/embed/b8LRRCgTn00" title="Sarandë, Albania Travel Video" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+            </div>
+
+            <div class="glass-card rounded-2xl p-8">
+                <h2 class="heading-font text-3xl text-white mb-4">Realistic Monthly Budget in Sarandë</h2>
+                <ul class="list-disc list-inside space-y-2">
+                    <li><strong>Rent:</strong> €340 (Airbnb, off-season)</li>
+                    <li><strong>Power:</strong> €50</li>
+                    <li><strong>Food:</strong> €400–450</li>
+                    <li><strong>Transport:</strong> €10–15</li>
+                    <li><strong>Phone:</strong> €15</li>
+                </ul>
+                <p class="mt-5">Total: around <strong>€800–900/month</strong>. That’s not extreme budget mode either. You can eat out, move around, and still keep costs steady.</p>
+            </div>
+
+            <div class="glass-card rounded-2xl p-8">
+                <h2 class="heading-font text-3xl text-white mb-4">Getting to Ksamil and Butrint (The Easy Way)</h2>
+                <p>If you’re based in Sarandë, skip the tour logistics. The local bus is the best option and the cheapest.</p>
+                <h3 class="text-xl font-semibold text-white mt-6 mb-3">Where to catch it</h3>
+                <ul class="list-disc list-inside space-y-2">
+                    <li>Go to the main road near the waterfront promenade.</li>
+                    <li>Look for signs saying <strong>Ksamil</strong> or <strong>Butrint</strong>.</li>
+                    <li>No formal station needed. If unsure, ask locals “Ksamil?” and they’ll point you.</li>
+                </ul>
+                <h3 class="text-xl font-semibold text-white mt-6 mb-3">Cost and timing</h3>
+                <ul class="list-disc list-inside space-y-2">
+                    <li><strong>200 lek per trip</strong> (about €2), paid onboard.</li>
+                    <li>~20 minutes to Ksamil.</li>
+                    <li>~30 minutes to Butrint National Park.</li>
+                    <li>Frequent buses during the day, no booking stress.</li>
+                </ul>
+                <p class="mt-5">The ride is scenic the whole way: coastline, elevated sea views, and moments where you’ll want to put your phone down and just look outside.</p>
+            </div>
+
+            <div class="glass-card rounded-2xl p-8 video-wrap">
+                <h2 class="heading-font text-3xl text-white mb-4">Ksamil: Clear Water, No Effort</h2>
+                <p class="mb-4">Get off in central Ksamil and you’re usually 2–5 minutes from the beach. Water is clear, everything is close together, and it’s easy to explore without overplanning.</p>
+                <iframe src="https://www.youtube.com/embed/YNO8wWjcyqU" title="Ksamil Albania Travel Video" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+            </div>
+
+            <div class="glass-card rounded-2xl p-8 video-wrap">
+                <h2 class="heading-font text-3xl text-white mb-4">Butrint: Ancient Site With Zero Transport Hassle</h2>
+                <p class="mb-4">Stay on the same bus route until the final stop and you’ll be dropped at the entrance to Butrint National Park. Entry is usually around <strong>€10</strong>, and you can walk straight into the ruins.</p>
+                <iframe src="https://www.youtube.com/embed/Re8xO-VQUog" title="Butrint National Park Travel Video" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+            </div>
+
+            <div class="glass-card rounded-2xl p-8">
+                <h2 class="heading-font text-3xl text-white mb-4">Sarandë Highlights You Shouldn’t Skip</h2>
+                <h3 class="text-xl font-semibold text-white mt-2 mb-3">Lëkurësi Castle at Sunset</h3>
+                <p>Walk, taxi, or drive to Lëkurësi Castle for the best panorama over Sarandë and across to Corfu. There’s a restaurant and open terrace at the top, and sunset is the standout timing.</p>
+                <h3 class="text-xl font-semibold text-white mt-6 mb-3">The Promenade at Night</h3>
+                <p>Simple and relaxed: evening walks, waterfront restaurants, people out by the sea. It’s not overly polished, which is exactly why it feels good.</p>
+            </div>
+
+            <div class="glass-card rounded-2xl p-8">
+                <h2 class="heading-font text-3xl text-white mb-4">Corfu Day Trip (Easy Contrast)</h2>
+                <p>From Sarandë, you can take a ferry to Corfu in roughly 30 minutes. Return fares often start around €50 depending on season and operator. Corfu feels more structured and polished, and that contrast makes you appreciate the Albanian coast even more when you return.</p>
+            </div>
+
+            <div class="glass-card rounded-2xl p-8 video-wrap">
+                <h2 class="heading-font text-3xl text-white mb-4">Tirana for Context</h2>
+                <p class="mb-4">Tirana gives you a different side of Albania: faster pace, more urban energy, and deeper historical context through spots like Bunk’Art. It’s worth adding if you want to understand the country beyond the coast.</p>
+                <iframe src="https://www.youtube.com/embed/0TZEJ80_iO0" title="Tirana Albania Travel Video" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+            </div>
+
+            <div class="glass-card rounded-2xl p-8">
+                <h2 class="heading-font text-3xl text-white mb-4">Getting to Sarandë from Athens</h2>
+                <p>One of the easiest overland options is the direct bus from Athens, typically around 8 hours and roughly €35, including the border crossing process. If you want a step-by-step breakdown, read my full post: <a href="/how-to-get-to-sarande-from-athens-by-bus.html">How to Get to Sarandë from Athens by Bus</a>.</p>
+            </div>
+
+            <div class="glass-card rounded-2xl p-8">
+                <h2 class="heading-font text-3xl text-white mb-4">Final Thoughts</h2>
+                <p>Sarandë gives you the base. Ksamil gives you the water. Butrint gives you history. Corfu gives you contrast. Tirana gives you context.</p>
+                <p class="mt-4">Put together, Albania becomes one of the easiest destinations in Europe to actually enjoy without overpaying or overplanning.</p>
+            </div>
+        </article>
+    </main>
+
+    <footer class="bg-[#030303] border-t border-white/10 py-10">
+        <div class="container mx-auto px-6 text-center text-gray-400">
+            <p>© <span id="year"></span> Carl Travels. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <script>
+        const navbar = document.getElementById('navbar');
+        window.addEventListener('scroll', function () {
+            if (window.scrollY > 50) {
+                navbar.classList.add('scrolled');
+            } else {
+                navbar.classList.remove('scrolled');
+            }
+        });
+
+        const mobileMenuButton = document.getElementById('mobile-menu-button');
+        const mobileMenu = document.getElementById('mobile-menu');
+        if (mobileMenuButton && mobileMenu) {
+            mobileMenuButton.addEventListener('click', () => {
+                mobileMenu.classList.toggle('open');
+            });
+        }
+
+        document.getElementById('year').textContent = new Date().getFullYear();
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
### Motivation
- Provide a full, publishable travel post about Sarandë as a base for Ksamil, Butrint, Corfu and Tirana that matches the existing site layout and tone.
- Embed the supplied videos and use the Sarandë video thumbnail as the hero/social image to improve visual/social previews.

### Description
- Added a new page `guide-to-sarande.html` containing a full long-form guide with sections for why Sarandë works as a base, realistic monthly budget, local bus instructions to Ksamil and Butrint, Sarandë highlights, Corfu day-trip notes, Tirana context, and final thoughts.
- Set meta/OG/Twitter tags and used `https://img.youtube.com/vi/b8LRRCgTn00/maxresdefault.jpg` as the hero/preview image.
- Embedded the four provided YouTube videos via `iframe` for Sarandë (`b8LRRCgTn00`), Ksamil (`YNO8wWjcyqU`), Butrint (`Re8xO-VQUog`), and Tirana (`0TZEJ80_iO0`).
- Kept styling and navigation consistent with existing site templates (nav, hero, glass-card styling, footer) and added an internal link to the Athens→Sarandë bus post for more detail.

### Testing
- Ran a basic HTML integrity check with a Python script that verified top-level document markers and reported `basic-html-check: ok, bytes=17508`, which succeeded.
- Attempted to run `xmllint --html --noout` for linting, but the `xmllint` binary is not available in this environment, so full HTML linting could not be performed.
- Verified the new file exists and that the expected YouTube thumbnail and embedded video IDs are present in the page source via automated file-read checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4267e47788323899a1e551439529e)