### PR TITLE
Replace hero tagline with site owner name on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,7 +267,7 @@
         <div class="hero-overlay"></div>
         <div class="relative z-10 text-center px-6 max-w-5xl mx-auto">
             <h1 class="heading-font text-white mb-6" style="font-size: clamp(2.5rem, 8vw, 7rem);">
-                I engineer extreme life projects<br>and turn them into films.
+                CARL TOMICH
             </h1>
             <p class="text-2xl mb-4" style="color: var(--primary);">Carl Tomich , Documentary Filmmaker</p>
             <p class="text-lg mb-8 max-w-3xl mx-auto" style="color: var(--light);">


### PR DESCRIPTION
### Motivation
- Simplify the hero section by replacing the descriptive tagline with the site owner's name to create a more prominent personal brand on the homepage.

### Description
- Updated the homepage hero heading in `index.html` from `I engineer extreme life projects<br>and turn them into films.` to `CARL TOMICH`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f68976e234832391dc1e8f016a52d7)